### PR TITLE
Get templates to pass W3C validation - pass 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ Features & Improvements
 Fixes
 +++++
 - (:pr:`1062`) Fix duplicate HTML ids in templates.
-- (:issue:`xx`) Ensure templates pass W3C validation (see below)
+- (:pr:`xx`) Fix more duplicate HTML ids in templates.
+- (:issue:`1064`) Ensure templates pass W3C validation (see below)
 
 Docs and Chores
 +++++++++++++++
@@ -48,10 +49,13 @@ Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
 Fixing all the templates to pass W3C validation could introduce some incompatibilities:
 
-- All templates now have a default <title> - before the <title> element was empty.
+- All templates now have a default <title> - before, the <title> element was empty.
 - The HTML id of the rescue form submit button was changed to 'rescue'
 - The HTML id of the webauthn delete form name field was changed to 'delete-name'
 - Some template headings were changed to improve consistency
+- The csrf_token HTML id was changed on us_setup.html, wan_register.html, two_factor_setup.html
+  two_factor_verify_code.html, us_verify.html, verify.html for the second form on the page.
+- On us_setup.html and two_factor_setup.html the submit code button HTML id was changed.
 
 Version 5.5.2
 -------------

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -968,7 +968,7 @@ class TwoFactorSetupForm(Form):
 class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
     """The Two-factor token validation form"""
 
-    submit = SubmitField(get_form_field_label("submitcode"))
+    submit = SubmitField(get_form_field_label("submitcode"), id="submit-code")
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)

--- a/flask_security/templates/security/_macros.html
+++ b/flask_security/templates/security/_macros.html
@@ -43,3 +43,11 @@
 {% macro prop_next() -%}
   {% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}
 {%- endmacro %}
+
+  {# For forms that have multiple POST forms - explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+{% macro render_csrf(form, pfx) %}
+  {% set csrf_field_name = form.meta.csrf_field_name | default %}
+  {% if form[csrf_field_name] is defined %}
+    {{ form[csrf_field_name](id=pfx~'-csrf') }}
+  {% endif %}
+{% endmacro %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -20,7 +20,8 @@
 #}
 {% set title = title|default(_fsdomain("Two-Factor Setup")) %}
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_no_label, render_field_errors, render_form_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field,
+ render_field_no_label, render_field_errors, render_form_errors, render_csrf %}
 
 {% block content %}
   {% include "security/_messages.html" %}
@@ -69,7 +70,8 @@
       {% set faction = url_for_security('two_factor_token_validation') %}
     {% endif %}
     <form action="{{ faction }}" method="post" name="two_factor_verify_code_form">
-      {{ two_factor_verify_code_form.hidden_tag() }}
+      {# explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+      {{ render_csrf(two_factor_verify_code_form, "code") }}
       {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder=_fsdomain("enter numeric code")) }}
       <div class="fs-gap">{{ render_field(two_factor_verify_code_form.submit) }}</div>
     </form>

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -1,6 +1,6 @@
 {% set title = title|default(_fsdomain("Two-Factor Authentication")) %}
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next, render_csrf %}
 
 {% block content %}
   {% include "security/_messages.html" %}
@@ -14,7 +14,8 @@
   {% if two_factor_rescue_form %}
     <hr class="fs-gap">
     <form action="{{ url_for_security('two_factor_rescue') }}{{ prop_next() }}" method="post" name="two_factor_rescue_form">
