### PR TITLE
Get templates to pass W3C validation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 5.6.0
 -------------
 
-Released TBD
+Released January xx, 2025
 
 Features & Improvements
 +++++++++++++++++++++++
@@ -14,12 +14,16 @@ Features & Improvements
 - (:issue:`980`) Add support for username recovery in simple login flows (jamesejr)
 - (:issue:`1055`) Add support for changing username
 - (:pr:`1048`) Add support for Python 3.13
-- (:issue:`1043`) Unify Register forms (and split out re-type password option)
-- (:pr:`1052`) Remove deprecated TWO_FACTOR configuration variables
+- (:issue:`1043`) Unify Register forms (and split out re-type password option) Please read :ref:`register_form_migration`.
 
 Fixes
 +++++
-- (:pr:`zz`) Fix duplicate HTML ids in templates.
+- (:pr:`1062`) Fix duplicate HTML ids in templates.
+- (:issue:`xx`) Ensure templates pass W3C validation (see below)
+
+Docs and Chores
++++++++++++++++
+- (:pr:`1052`) Remove deprecated TWO_FACTOR configuration variables
 
 Notes
 +++++
@@ -39,6 +43,15 @@ The SECURITY_TWO_FACTOR_{SECRET, URI_SERVICE_NAME, SMS_SERVICE, SMS_SERVICE_CONF
 have been removed (they have been deprecated for a while). Use the equivalent
 :py:data:`SECURITY_TOTP_SECRETS`, :py:data:`SECURITY_TOTP_ISSUER`, :py:data:`SECURITY_SMS_SERVICE` and
 :py:data:`SECURITY_SMS_SERVICE_CONFIG`.
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+Fixing all the templates to pass W3C validation could introduce some incompatibilities:
+
+- All templates now have a default <title> - before the <title> element was empty.
+- The HTML id of the rescue form submit button was changed to 'rescue'
+- The HTML id of the webauthn delete form name field was changed to 'delete-name'
+- Some template headings were changed to improve consistency
 
 Version 5.5.2
 -------------

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1687,7 +1687,7 @@ class Security:
             build_register_form(app=app, fcls=fcls)
         fcls = self.forms["change_username_form"].cls
         if fcls and issubclass(fcls, ChangeUsernameForm):
-            fcls.username = build_username_field(app=app, autocomplete="new-username")
+            fcls.username = build_username_field(app=app)
 
         # initialize two-factor plugins. Note that each implementation likely
         # has its own feature flag which will control whether it is active or not.

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -369,14 +369,14 @@ class CodeFormMixin:
         get_form_field_label("code"),
         render_kw={
             "autocomplete": "one-time-code",
-            "inputtype": "numeric",
+            "type": "text",
             "pattern": "[0-9]*",
         },
         validators=[RequiredLocalize()],
     )
 
 
-def build_username_field(app, autocomplete="username"):
+def build_username_field(app):
     if cv("USERNAME_REQUIRED", app=app):
         validators = [
             RequiredLocalize(message="USERNAME_NOT_PROVIDED"),
@@ -387,7 +387,7 @@ def build_username_field(app, autocomplete="username"):
         validators = [username_validator, unique_username]
     return StringField(
         get_form_field_label("username"),
-        render_kw={"autocomplete": autocomplete},
+        render_kw={"autocomplete": "username"},
         validators=validators,
     )
 
@@ -1017,7 +1017,7 @@ class TwoFactorRescueForm(Form):
             ("help", get_form_field_xlate(_("Contact Administrator"))),
         ],
     )
-    submit = SubmitField(get_form_field_label("submit"))
+    submit = SubmitField(get_form_field_label("submit"), id="rescue")
 
 
 class UsernameRecoveryForm(Form, UserEmailFormMixin):

--- a/flask_security/templates/security/base.html
+++ b/flask_security/templates/security/base.html
@@ -8,6 +8,7 @@
     <title>{% block title %}{{ title|default }}{% endblock title %}</title>
 
       {%- block metas %}
+        <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
       {%- endblock metas %}
 

