### PR TITLE
Minor change to how LoginForm and RegisterFormV2 is created/modified

### DIFF
--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -7,9 +7,10 @@
   <form action="{{ url_for_security('login') }}{{ prop_next() }}" method="post" name="login_user_form">
     {{ login_user_form.hidden_tag() }}
     {{ render_form_errors(login_user_form) }}
-    {% if "email" in identity_attributes %}{{ render_field_with_errors(login_user_form.email) }}{% endif %}
+    {% if login_user_form.email and "email" in identity_attributes %}
+      {{ render_field_with_errors(login_user_form.email) }}{% endif %}
     {% if login_user_form.username and "username" in identity_attributes %}
-      {% if "email" in identity_attributes %}<h3>{{ _fsdomain("or") }}</h3>{% endif %}
+      {% if login_user_form.email and "email" in identity_attributes %}<h3>{{ _fsdomain("or") }}</h3>{% endif %}
       {{ render_field_with_errors(login_user_form.username) }}
     {% endif %}
     <div class="fs-gap">{{ render_field_with_errors(login_user_form.password) }}</div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,10 +340,13 @@ def app(request):
                     del app.security.forms[form_name].cls.username
 
         from flask_security import RegisterFormV2
+        from flask_security.forms import PasswordConfirmFormMixin, NewPasswordFormMixin
 
-        for attr in ["username", "password", "password_confirm"]:
+        for attr in ["username"]:
             if hasattr(RegisterFormV2, attr):
                 delattr(RegisterFormV2, attr)
+        RegisterFormV2.password_confirm = PasswordConfirmFormMixin.password_confirm
+        RegisterFormV2.password = NewPasswordFormMixin.password
 
     request.addfinalizer(revert_forms)
     yield app

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -228,7 +228,7 @@ def test_authenticate_case_insensitive_email(app, client):
 def test_authenticate_with_invalid_input(client, get_message):
     response = client.post(
         "/login",
-        json=dict(password="password"),
+        json=dict(password="password", email="mememe@test.com"),
         headers={"Content-Type": "application/json"},
     )
     assert get_message("USER_DOES_NOT_EXIST") in response.data


### PR DESCRIPTION
The default LoginForm now reflects the default configuration - email is required. In init_app() build_login_form() is called that if USERNAME_ENABLE is set will add the username field (as before) and change the email field to be Optional(). This is a small semantic change - prior the email field was not marked as required.

Change the new RegisterFormV2 construction - now the default form reflects the default configuration - new_password and confirm_password are required. From init_app build_register_form() is called and it will: 1) remove password_confirm field if PASSWORD_CONFIRM_REQUIRED is False 2) add username field if USERNAME_ENABLE is True
3) mark the password field as optional if PASSWORD_REQUIRED is False or UNIFIED_SIGNING is True