-      {{ two_factor_rescue_form.hidden_tag() }}
+      {# explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+      {{ render_csrf(two_factor_rescue_form, "rescue") }}
       {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
       {% if problem=="email" %}
         <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -23,7 +23,7 @@
 #}
 {% set title = title|default(_fsdomain('Setup Unified Sign In')) %}
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, render_csrf %}
 
 {% block content %}
   {% include "security/_messages.html" %}
@@ -76,7 +76,8 @@
     <hr class="fs-gap">
     <div class="fs-important">{{ _fsdomain("Enter code here to complete setup") }}</div>
     <form action="{{ url_for_security('us_setup_validate', token=state) }}" method="post" name="us_setup_validate_form">
-      {{ us_setup_validate_form.hidden_tag() }}
+      {# explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+      {{ render_csrf(us_setup_validate_form, "code") }}
       {{ render_field_with_errors(us_setup_validate_form.passcode) }}
       <div class="fs-gap">{{ render_field(us_setup_validate_form.submit) }}</div>
     </form>

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -1,6 +1,6 @@
 {% set title = title|default(_fsdomain('Reauthenticate')) %}
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, prop_next %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, prop_next, render_csrf %}
 
 {% block content %}
   {% include "security/_messages.html" %}
@@ -25,7 +25,8 @@
     <hr class="fs-gap">
     <h2>{{ _fsdomain("Use a WebAuthn Security Key to Reauthenticate") }}</h2>
     <form action="{{ url_for_security('wan_verify') }}{{ prop_next() }}" method="post" name="wan_verify_form">
-      {{ wan_verify_form.hidden_tag() }}
+      {# explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+      {{ render_csrf(wan_verify_form, "wan") }}
       {{ render_field(wan_verify_form.submit) }}
     </form>
   {% endif %}

--- a/flask_security/templates/security/verify.html
+++ b/flask_security/templates/security/verify.html
@@ -1,6 +1,6 @@
 {% set title = title|default(_fsdomain("Reauthenticate")) %}
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next, render_csrf %}
 
 {% block content %}
   {% include "security/_messages.html" %}
@@ -14,7 +14,8 @@
     <hr class="fs-gap">
     <h2>{{ _fsdomain("Use a WebAuthn Security Key to Reauthenticate") }}</h2>
     <form action="{{ url_for_security('wan_verify') }}{{ prop_next() }}" method="post" name="wan_verify_form">
-      {{ wan_verify_form.hidden_tag() }}
+      {# explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+      {{ render_csrf(wan_verify_form, "wan") }}
       {{ render_field(wan_verify_form.submit) }}
     </form>
   {% endif %}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -3,7 +3,7 @@
 #}
 {% set title = title|default(_fsdomain("Setup New WebAuthn Security Key")) %}
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_csrf %}
 
 {% block head_scripts %}
   {{ super() }}
@@ -65,7 +65,8 @@
     <hr>
     <h2>{{ _fsdomain("Delete Existing WebAuthn Security Key") }}</h2>
     <form action="{{ url_for_security('wan_delete') }}" method="post" name="wan_delete_form">
-      {{ wan_delete_form.hidden_tag() }}
+      {# explicitly render csrf_token so we can change the ID so we don't get duplicates #}
+      {{ render_csrf(wan_delete_form, "delete") }}
       {{ render_field_with_errors(wan_delete_form.name) }}
       {{ render_field(wan_delete_form.submit) }}
     </form>

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -4,7 +4,7 @@ flask_security.unified_signin
 
 Flask-Security Unified Signin module
 
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
 This implements a unified sign in endpoint - allowing
@@ -371,12 +371,12 @@ class UnifiedSigninSetupValidateForm(Form):
         get_form_field_label("passcode"),
         render_kw={
             "autocomplete": "one-time-code",
-            "inputtype": "numeric",
+            "type": "text",
             "pattern": "[0-9]*",
         },
         validators=[RequiredLocalize()],
     )
-    submit = SubmitField(get_form_field_label("submitcode"))
+    submit = SubmitField(get_form_field_label("submitcode"), id="submit-code")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ test_utils
 
 Test utils
 
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -141,17 +141,18 @@ def get_session(response):
                 return val[1]
 
 
-def setup_tf_sms(client, url_prefix=None):
+def setup_tf_sms(client, url_prefix=None, csrf_token=None):
     # Simple setup of SMS as a second factor and return the sender so caller
     # can get codes.
     SmsSenderFactory.senders["test"] = SmsTestSender
     sms_sender = SmsSenderFactory.createSender("test")
-    data = dict(setup="sms", phone="+442083661188")
+    data = dict(setup="sms", phone="+442083661188", csrf_token=csrf_token)
     response = client.post("/".join(filter(None, (url_prefix, "tf-setup"))), json=data)
     assert sms_sender.get_count() == 1
     code = sms_sender.messages[0].split()[-1]
     response = client.post(
-        "/".join(filter(None, (url_prefix, "tf-validate"))), json=dict(code=code)
+        "/".join(filter(None, (url_prefix, "tf-validate"))),
+        json=dict(code=code, csrf_token=csrf_token),
     )
     assert response.status_code == 200
     return sms_sender

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -203,8 +203,10 @@ def _register_start(
     return register_options, response_url
 
 
-def _register_start_json(client, name="testr1", usage="secondary"):
-    response = client.post("wan-register", json=dict(name=name, usage=usage))
+def _register_start_json(client, name="testr1", usage="secondary", csrf_token=None):
+    response = client.post(
+        "wan-register", json=dict(name=name, usage=usage, csrf_token=csrf_token)
+    )
     register_options = response.json["response"]["credential_options"]
     response_url = f'wan-register/{response.json["response"]["wan_state"]}'
     return register_options, response_url
@@ -230,6 +232,20 @@ def reg_2_keys(client):
         "first": {"id": REG_DATA_UV["id"], "signin": SIGNIN_DATA_UV},
         "secondary": {"id": REG_DATA1["id"], "signin": SIGNIN_DATA1},
     }
+
+
+def reg_first_key(client, csrf_token=None):
+    # Register a primary key - assumes already authenticated
+    # This can be used by other tests outside this module.
+    register_options, response_url = _register_start_json(
+        client, name="first", usage="first", csrf_token=csrf_token
+    )
+    response = client.post(
+        response_url,
+        json=dict(credential=json.dumps(REG_DATA_UV), csrf_token=csrf_token),
+    )
+    assert response.status_code == 200
+    return {"id": REG_DATA_UV["id"], "signin": SIGNIN_DATA_UV}
 
 
 def _signin_start(


### PR DESCRIPTION
Validation did find some other bugs:
- Other duplicate HTML ids in some of the more complex multi-form templates
- Error in one-time-code input type

Improved (manual) test to use W3C validator to check templates. We can't do this all the time since we get rate-limited.

Turned on CSRF for testing templates - many duplicate csrf_token ids. Added a new macro - render_csrf that can be used to render the token with a unique HTML id.

Improve webauthn test utils to support CSRF.

close #1064