### PR TITLE
Fix subdomain issue with Flask 3.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.19.0
     hooks:
     -   id: pyupgrade
         args: [--py39-plus]
@@ -31,7 +31,7 @@ repos:
           - flake8-bugbear
           - flake8-implicit-str-concat
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.35.2
+    rev: v1.36.1
     hooks:
       - id: djlint-jinja
         files: "\\.html"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -157,6 +157,8 @@ def test_authenticate_with_subdomain_next(app, client, get_message):
 
 @pytest.mark.settings(subdomain="auth")
 def test_authenticate_with_root_domain_next(app, client, get_message):
+    # As of Flask 3.1 this must be explicitly set.
+    app.subdomain_matching = True
     app.config["SERVER_NAME"] = "lp.com"
     app.config["SECURITY_REDIRECT_ALLOW_SUBDOMAINS"] = True
     data = dict(email="matt@lp.com", password="password")


### PR DESCRIPTION
Flask 3.1 fixed https://github.com/pallets/flask/issues/5553 which had the side-effect of enforcing that subdomain_matching=True must be set. This is a test case change only.