--- a/flask_security/templates/security/change_email.html
+++ b/flask_security/templates/security/change_email.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Change email')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/change_password.html
+++ b/flask_security/templates/security/change_password.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Change password')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/change_username.html
+++ b/flask_security/templates/security/change_username.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Change Username')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/forgot_password.html
+++ b/flask_security/templates/security/forgot_password.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Send password reset instructions')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Login')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, prop_next %}
 

--- a/flask_security/templates/security/mf_recovery.html
+++ b/flask_security/templates/security/mf_recovery.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain("Enter Recovery Code")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field %}
 

--- a/flask_security/templates/security/mf_recovery_codes.html
+++ b/flask_security/templates/security/mf_recovery_codes.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Recovery Codes')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
 

--- a/flask_security/templates/security/recover_username.html
+++ b/flask_security/templates/security/recover_username.html
@@ -1,9 +1,10 @@
+{% set title = title|default(_fsdomain('Username Recovery')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain('Username recovery') }}</h1>
+  <h1>{{ _fsdomain('Username Recovery') }}</h1>
   <form action="{{ url_for_security('recover_username') }}" method="post" name="username_recovery_form">
     {{ username_recovery_form.hidden_tag() }}
     {{ render_form_errors(username_recovery_form) }}

--- a/flask_security/templates/security/register_user.html
+++ b/flask_security/templates/security/register_user.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Register')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_form_errors, render_field_errors %}
 

--- a/flask_security/templates/security/reset_password.html
+++ b/flask_security/templates/security/reset_password.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain("Reset password")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/send_confirmation.html
+++ b/flask_security/templates/security/send_confirmation.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain("Resend confirmation instructions")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field %}
 

--- a/flask_security/templates/security/send_login.html
+++ b/flask_security/templates/security/send_login.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain("Login")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field %}
 

--- a/flask_security/templates/security/two_factor_select.html
+++ b/flask_security/templates/security/two_factor_select.html
@@ -1,9 +1,10 @@
+{% set title = title|default(_fsdomain("Select Two-Factor Method")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import prop_next, render_field_with_errors, render_field %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain('Select Two Factor Method') }}</h1>
+  <h1>{{ _fsdomain('Select Two-Factor Method') }}</h1>
   <form action="{{ url_for_security('tf_select') }}{{ prop_next() }}" method="post" name="tf_select">
     {{ two_factor_select_form.hidden_tag() }}
     {{ render_field_with_errors(two_factor_select_form.which) }}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -18,7 +18,7 @@
       authr_username: same username as in qrcode
       authr_issuer: same issuer as in qrcode
 #}
