### PR TITLE
New unified RegisterFormV2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Features & Improvements
 +++++++++++++++++++++++
 - (:issue:`1038`) Add support for 'secret_key' rotation
 - (:issue:`980`) Add support for username recovery in simple login flows
-- (:pr:`xx`) Add support for Python 3.13
+- (:pr:`1048`) Add support for Python 3.13
+- (:issue:`1043`) Unify Register forms (and split out re-type password option)
 
 Notes
 +++++
@@ -21,8 +22,12 @@ part of its safe_crypt() method (fallback is to return None).
 However - that method only appears to be called in a few crypt handlers and
 for bcrypt - only for the built-in bcrypt - not if the bcrypt package is installed.
 passlib is not maintained - a new fork (10/1/2024) (https://pypi.org/project/libpass/)
-seems promising and has been tested with python 3.13. If that fork matures we will
+seems promising and has been tested with python 3.13 and Flask-Security. If that fork matures we will
 change the dependencies appropriately.
+
+The register forms have been combined - or more accurately - there is a new RegisterFormV2
+that subsumes the features of both the old RegisterForm and ConfirmRegisterForm.
+Please read :ref:`register_form_migration`.
 
 Version 5.5.2
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -239,6 +239,7 @@ Forms
 .. autoclass:: flask_security.MfRecoveryForm
 .. autoclass:: flask_security.PasswordlessLoginForm
 .. autoclass:: flask_security.RegisterForm
+.. autoclass:: flask_security.RegisterFormV2
 .. autoclass:: flask_security.ResetPasswordForm
 .. autoclass:: flask_security.SendConfirmationForm
 .. autoclass:: flask_security.TwoFactorRescueForm

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -577,6 +577,15 @@ Core - Passwords and Tokens
 
     .. versionadded:: 5.0.0
 
+.. py:data:: SECURITY_PASSWORD_CONFIRM_REQUIRED
+
+    If set to ``True`` then during registration a 'password confirmation' field is presented.
+    N.B. this just applies to the new(er) RegisterFormV2 (see :py:data:`SECURITY_USE_REGISTER_V2`)
+
+    Default: ``True``
+
+    .. versionadded:: 5.6.0
+
 Core - Multi-factor
 -------------------
 These are used by the Two-Factor and Unified Signin features.
@@ -944,6 +953,19 @@ Registerable
     Default: ``"NFKD"``
 
     .. versionadded:: 4.1.0
+
+.. py:data:: SECURITY_USE_REGISTER_V2
+
+    The :py:class:`flask_security.RegisterFormV2` is a single form used for registration. This is replacing the
+    RegisterForm and ConfirmRegisterForm (over a few releases). Setting this option
+    to ``True`` will set both registration forms to RegisterFormV2. Note that this
+    option is ignored if the application has sub-classed the registration form.
+
+    Default: ``False``
+
+    .. versionadded:: 5.6.0
+
+
 
 Confirmable
 -----------

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -52,6 +52,7 @@ from .forms import (
     LoginForm,
     PasswordlessLoginForm,
     RegisterForm,
+    RegisterFormV2,
     ResetPasswordForm,
     SendConfirmationForm,
     TwoFactorRescueForm,

--- a/flask_security/templates/security/register_user.html
+++ b/flask_security/templates/security/register_user.html
@@ -8,7 +8,9 @@
     {{ register_user_form.hidden_tag() }}
     {{ render_form_errors(register_user_form) }}
     {{ render_field_with_errors(register_user_form.email) }}
-    {% if config["SECURITY_USERNAME_ENABLE"] %}{{ render_field_with_errors(register_user_form.username) }}{% endif %}
+    {% if register_user_form.username %}
+      {{ render_field_with_errors(register_user_form.username) }}
+    {% endif %}
     {{ render_field_with_errors(register_user_form.password) }}
     {% if register_user_form.password_confirm %}
       {{ render_field_with_errors(register_user_form.password_confirm) }}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -292,7 +292,7 @@ def register() -> ResponseValue:
     # (via email) then you need to type in your password twice. That might
     # make sense if you can't reset your password but in modern (2020) UX models
     # don't ask twice.
-    if _security.confirmable or request.is_json:
+    if (_security.confirmable or request.is_json) and _security._use_confirm_form:
         form_name = "confirm_register_form"
     else:
         form_name = "register_form"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,6 +338,12 @@ def app(request):
                 if hasattr(app.security.forms[form_name].cls, "username"):
                     del app.security.forms[form_name].cls.username
 
+        from flask_security import RegisterFormV2
+
+        for attr in ["username", "password", "password_confirm"]:
+            if hasattr(RegisterFormV2, attr):
+                delattr(RegisterFormV2, attr)
+
     request.addfinalizer(revert_forms)
     yield app
     # help find tests that don't clean up - note that pony leaves a connection so

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -28,7 +28,7 @@ from tests.test_utils import (
     check_location,
     get_auth_token_version_3x,
     get_form_action,
-    get_form_input,
+    get_form_input_value,
     hash_password,
     init_app_with_options,
     is_authenticated,
@@ -899,7 +899,7 @@ def test_http_auth_csrf(client, get_message):
 
     # grab a csrf_token
     response = client.get("/login")
-    csrf_token = get_form_input(response, "csrf_token")
+    csrf_token = get_form_input_value(response, "csrf_token")
     headers["X-CSRF-Token"] = csrf_token
     response = client.post(
         "/http",

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -21,7 +21,7 @@ from tests.test_utils import (
     authenticate,
     check_location,
     check_xlation,
-    get_form_input,
+    get_form_input_value,
     get_session,
     hash_password,
     init_app_with_options,
@@ -688,7 +688,7 @@ def test_csrf(app, client):
     assert b"The CSRF token is missing" in response.data
     # Note that we get a CSRF token EVEN for errors - this seems odd
     # but can't find anything that says its a security issue
-    csrf_token = get_form_input(response, "csrf_token")
+    csrf_token = get_form_input_value(response, "csrf_token")
 
     data["csrf_token"] = csrf_token
     response = client.post("/change", data=data)

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -19,7 +19,7 @@ from freezegun import freeze_time
 from flask import render_template_string
 
 from flask_security import Security, auth_required
-from tests.test_utils import get_form_input, get_session, logout
+from tests.test_utils import get_form_input_value, get_session, logout
 
 
 REAL_VALIDATE_CSRF = None
@@ -108,7 +108,7 @@ def test_login_csrf(app, client):
     assert response.status_code == 200
     assert b"The CSRF token is missing." in response.data
 
-    data["csrf_token"] = get_form_input(response, "csrf_token")
+    data["csrf_token"] = get_form_input_value(response, "csrf_token")
     response = client.post("/login", data=data, follow_redirects=True)
     assert response.status_code == 200
     assert b"Welcome matt" in response.data

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -18,7 +18,7 @@ from flask_security import (
     Security,
     UserMixin,
     LoginForm,
-    RegisterForm,
+    RegisterFormV2,
     naive_utcnow,
 )
 from flask_security.datastore import Datastore, UserDatastore
@@ -230,7 +230,7 @@ def test_init_app_kwargs_override_constructor_kwargs(app, datastore):
     class ConLoginForm(LoginForm):
         pass
 
-    class ConRegisterForm(RegisterForm):
+    class ConRegisterForm(RegisterFormV2):
         pass
 
     class InitLoginForm(LoginForm):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -49,6 +49,7 @@ from flask_security.forms import (
     PasswordField,
     PasswordlessLoginForm,
     RegisterForm,
+    RegisterFormV2,
     Required,
     ResetPasswordForm,
     SendConfirmationForm,
@@ -115,6 +116,9 @@ def test_register_blueprint_flag(app, sqlalchemy_datastore):
         {"username": {"mapper": lambda x: x}},
     ]
 )
+@pytest.mark.filterwarnings(
+    "ignore:.*The RegisterForm is deprecated.*:DeprecationWarning"
+)
 def test_basic_custom_forms(app, sqlalchemy_datastore):
     class MyLoginForm(LoginForm):
         username = StringField("My Login Username Field")
@@ -171,6 +175,7 @@ def test_basic_custom_forms(app, sqlalchemy_datastore):
 
 @pytest.mark.registerable()
 @pytest.mark.confirmable()
+@pytest.mark.filterwarnings("ignore:.*The ConfirmRegisterForm.*:DeprecationWarning")
 def test_confirmable_custom_form(app, sqlalchemy_datastore):
     app.config["SECURITY_REGISTERABLE"] = True
     app.config["SECURITY_CONFIRMABLE"] = True
@@ -360,7 +365,7 @@ def test_custom_forms_via_config(app, sqlalchemy_datastore):
     class MyLoginForm(LoginForm):
         email = StringField("My Login Email Address Field")
 
-    class MyRegisterForm(RegisterForm):
+    class MyRegisterForm(RegisterFormV2):
         email = StringField("My Register Email Address Field")
 
     app.config["SECURITY_LOGIN_FORM"] = MyLoginForm

--- a/tests/test_oauthglue.py
+++ b/tests/test_oauthglue.py
@@ -21,7 +21,7 @@ from tests.test_utils import (
     check_location,
     get_csrf_token,
     get_form_action,
-    get_form_input,
+    get_form_input_value,
     get_session,
     init_app_with_options,
     is_authenticated,
@@ -85,7 +85,7 @@ def test_github(app, sqlalchemy_datastore, get_message):
     client = app.test_client()
     response = client.get("/login")
     github_url = get_form_action(response, 1)
-    csrf_token = get_form_input(response, field_id="github_csrf_token")
+    csrf_token = get_form_input_value(response, field_id="github_csrf_token")
 
     # make sure required CSRF
     response = client.post(github_url, follow_redirects=False)

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -22,7 +22,7 @@ from tests.test_utils import (
     capture_flashes,
     capture_reset_password_requests,
     check_location,
-    get_form_input,
+    get_form_input_value,
     logout,
     populate_data,
 )
@@ -778,7 +778,7 @@ def test_recoverable_json_async(app, client, get_message):
 @pytest.mark.settings(post_reset_view="/post_reset_view")
 def test_csrf(app, client, get_message):
     response = client.get("/reset")
-    csrf_token = get_form_input(response, "csrf_token")
+    csrf_token = get_form_input_value(response, "csrf_token")
     with capture_reset_password_requests() as requests:
         client.post(
             "/reset",

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -32,7 +32,7 @@ from tests.test_utils import (
     check_location,
     check_xlation,
     get_form_action,
-    get_form_input,
+    get_form_input_value,
     get_session,
     is_authenticated,
     json_authenticate,
@@ -1608,7 +1608,7 @@ def test_setup_csrf(app, client):
     tf_authenticate(app, client)
     response = client.get("tf-setup")
     assert b"Disable" in response.data
-    csrf_token = get_form_input(response, "csrf_token")
+    csrf_token = get_form_input_value(response, "csrf_token")
 
     response = client.post("tf-setup", data=dict(setup="disable"))
     assert b"The CSRF token is missing" in response.data

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -25,7 +25,7 @@ from tests.test_utils import (
     check_location,
     get_existing_session,
     get_form_action,
-    get_form_input,
+    get_form_input_value,
     is_authenticated,
     json_authenticate,
     logout,
@@ -305,8 +305,8 @@ def test_basic(app, clients, get_message):
     response = clients.get("/wan-register")
     # default config allows for both primary and secondary usage
     # so form should have selector
-    assert get_form_input(response, "usage-0")
-    assert get_form_input(response, "usage-1")
+    assert get_form_input_value(response, "usage-0")
+    assert get_form_input_value(response, "usage-1")
 
     # post with no name
     response = clients.post("/wan-register", data=dict())
@@ -1677,7 +1677,7 @@ def test_login_next(app, client, get_message):
     )
     response_url = get_form_action(response)
 
-    next_loc = get_form_input(response, "next")
+    next_loc = get_form_input_value(response, "next")
     response = client.post(
         response_url,
         data=dict(credential=json.dumps(SIGNIN_DATA1), next=next_loc),
@@ -1739,7 +1739,7 @@ def test_async(app, client, get_message):
 )
 def test_csrf(app, client, get_message):
     response = client.get("/login")
-    csrf_token = get_form_input(response, "csrf_token")
+    csrf_token = get_form_input_value(response, "csrf_token")
     authenticate(client, csrf=True)
 
     register_options, response_url = _register_start(
@@ -1763,7 +1763,7 @@ def test_csrf(app, client, get_message):
     assert b"The CSRF tokens do not match." in response.data
 
     response = client.get("/wan-signin")
-    csrf_token = get_form_input(response, "csrf_token")
+    csrf_token = get_form_input_value(response, "csrf_token")
     signin_options, response_url = _signin_start(
         client, "matt@lp.com", csrf_token=csrf_token
     )

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -247,6 +247,8 @@ def create_app() -> Flask:
     def get_locale():
         # For a given session - set lang based on first request.
         # Honor explicit url request first
+        if not session:  # if running CLI
+            return
         global SET_LANG
         if not SET_LANG:
             session.pop("lang", None)


### PR DESCRIPTION
This deprecates RegisterForm and ConfirmRegisterForm and introduces RegisterFormV2.

Currently, the old forms are used so no backwards compat issue. The new form can be used by setting SECURITY_REGISTER_V2 to True.

Add the SECURITY_PASSWORD_CONFIRM_REQUIRED option that controls whether the RegisterFormV2 add that field.

Deprecate RegisterForm, ConfirmRegisterForm and confirm_register_form options.

closes #1043