-
+{% set title = title|default(_fsdomain("Two-Factor Setup")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_no_label, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain("Two-Factor Authentication")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -21,7 +21,7 @@
     authr_username: same username as in qrcode
     authr_issuer: same issuer as in qrcode
 #}
-
+{% set title = title|default(_fsdomain('Setup Unified Sign In')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -1,3 +1,4 @@
+{% set title = title|default(_fsdomain('Sign In')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, prop_next %}
 

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -1,9 +1,10 @@
+{% set title = title|default(_fsdomain('Reauthenticate')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, prop_next %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Please Reauthenticate") }}</h1>
+  <h1>{{ _fsdomain("Reauthenticate") }}</h1>
   <form action="{{ url_for_security('us_verify') }}{{ prop_next() }}" method="post" name="us_verify_form">
     {{ us_verify_form.hidden_tag() }}
     {{ render_field_with_errors(us_verify_form.passcode) }}

--- a/flask_security/templates/security/verify.html
+++ b/flask_security/templates/security/verify.html
@@ -1,9 +1,10 @@
+{% set title = title|default(_fsdomain("Reauthenticate")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Please Reauthenticate") }}</h1>
+  <h1>{{ _fsdomain("Reauthenticate") }}</h1>
   <form action="{{ url_for_security('verify') }}{{ prop_next() }}" method="post" name="verify_form">
     {{ verify_form.hidden_tag() }}
     {{ render_field_with_errors(verify_form.password) }}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -1,13 +1,13 @@
 {#
   This template receives the following pieces of context in addition to the form:
 #}
-
+{% set title = title|default(_fsdomain("Setup New WebAuthn Security Key")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
 
 {% block head_scripts %}
   {{ super() }}
-  <script src="{{ url_for('.static', filename='js/webauthn.js') }}" xmlns="http://www.w3.org/1999/html"></script>
+  <script src="{{ url_for('.static', filename='js/webauthn.js') }}"></script>
   <script src="{{ url_for('.static', filename='js/base64.js') }}"></script>
 {% endblock head_scripts %}
 

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -1,13 +1,13 @@
 {#
   This template receives the following pieces of context in addition to the form:
 #}
-
+{% set title = title|default(_fsdomain("WebAuthn Security Key")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, prop_next %}
 
 {% block head_scripts %}
   {{ super() }}
-  <script src="{{ url_for('.static', filename='js/webauthn.js') }}" xmlns="http://www.w3.org/1999/html"></script>
+  <script src="{{ url_for('.static', filename='js/webauthn.js') }}"></script>
   <script src="{{ url_for('.static', filename='js/base64.js') }}"></script>
 {% endblock head_scripts %}
 

--- a/flask_security/templates/security/wan_verify.html
+++ b/flask_security/templates/security/wan_verify.html
@@ -6,19 +6,19 @@
   skip_login_menu - True
   Any other context provided by the "wan_verify" context processer.
 #}
-
+{% set title = title|default(_fsdomain("Re-Authenticate Using Your WebAuthn Security Key")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 
 {% block head_scripts %}
   {{ super() }}
-  <script src="{{ url_for('.static', filename='js/webauthn.js') }}" xmlns="http://www.w3.org/1999/html"></script>
+  <script src="{{ url_for('.static', filename='js/webauthn.js') }}"></script>
   <script src="{{ url_for('.static', filename='js/base64.js') }}"></script>
 {% endblock head_scripts %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Please Re-Authenticate Using Your WebAuthn Security Key") }}</h1>
+  <h1>{{ _fsdomain("Re-Authenticate Using Your WebAuthn Security Key") }}</h1>
   {% if not credential_options %}
     <form action="{{ url_for_security('wan_verify') }}{{ prop_next() }}" method="post" name="wan_verify_form">
       {{ wan_verify_form.hidden_tag() }}

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -352,9 +352,12 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
 
 
 class WebAuthnDeleteForm(Form):
+    # Change id of name since this shows up on register form that ALSO has a name
+    # element.
     name = StringField(
         get_form_field_xlate(_("Nickname")),
         validators=[RequiredLocalize(message="WEBAUTHN_NAME_REQUIRED")],
+        id="delete-name",
     )
     submit = SubmitField(label=get_form_field_label("delete"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@
     Test fixtures and what not
 
     :copyright: (c) 2017 by CERN.
-    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -182,7 +182,7 @@ def app(request):
     if request.config.option.setting:
         for s in request.config.option.setting:
             key, value = s.split("=")
-            app.config["SECURITY_" + key.upper()] = convert_bool_option(value)
+            app.config[key.upper()] = convert_bool_option(value)
 
     app.mail = Mail(app)  # type: ignore
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1148,7 +1148,7 @@ def test_verify_fresh(app, client, get_message):
 
     with capture_flashes() as flashes:
         response = client.get("/fresh", follow_redirects=True)
-        assert b"Please Reauthenticate" in response.data
+        assert b"Reauthenticate" in response.data
     assert flashes[0]["category"] == "error"
     assert flashes[0]["message"].encode("utf-8") == get_message(
         "REAUTHENTICATION_REQUIRED"
@@ -1161,12 +1161,12 @@ def test_verify_fresh(app, client, get_message):
 
     reset_fresh(client, app.config["SECURITY_FRESHNESS"])
     response = client.get(verify_url)
-    assert b"Please Reauthenticate" in response.data
+    assert b"Reauthenticate" in response.data
 
     response = client.post(
         verify_url, data=dict(password="not my password"), follow_redirects=False
     )
-    assert b"Please Reauthenticate" in response.data
+    assert b"Reauthenticate" in response.data
 
     response = client.post(
         verify_url, data=dict(password="password"), follow_redirects=False
@@ -1189,7 +1189,7 @@ def test_verify_fresh_json(app, client, get_message):
     assert response.json["response"]["reauth_required"]
 
     response = client.get("/verify")
-    assert b"Please Reauthenticate" in response.data
+    assert b"Reauthenticate" in response.data
 
     response = client.post(
         "/verify", json=dict(password="not my password"), headers=headers

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -812,7 +812,7 @@ def test_username_recovery_valid_email(app, clients, get_message):
 
     # Test the username recovery view
     response = clients.get("/recover-username")
-    assert b"<h1>Username recovery</h1>" in response.data
+    assert b"<h1>Username Recovery</h1>" in response.data
 
     response = clients.post(
         "/recover-username", data=dict(email="joe@lp.com"), follow_redirects=True

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,162 @@
+"""
+    test_templates
+    ~~~~~~~~~~
+
+    Test templates to be W3C valid
+
+    :copyright: (c) 2025-2025 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+    Note that the validator definitely rate-limits us - so we don't just run
+    them all.
+
+    To run a test pass templates="RESET,LOGIN" on the command line.
+"""
+
+from time import sleep
+
+import pytest
+import requests
+
+from tests.test_utils import (
+    authenticate,
+    logout,
+    capture_reset_password_requests,
+    reset_fresh,
+    setup_tf_sms,
+)
+
+
+def check_message(msgs, mtype="error"):
+    # list of JSON messages from validator
+    errors = []
+    for msg in msgs:
+        if msg["type"] == mtype:
+            errors.append(msg["message"])
+    return errors
+
+
+def check_template(name, client, r):
+    # returns list of validation errors
+    t = client.get(name)
+    if t.status_code != 200:
+        return [f"{name} error {t.status_code}"]
+    vout = r.post("https://validator.w3.org/nu/?out=json", t.data)
+    if vout.status_code == 429:
+        # we got rate limited try again
+        sleep(2.0)
+        vout = r.post("https://validator.w3.org/nu/?out=json", t.data)
+        if vout.status_code != 200:
+            return [f"{name} API error {vout.status_code}"]
+    if vout.status_code != 200:
+        return [f"{name} API error {vout.status_code}"]
+    return check_message(vout.json()["messages"])
+
+
+@pytest.mark.registerable()
+@pytest.mark.recoverable()
+@pytest.mark.changeable()
+@pytest.mark.change_email()
+@pytest.mark.change_username()
+@pytest.mark.username_recovery()
+@pytest.mark.unified_signin()
+@pytest.mark.webauthn()
+@pytest.mark.two_factor()
+@pytest.mark.settings(multi_factor_recovery_codes=True)
+def test_valid_html(app, client):
+    # since we get rate limited - use external pytest option to specify
+    totry = app.config.get("TEMPLATES", "").split(",")
+    rsession = requests.session()
+    rsession.headers.update({"Content-Type": "text/html; charset=utf-8"})
+
+    unauth_urls = [
+        "LOGIN",
+        "REGISTER",
+        "RESET",
+        "US_SIGNIN",
+        "USERNAME_RECOVERY",
+        "WAN_SIGNIN",
+    ]
+    auth_urls = [
+        "CHANGE",
+        "CHANGE_USERNAME",
+        "CHANGE_EMAIL",
+        "MULTI_FACTOR_RECOVERY_CODES",
+        "TWO_FACTOR_SETUP",
+        "US_SETUP",
+        "US_VERIFY",
+        "WAN_REGISTER",
+        "WAN_VERIFY",
+    ]
+
+    # MULTI_FACTOR_RECOVERY requires tf-setup and login/password
+    # TWO_FACTOR_RESCUE has an issue with the RadioField - possibly because we
+    # change it after instantiation???
+    # TWO_FACTOR_SELECT needs special setup
+    authenticate(client)
+    logout(client)
+
+    terrors = dict()
+    for t in [u for u in unauth_urls if u in totry]:
+        terrors[t] = check_template(app.config[f"SECURITY_{t}_URL"], client, rsession)
+
+    authenticate(client)
+    for t in [u for u in auth_urls if u in totry]:
+        terrors[t] = check_template(app.config[f"SECURITY_{t}_URL"], client, rsession)
+
+    if "VERIFY" in totry:
+        reset_fresh(client, app.config["SECURITY_FRESHNESS"])
+        terrors["VERIFY"] = check_template(
+            app.config["SECURITY_VERIFY_URL"], client, rsession
+        )
+
+    print(f"Validated: {totry}")
+    errors = {k: v for k, v in terrors.items() if v}
+    assert not any(errors), errors
+
+
+@pytest.mark.confirmable()
+def test_valid_html_confirm(app, client):
+    rsession = requests.session()
+    rsession.headers.update({"Content-Type": "text/html; charset=utf-8"})
+    # since we get rate limited - use external pytest option to specify
+    totry = app.config.get("TEMPLATES", "").split(",")
+    if "CONFIRM" in totry:
+        print(f"Validated: {totry}")
+        terrors = check_template(app.config["SECURITY_CONFIRM_URL"], client, rsession)
+        assert not terrors
+
+
+@pytest.mark.recoverable()
+def test_valid_html_recover(app, client):
+    rsession = requests.session()
+    rsession.headers.update({"Content-Type": "text/html; charset=utf-8"})
+    # since we get rate limited - use external pytest option to specify
+    totry = app.config.get("TEMPLATES", "").split(",")
+    if "RESET" in totry:
+        print(f"Validated: {totry}")
+        with capture_reset_password_requests() as resets:
+            client.post("/reset", data=dict(email="joe@lp.com"))
+        token = resets[0]["token"]
+        terrors = check_template(
+            f'{app.config[f"SECURITY_RESET_URL"]}/{token}', client, rsession
+        )
+        assert not terrors
+
+
+@pytest.mark.two_factor()
+def test_valid_html_rescue(app, client):
+    rsession = requests.session()
+    rsession.headers.update({"Content-Type": "text/html; charset=utf-8"})
+    # since we get rate limited - use external pytest option to specify
+    totry = app.config.get("TEMPLATES", "").split(",")
+    if "TWO_FACTOR_RESCUE" in totry:
+        authenticate(client)
+        setup_tf_sms(client)
+        logout(client)
+        authenticate(client)
+        print(f"Validated: {totry}")
+        terrors = check_template(
+            app.config["SECURITY_TWO_FACTOR_RESCUE_URL"], client, rsession
+        )
+        assert not terrors

--- a/tests/test_tf_plugin.py
+++ b/tests/test_tf_plugin.py
@@ -41,7 +41,7 @@ def test_tf_select(app, client, get_message):
         data=dict(email="matt@lp.com", password="password"),
         follow_redirects=True,
     )
-    assert b"Select Two Factor Method" in response.data
+    assert b"Select Two-Factor Method" in response.data
     tf_select_url = get_form_action(response)
     response = client.post(
         tf_select_url, data=dict(which="webauthn"), follow_redirects=True
@@ -63,7 +63,7 @@ def test_tf_select(app, client, get_message):
         data=dict(email="matt@lp.com", password="password"),
         follow_redirects=True,
     )
-    assert b"Select Two Factor Method" in response.data
+    assert b"Select Two-Factor Method" in response.data
     response = client.post("/tf-select", data=dict(which="sms"), follow_redirects=True)
     assert b"Please enter your authentication code generated via: SMS" in response.data
     code = sms_sender.messages[0].split()[-1]

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1021,7 +1021,7 @@ def test_verify(app, clients, get_message):
 
     response = client.get("us-setup", follow_redirects=True)
     form_response = response.data.decode("utf-8")
-    assert "Please Reauthenticate" in form_response
+    assert "Reauthenticate" in form_response
     send_code_url = get_form_action(response, 1)
 
     # Send unknown method


### PR DESCRIPTION
Most changes were to simply add a default <title>

Validation did find some other bugs:
- Other duplicate HTML ids in some of the more complex multi-form templates
- Error in one-time-code input type

Changed some titles to get more consistent around case

Added (manual) test to use W3C validator to check templates. We can't do this all the time since we get rate-limited.

Currently TWO_FACTOR_VERIFY_CODE template is failing due to some label

close #1064

@ademaro please review.. Thanks!