### PR TITLE
Improve templates - grammar, spelling, better formatting for xlation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 5.6.0
 -------------
 
-Released January xx, 2025
+Released February xx, 2025
 
 Features & Improvements
 +++++++++++++++++++++++
@@ -19,12 +19,15 @@ Features & Improvements
 Fixes
 +++++
 - (:pr:`1062`) Fix duplicate HTML ids in templates.
-- (:pr:`xx`) Fix more duplicate HTML ids in templates.
+- (:pr:`1067`) Fix more duplicate HTML ids in templates.
 - (:issue:`1064`) Ensure templates pass W3C validation (see below)
 
 Docs and Chores
 +++++++++++++++
 - (:pr:`1052`) Remove deprecated TWO_FACTOR configuration variables
+- (:pr:`1069`) Update ES and IT translations (gissimo)
+- (:pr:`1071`) Improve templates - two-factor is hyphenated, re-authenticate is not.
+  Also try to embed links into xlatable strings.
 
 Notes
 +++++
@@ -47,7 +50,7 @@ have been removed (they have been deprecated for a while). Use the equivalent
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
-Fixing all the templates to pass W3C validation could introduce some incompatibilities:
+The fixes to all the templates to pass W3C validation could introduce some incompatibilities:
 
 - All templates now have a default <title> - before, the <title> element was empty.
 - The HTML id of the rescue form submit button was changed to 'rescue'

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,5 @@ coverage:
         if_ci_failed: error #success, failure, error, ignore
         informational: false
         only_pulls: false
+        ignore:
+          - "flask_security/flask_security/templates"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -714,7 +714,7 @@ Core - rarely need changing
     Default: ``"remember-salt"``.
 .. py:data:: SECURITY_TWO_FACTOR_VALIDITY_SALT
 
-    Specifies the salt value when generating two factor validity tokens.
+    Specifies the salt value when generating two-factor validity tokens.
 
     Default: ``"tf-validity-salt"``.
 .. py:data:: SECURITY_US_SETUP_SALT
@@ -830,7 +830,7 @@ Login/Logout
 
 .. py:data:: SECURITY_VERIFY_URL
 
-    Specifies the re-authenticate URL. If :py:data:`SECURITY_FRESHNESS` evaluates to < 0; this
+    Specifies the reauthenticate URL. If :py:data:`SECURITY_FRESHNESS` evaluates to < 0; this
     endpoint won't be registered.
 
     Default: ``"/verify"``
@@ -848,9 +848,9 @@ Login/Logout
 
 .. py:data:: SECURITY_POST_VERIFY_URL
 
-    Specifies the default view to redirect to after a user successfully re-authenticates either via
+    Specifies the default view to redirect to after a user successfully reauthenticates either via
     the :py:data:`SECURITY_VERIFY_URL` or the :py:data:`SECURITY_US_VERIFY_URL`.
-    Normally this won't need to be set and after the verification/re-authentication, the referring
+    Normally this won't need to be set and after the verification/reauthentication, the referring
     view (held in the ``next`` parameter) will be redirected to.
 
     Default: ``None``.
@@ -1252,7 +1252,7 @@ Configuration related to the two-factor authentication feature.
     Default: ``False``.
 .. py:data:: SECURITY_TWO_FACTOR_REQUIRED
 
-    If set to ``True`` then all users will be required to setup and use two factor authorization.
+    If set to ``True`` then all users will be required to setup and use two-factor authorization.
 
     Default: ``False``.
 .. py:data:: SECURITY_TWO_FACTOR_ENABLED_METHODS
@@ -1277,7 +1277,7 @@ Configuration related to the two-factor authentication feature.
     Default: ``120``.
 .. py:data:: SECURITY_TWO_FACTOR_SETUP_WITHIN
 
-    Specifies the amount of time a user has before their two factor setup
+    Specifies the amount of time a user has before their two-factor setup
     token expires. Always pluralize the time unit for this value.
 
     Default: ``"30 minutes"``
@@ -1292,14 +1292,14 @@ Configuration related to the two-factor authentication feature.
 
 .. py:data:: SECURITY_EMAIL_SUBJECT_TWO_FACTOR
 
-    Sets the subject for the two factor feature.
+    Sets the subject for the two-factor feature.
 
-    Default: ``_("Two-factor Login")``
+    Default: ``_("Two-Factor Login")``
 .. py:data:: SECURITY_EMAIL_SUBJECT_TWO_FACTOR_RESCUE
 
-    Sets the subject for the two factor help function.
+    Sets the subject for the two-factor help function.
 
-    Default: ``_("Two-factor Rescue")``
+    Default: ``_("Two-Factor Rescue")``
 .. py:data:: SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE
 
     Specifies the path to the template for the verify code page for the two-factor authentication process.
@@ -1307,30 +1307,30 @@ Configuration related to the two-factor authentication feature.
     Default: ``"security/two_factor_verify_code.html"``.
 .. py:data:: SECURITY_TWO_FACTOR_SETUP_TEMPLATE
 
-    Specifies the path to the template for the setup page for the two factor authentication process.
+    Specifies the path to the template for the setup page for the two-factor authentication process.
 
     Default: ``"security/two_factor_setup.html"``.
 
 .. py:data:: SECURITY_TWO_FACTOR_SETUP_URL
 
-    Specifies the two factor setup URL.
+    Specifies the two-factor setup URL.
 
     Default: ``"/tf-setup"``.
 .. py:data:: SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL
 
-    Specifies the two factor token validation URL.
+    Specifies the two-factor token validation URL.
 
     Default: ``"/tf-validate"``.
 
 .. py:data:: SECURITY_TWO_FACTOR_RESCUE_URL
 
-    Specifies the two factor rescue URL.
+    Specifies the two-factor rescue URL.
 
     Default: ``"/tf-rescue"``.
 
 .. py:data:: SECURITY_TWO_FACTOR_SELECT_URL
 
-    Specifies the two factor select URL. This is used when the user has
+    Specifies the two-factor select URL. This is used when the user has
     setup more than one second factor.
 
     Default: ``"/tf-select"``.
@@ -1368,7 +1368,7 @@ Configuration related to the two-factor authentication feature.
 
 .. py:data:: SECURITY_TWO_FACTOR_ALWAYS_VALIDATE
 
-    Specifies whether the application should require a two factor code upon every login.
+    Specifies whether the application should require a two-factor code upon every login.
     If set to ``False`` then the 2 values below are used to determine when
     a code is required. Note that this is cookie based - so a new browser
     session will always require a fresh two-factor code.
@@ -1376,14 +1376,14 @@ Configuration related to the two-factor authentication feature.
     Default: ``True``.
 .. py:data:: SECURITY_TWO_FACTOR_LOGIN_VALIDITY
 
-    Specifies the expiration of the two factor validity cookie and verification of the token.
+    Specifies the expiration of the two-factor validity cookie and verification of the token.
 
     Default: ``"30 Days"``.
 
 
 .. py:data:: SECURITY_TWO_FACTOR_VALIDITY_COOKIE
 
-    A dictionary containing the parameters of the two factor validity cookie.
+    A dictionary containing the parameters of the two-factor validity cookie.
     The complete set of parameters is described in Flask's `set_cookie`_ documentation.
 
     Default: ``{'httponly': True, 'secure': False, 'samesite': None}``.
@@ -1452,7 +1452,7 @@ Unified Signin
 
 .. py:data:: SECURITY_US_VERIFY_URL
 
-    This endpoint handles re-authentication, the caller must be already authenticated
+    This endpoint handles reauthentication, the caller must be already authenticated
     and then enter in their primary credentials (password/passcode) again. This is
     used when an endpoint (such as ``/us-setup``) fails freshness checks.
     This endpoint won't be registered if :py:data:`SECURITY_FRESHNESS` evaluates to < 0.
@@ -1724,7 +1724,7 @@ WebAuthn
 
 .. py:data:: SECURITY_WAN_VERIFY_URL
 
-    Endpoint for re-authenticating using a WebAuthn credential.
+    Endpoint for reauthenticating using a WebAuthn credential.
 
     Default: ``"/wan-verify"``
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -227,13 +227,13 @@ paths:
                         description: Http status code
   /verify:
     get:
-      summary: GET verify/re-authentication form
+      summary: GET verify/reauthentication form
       description: >
         If an endpoint is protected with @auth_required() with a freshness declaration
-        this endpoint will be called to request an already signed in user to re-authenticate.
+        this endpoint will be called to request an already signed in user to reauthenticate.
       responses:
         200:
-          description: Verify/re-authenticate form
+          description: Verify/reauthenticate form
           content:
             text/html:
               schema:
@@ -250,7 +250,7 @@ paths:
                       True if caller has a registered WebAuthn Key which has a `usage` that
                       is allowed by the SECURITY_WAN_ALLOW_AS_VERIFY configuration setting.
     post:
-      summary: Verify/re-authentication
+      summary: Verify/Reauthentication
       parameters:
         - $ref: "#/components/parameters/include_auth_token"
       requestBody:
@@ -264,21 +264,21 @@ paths:
               $ref: "#/components/schemas/Verify"
       responses:
         200:
-          description: Verify/re-authenticate response.
+          description: Verify/Reauthenticate response.
           content:
             application/json:
               schema:
                 allOf:
                   - description: >
-                      The user successfully re-authenticated.
+                      The user successfully reauthenticated.
                   - $ref: "#/components/schemas/JsonResponseWithToken"
             text/html:
               schema:
-                description: Unsuccessful re-authentication.
+                description: Unsuccessful reauthentication.
                 type: string
                 example: render_template(SECURITY_VERIFY_TEMPLATE) with error values
         302:
-          description: User successfully re-authenticated when using form based request.
+          description: User successfully reauthenticated when using form based request.
           headers:
             Location:
               description: Redirect to ``next`` or ``SECURITY_POST_VERIFY_VIEW``
@@ -962,13 +962,13 @@ paths:
 
   /us-verify:
     get:
-      summary: GET Unified sign in verify/re-authentication form/information
+      summary: GET Unified sign in verify/reauthentication form/information
       description: >
         If an endpoint is protected with @auth_required() with a freshness declaration
-        this endpoint will be called to request an already signed in user to re-authenticate.
+        this endpoint will be called to request an already signed in user to reauthenticate.
       responses:
         200:
-          description: Verify/re-authenticate form
+          description: Verify/Reauthenticate form
           content:
             text/html:
               schema:
@@ -997,7 +997,7 @@ paths:
                       True if caller has a registered WebAuthn Key which has a `usage` that
                       is allowed by the SECURITY_WAN_ALLOW_AS_VERIFY configuration setting.
     post:
-      summary: Unified sign in verify/re-authentication
+      summary: Unified sign in verify/reauthentication
       parameters:
         - $ref: "#/components/parameters/include_auth_token"
       requestBody:
@@ -1011,21 +1011,21 @@ paths:
               $ref: "#/components/schemas/UsSigninVerify"
       responses:
         200:
-          description: Verify/re-authenticate response.
+          description: Verify/reauthenticate response.
           content:
             application/json:
               schema:
                 allOf:
                   - description: >
-                      The user successfully re-authenticated.
+                      The user successfully reauthenticated.
                   - $ref: "#/components/schemas/JsonResponseWithToken"
             text/html:
               schema:
                 type: string
-                description: Unsuccessful re-authentication - render_template(SECURITY_US_VERIFY_TEMPLATE) with error values
+                description: Unsuccessful reauthentication - render_template(SECURITY_US_VERIFY_TEMPLATE) with error values
                 example: render_template(SECURITY_US_VERIFY_TEMPLATE) with error values
         302:
-          description: User successfully re-authenticated when using form based request.
+          description: User successfully reauthenticated when using form based request.
           headers:
             Location:
               description: Redirect to ``next`` or ``SECURITY_POST_VERIFY_VIEW``
@@ -1273,7 +1273,7 @@ paths:
                     type: string
                     description: Currently configured (if any) phone number.
     post:
-      summary: Two factor setup.
+      summary: Two-Factor setup.
       description: >
         Two-factor setup can be used in three cases:
 
@@ -1299,7 +1299,7 @@ paths:
       responses:
         200:
           description: >
-            Two factor setup response. Please note that the newly setup method must be validated PRIOR to it being stored permanently.
+            Two-Factor setup response. Please note that the newly setup method must be validated PRIOR to it being stored permanently.
           content:
             application/json:
               schema:
@@ -1350,7 +1350,7 @@ paths:
               $ref: "#/components/schemas/TfSetupValidateRequest"
       responses:
         200:
-          description: Successfully validated and persisted two factor method.
+          description: Successfully validated and persisted two-factor method.
           content:
             application/json:
               schema:
@@ -1410,7 +1410,7 @@ paths:
                   example: 12345
       responses:
         200:
-          description: Two factor code validation response.
+          description: Two-Factor code validation response.
           content:
             application/json:
               schema:
@@ -1423,7 +1423,7 @@ paths:
               schema:
                 description: >
                   Unsuccessfully processed code. As above, which form is
-                  rendered depends on the state of the user's two factor configuration.
+                  rendered depends on the state of the user's two-factor configuration.
                 type: string
         302:
           description: User successfully sent code when using form based request.
@@ -1566,7 +1566,7 @@ paths:
                 type: string
                 example: render_template(SECURITY_TWO_FACTOR_SELECT_TEMPLATE) with error values
         302:
-          description: User selected which two factor to use when using form based request.
+          description: User selected which two-factor to use when using form based request.
           headers:
             Location:
               description: Redirect to ``SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL`` or ``SECURITY_WAN_SIGNIN_URL``.
@@ -1986,13 +1986,13 @@ paths:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /wan-verify:
     get:
-      summary: GET Re-authenticate using WebAuthn form
+      summary: GET Reauthenticate using WebAuthn form
       description: >
         If an endpoint is protected with @auth_required() with a freshness declaration
-        this endpoint can be used to re-authenticate with a previously registered WebAuthn Key.
+        this endpoint can be used to reauthenticate with a previously registered WebAuthn Key.
       responses:
         200:
-          description: Verify/re-authenticate form
+          description: Verify/reauthenticate form
           content:
             text/html:
               schema:
@@ -2003,10 +2003,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/DefaultJsonResponse"
     post:
-      summary: Re-authenticate using a WebAuthn Key.
+      summary: Reauthenticate using a WebAuthn Key.
       responses:
         200:
-          description: Verify/re-authenticate response.
+          description: Verify/Reauthenticate response.
           content:
             application/json:
               schema:
@@ -2033,7 +2033,7 @@ paths:
         schema:
           type: string
     post:
-      summary: Re-authenticate using a WebAuthn Key - Part 2.
+      summary: Reauthenticate using a WebAuthn Key - Part 2.
       parameters:
         - $ref: "#/components/parameters/include_auth_token"
       requestBody:
@@ -2047,16 +2047,16 @@ paths:
               $ref: "#/components/schemas/WanSignin2"
       responses:
         200:
-          description: Verify/re-authenticate response.
+          description: Verify/Reauthenticate response.
           content:
             application/json:
               schema:
                 allOf:
                   - description: >
-                      The user successfully re-authenticated.
+                      The user successfully reauthenticated.
                   - $ref: "#/components/schemas/JsonResponseWithToken"
         302:
-          description: User successfully re-authenticated or error in validation when using form based request.
+          description: User successfully reauthenticated or error in validation when using form based request.
           headers:
             Location:
               description: >
@@ -2480,7 +2480,7 @@ components:
                 tf_state:
                   type: string
                   description: >
-                    Current state of Two Factor configuration. Not present when disabling 2FA. This will be set to 'validating_profile'
+                    Current state of Two-Factor configuration. Not present when disabling 2FA. This will be set to 'validating_profile'
                     indicating the caller needs to call '/tf-validate' with the correct code.
                     N.B. as of 5.5.0 this is only used for setting up as part of initial login when 2FA is required.
                     See tf_state_token below for use when an authenticated user wants to change their 2FA method.

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -82,16 +82,16 @@ Freshness
 ~~~~~~~~~
 A common pattern for browser-based sites is to use sessions to manage identity. This is usually
 implemented using session cookies. These cookies expire once the session (browser tab) is closed. This is very
-convenient, and keeps the users from having to constantly re-authenticate. The downside is that sessions can easily be
+convenient, and keeps the users from having to constantly reauthenticate. The downside is that sessions can easily be
 open for days or weeks. This adds to the security risk that some bad-actor or XSS gets control of the browser and then can
 do anything the user can. To mitigate that, operations that change fundamental identity characteristics (such as email, password, etc.)
 can be protected by requiring a 'fresh' or recent authentication. Flask-Security supports this with the following:
 
     - :func:`.auth_required` takes parameters that define how recent the authentication must have happened. In addition a grace
-      period can be specified so that multiple step operations don't require re-authentication in the middle.
+      period can be specified so that multiple step operations don't require reauthentication in the middle.
     - A default :meth:`.Security.reauthn_handler` that is called when a request fails the recent authentication check.
     - :py:data:`SECURITY_VERIFY_URL`, :py:data:`SECURITY_US_VERIFY_URL`, :py:data:`SECURITY_WAN_VERIFY_URL` endpoints
-      that request the user to re-authenticate.
+      that request the user to reauthenticate.
     - ``VerifyForm``, ``UsVerifyForm``, ``WebAuthnVerifyForm`` forms that can be extended.
 
 Flask-Security itself uses this as part of securing the following endpoints:

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -304,8 +304,8 @@ _default_config: dict[str, t.Any] = {
     "EMAIL_SUBJECT_USERNAME_RECOVERY": _("Your requested username"),
     "EMAIL_PLAINTEXT": True,
     "EMAIL_HTML": True,
-    "EMAIL_SUBJECT_TWO_FACTOR": _("Two-factor Login"),
-    "EMAIL_SUBJECT_TWO_FACTOR_RESCUE": _("Two-factor Rescue"),
+    "EMAIL_SUBJECT_TWO_FACTOR": _("Two-Factor Login"),
+    "EMAIL_SUBJECT_TWO_FACTOR_RESCUE": _("Two-Factor Rescue"),
     "USER_IDENTITY_ATTRIBUTES": [
         {"email": {"mapper": uia_email_mapper, "case_insensitive": True}}
     ],
@@ -415,7 +415,7 @@ _default_messages = {
         "error",
     ),
     "REAUTHENTICATION_REQUIRED": (
-        _("You must re-authenticate to access this endpoint"),
+        _("You must reauthenticate to access this endpoint"),
         "error",
     ),
     "CONFIRM_REGISTRATION": (
@@ -548,7 +548,7 @@ _default_messages = {
     ),
     "TWO_FACTOR_METHOD_NOT_AVAILABLE": (_("Marked method is not valid"), "error"),
     "TWO_FACTOR_DISABLED": (
-        _("You successfully disabled two factor authorization."),
+        _("You successfully disabled two-factor authorization."),
         "success",
     ),
     "TWO_FACTOR_SETUP_EXPIRED": (
@@ -566,7 +566,7 @@ _default_messages = {
     ),
     "US_SETUP_SUCCESSFUL": (_("Unified sign in setup successful"), "info"),
     "US_SPECIFY_IDENTITY": (_("You must specify a valid identity to sign in"), "error"),
-    "USE_CODE": (_("Use this code to sign in: %(code)s."), "info"),
+    "USE_CODE": (_("Use this code to sign in: %(code)s"), "info"),
     "USERNAME_CHANGE": (_("You successfully changed your username"), "success"),
     "USERNAME_INVALID_LENGTH": (
         _(
@@ -1147,7 +1147,7 @@ class Security:
     :param datastore: An instance of a user datastore.
     :param register_blueprint: to register the Security blueprint or not.
     :param login_form: set form for the login view
-    :param verify_form: set form for re-authentication due to freshness check
+    :param verify_form: set form for reauthentication due to freshness check
     :param change_email_form: set form for changing email address
     :param register_form: set form for the register view when
             :data:`SECURITY_CONFIRMABLE` is false
@@ -1169,7 +1169,7 @@ class Security:
     :param us_signin_form: set form for the unified sign in view
     :param us_setup_form: set form for the unified sign in setup view
     :param us_setup_validate_form: set form for the unified sign in setup validate view
-    :param us_verify_form: set form for re-authenticating due to freshness check
+    :param us_verify_form: set form for reauthenticating due to freshness check
     :param wan_register_form: set form for registering a webauthn security key
     :param wan_register_response_form: set form for registering a webauthn security key
     :param wan_signin_form: set form for authenticating with a webauthn security key
@@ -1199,7 +1199,7 @@ class Security:
         on the instance and therefore won't track any changes.
 
     .. versionadded:: 3.4.0
-        ``verify_form`` added as part of freshness/re-authentication
+        ``verify_form`` added as part of freshness/reauthentication
 
     .. versionadded:: 3.4.0
         ``us_signin_form``, ``us_setup_form``, ``us_setup_validate_form``, and

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -946,7 +946,7 @@ class TwoFactorSetupForm(Form):
     setup = RadioField(
         get_form_field_xlate(_("Available Methods")),
         choices=[
-            ("disable", get_form_field_xlate(_("Disable two factor authentication"))),
+            ("disable", get_form_field_xlate(_("Disable two-factor authentication"))),
             ("email", get_form_field_label("email_method")),
             (
                 "authenticator",

--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -26,7 +26,7 @@
       {% endif %}
       {% if security.two_factor %}
         <li>
-          <a href="{{ url_for_security('two_factor_setup') }}">{{ _fsdomain("Two Factor Setup") }}</a>
+          <a href="{{ url_for_security('two_factor_setup') }}">{{ _fsdomain("Two-Factor Setup") }}</a>
         </li>
       {% endif %}
       {% if security.unified_signin %}

--- a/flask_security/templates/security/change_email.html
+++ b/flask_security/templates/security/change_email.html
@@ -1,10 +1,10 @@
-{% set title = title|default(_fsdomain('Change email')) %}
+{% set title = title|default(_fsdomain('Change Email')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain('Change email') }}</h1>
+  <h1>{{ _fsdomain('Change Email') }}</h1>
   <h3>{{ _fsdomain('Once submitted, an email confirmation will be sent to this new email address.') }}</h3>
   <form action="{{ url_for_security('change_email') }}" method="post" name="change_email_form">
     {{ change_email_form.hidden_tag() }}

--- a/flask_security/templates/security/change_password.html
+++ b/flask_security/templates/security/change_password.html
@@ -1,10 +1,10 @@
-{% set title = title|default(_fsdomain('Change password')) %}
+{% set title = title|default(_fsdomain('Change Password')) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain('Change password') }}</h1>
+  <h1>{{ _fsdomain('Change Password') }}</h1>
   <form action="{{ url_for_security('change_password') }}" method="post" name="change_password_form">
     {{ change_password_form.hidden_tag() }}
     {{ render_form_errors(change_password_form) }}

--- a/flask_security/templates/security/email/change_email_instructions.html
+++ b/flask_security/templates/security/email/change_email_instructions.html
@@ -5,9 +5,6 @@
   user - the entire user model object
   security - the Flask-Security configuration
 #}
-<p>{{ _fsdomain('Please confirm your new email address by clicking on the link below:') }}</p>
-<p>
-  <a href="{{ link }}">{{ _fsdomain('Confirm my new email') }}</a>
-</p>
+<p>{{ _fsdomain('Use <a href="%(link)s">this link</a> to confirm your new email address.', link=link)|safe }}</p>
 <p>{{ _fsdomain('This link will expire in %(within)s.', within=config["SECURITY_CHANGE_EMAIL_WITHIN"]) }}</p>
 <p>{{ _fsdomain('Your currently registered email is %(email)s.', email=user.email) }}</p>

--- a/flask_security/templates/security/email/change_email_instructions.txt
+++ b/flask_security/templates/security/email/change_email_instructions.txt
@@ -5,9 +5,6 @@
   user - the entire user model object
   security - the Flask-Security configuration
 #}
-{{ _fsdomain('Please confirm your new email through the link below:') }}
-{{ link }}
-
+{{ _fsdomain('Use %(link)s to confirm your new email address.', link=link)|safe }}
 {{ _fsdomain('This link will expire in %(within)s.', within=config["SECURITY_CHANGE_EMAIL_WITHIN"]) }}
-
 {{ _fsdomain('Your currently registered email is %(email)s.', email=user.email) }}

--- a/flask_security/templates/security/email/confirmation_instructions.html
+++ b/flask_security/templates/security/email/confirmation_instructions.html
@@ -5,7 +5,4 @@
   user - the entire user model object
   security - the Flask-Security configuration
 #}
-<p>{{ _fsdomain('Please confirm your email through the link below:') }}</p>
-<p>
-  <a href="{{ confirmation_link }}">{{ _fsdomain('Confirm my account') }}</a>
-</p>
+<p>{{ _fsdomain('Use <a href="%(confirmation_link)s">this link</a> to confirm your email address.', confirmation_link=confirmation_link)|safe }}</p>

--- a/flask_security/templates/security/email/confirmation_instructions.txt
+++ b/flask_security/templates/security/email/confirmation_instructions.txt
@@ -5,6 +5,4 @@
   user - the entire user model object
   security - the Flask-Security configuration
 #}
-{{ _fsdomain('Please confirm your email through the link below:') }}
-
-{{ confirmation_link }}
+{{ _fsdomain('Use %(confirmation_link)s to confirm your email address.', confirmation_link=confirmation_link)|safe }}

--- a/flask_security/templates/security/email/two_factor_instructions.html
+++ b/flask_security/templates/security/email/two_factor_instructions.html
@@ -1,2 +1,2 @@
-<p>{{ _fsdomain("Welcome") }} {{ username }}!</p>
-<p>{{ _fsdomain("You can log into your account using the following code:") }} {{ token }}</p>
+<p>{{ _fsdomain("Welcome %(username)s!", username=username) }}</p>
+<p>{{ _fsdomain("You can log into your account using the following code: %(token)s", token=token) }}</p>

--- a/flask_security/templates/security/email/two_factor_instructions.txt
+++ b/flask_security/templates/security/email/two_factor_instructions.txt
@@ -1,3 +1,3 @@
-{{ _fsdomain("Welcome") }} {{ username }}!
+{{ _fsdomain("Welcome %(username)s!", username=username) }}
 
-{{ _fsdomain("You can log into your account using the following code:") }} {{ token }}
+{{ _fsdomain("You can log into your account using the following code: %(token)s", token=token) }}

--- a/flask_security/templates/security/email/us_instructions.html
+++ b/flask_security/templates/security/email/us_instructions.html
@@ -6,11 +6,8 @@
   username - username
   security - the Flask-Security configuration
 #}
-<p>{{ _fsdomain("Welcome") }} {{ username }}!</p>
-<p>{{ _fsdomain("You can sign into your account using the following code:") }} {{ token }}</p>
+<p>{{ _fsdomain("Welcome %(username)s!", username=username) }}</p>
+<p>{{ _fsdomain("You can sign in to your account using the following code: %(token)s", token=token) }}</p>
 {% if login_link %}
-  <p>{{ _fsdomain("Or use the link below:") }}</p>
-  <p>
-    <a href="{{ login_link }}">{{ _fsdomain("Sign In") }}</a>
-  </p>
+  <p>{{ _fsdomain('Or use this link: <a href="%(login_link)s">Sign in</a>', login_link=login_link)|safe }}</p>
 {% endif %}

--- a/flask_security/templates/security/email/us_instructions.txt
+++ b/flask_security/templates/security/email/us_instructions.txt
@@ -6,13 +6,8 @@
   username - username
   security - the Flask-Security configuration
 #}
-{{ _fsdomain("Welcome") }} {{ username }}!
-
-{{ _fsdomain("You can sign into your account using the following code:") }} {{ token }}
-
+{{ _fsdomain("Welcome %(username)s!", username=username) }}
+{{ _fsdomain("You can sign in to your account using the following code: %(token)s.", token=token) }}
 {% if login_link %}
-
-    {{ _fsdomain("Or use the link below:") }}
-
-    {{ login_link }}
+    {{ _fsdomain("Or use this link: %(login_link)s", login_link=login_link) }}
 {% endif %}

--- a/flask_security/templates/security/email/welcome.html
+++ b/flask_security/templates/security/email/welcome.html
@@ -7,8 +7,5 @@
 #}
 <p>{{ _fsdomain('Welcome %(email)s!', email=user.email) }}</p>
 {% if security.confirmable %}
-  <p>{{ _fsdomain('You can confirm your email through the link below:') }}</p>
-  <p>
-    <a href="{{ confirmation_link }}">{{ _fsdomain('Confirm my account') }}</a>
-  </p>
+  <p>{{ _fsdomain('Use <a href="%(confirmation_link)s">this link</a> to confirm your email address.', confirmation_link=confirmation_link)|safe }}</p>
 {% endif %}

--- a/flask_security/templates/security/email/welcome.txt
+++ b/flask_security/templates/security/email/welcome.txt
@@ -8,7 +8,5 @@
 {{ _fsdomain('Welcome %(email)s!', email=user.email) }}
 
 {% if security.confirmable %}
-{{ _fsdomain('You can confirm your email through the link below:') }}
-
-{{ confirmation_link }}
+  {{ _fsdomain('Use %(confirmation_link)s to confirm your email address.', confirmation_link=confirmation_link) }}
 {% endif %}

--- a/flask_security/templates/security/email/welcome_existing.html
+++ b/flask_security/templates/security/email/welcome_existing.html
@@ -17,7 +17,6 @@
 {% endif %}
 {% if recovery_link %}
   <div>
-    {{ _fsdomain('If you forgot your password you can reset it') }}
-    <a href="{{ recovery_link }}">{{ _fsdomain(' here.') }}</a>
+    {{ _fsdomain('If you forgot your password you can reset it <a href="%(recovery_link)s"> here.</a>', recovery_link=recovery_link)|safe }}
   </div>
 {% endif %}

--- a/flask_security/templates/security/email/welcome_existing.txt
+++ b/flask_security/templates/security/email/welcome_existing.txt
@@ -17,6 +17,5 @@
 {% endif %}
 
 {% if recovery_link %}
-    {{ _fsdomain('If you forgot your password you can reset it with the following link:') }}
-    {{ recovery_link }}
+    {{ _fsdomain('If you forgot your password you can reset it with the following link: %(recovery_link)s', recovery_link=recovery_link) }}
 {% endif %}

--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -34,7 +34,7 @@
     {% for provider in security.oauthglue.provider_names %}
       <div class="fs-gap">
         <form method="post" id="{{ provider }}_form" name="{{ provider }}_form">
-          <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Sign in with ')~provider }}" formaction="{{ url_for_security('oauthstart', name=provider) }}{{ prop_next() }}">
+          <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Sign in with %(provider)s', provider=provider) }}" formaction="{{ url_for_security('oauthstart', name=provider) }}{{ prop_next() }}">
           {% if csrf_token is defined %}
             <input id="{{ provider }}_csrf_token" name="{{ provider }}_csrf_token" type="hidden" value="{{ csrf_token() }}">
           {% endif %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -25,7 +25,7 @@
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Two-factor authentication adds an extra layer of security to your account") }}</h1>
+  <h1>{{ _fsdomain("Two-Factor authentication adds an extra layer of security to your account") }}</h1>
   <h3>{{ _fsdomain("In addition to your username and password, you'll need to use a code.") }}</h3>
   <form action="{{ url_for_security('two_factor_setup') }}" method="post" name="two_factor_setup_form">
     {{ two_factor_setup_form.hidden_tag() }}
@@ -52,7 +52,7 @@
           {{ _fsdomain("Open an authenticator app on your device and scan the following QRcode (or enter the code below manually) to start receiving codes:") }}
         </div>
         <div>
-          <img alt="{{ _fsdomain('Two factor authentication code') }}" id="qrcode" src="{{ authr_qrcode }}">
+          <img alt="{{ _fsdomain('Two-Factor authentication code') }}" id="qrcode" src="{{ authr_qrcode }}">
           {# TODO: add width and height attrs #}
         </div>
         <div>{{ authr_key }}</div>

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
+  <h1>{{ _fsdomain("Two-Factor Authentication") }}</h1>
   <h3>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h3> {# chosen_method is translated string #}
   <form action="{{ url_for_security('two_factor_token_validation') }}{{ prop_next() }}" method="post" name="two_factor_verify_code_form">
     {{ two_factor_verify_code_form.hidden_tag() }}

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -36,7 +36,7 @@
     {% for provider in security.oauthglue.provider_names %}
       <div class="fs-gap">
         <form method="post" id="{{ provider }}_form" name="{{ provider }}_form">
-          <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Sign in with ')~provider }}" formaction="{{ url_for_security('oauthstart', name=provider) }}{{ prop_next() }}">
+          <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Sign in with %(provider)s', provider=provider) }}" formaction="{{ url_for_security('oauthstart', name=provider) }}{{ prop_next() }}">
           {% if csrf_token is defined %}
             <input id="{{ provider }}_csrf_token" name="{{ provider }}_csrf_token" type="hidden" value="{{ csrf_token() }}">
           {% endif %}

--- a/flask_security/templates/security/wan_verify.html
+++ b/flask_security/templates/security/wan_verify.html
@@ -6,7 +6,7 @@
   skip_login_menu - True
   Any other context provided by the "wan_verify" context processer.
 #}
-{% set title = title|default(_fsdomain("Re-Authenticate Using Your WebAuthn Security Key")) %}
+{% set title = title|default(_fsdomain("Reauthenticate")) %}
 {% extends "security/base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 
@@ -18,7 +18,7 @@
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Re-Authenticate Using Your WebAuthn Security Key") }}</h1>
+  <h1>{{ _fsdomain("Reauthenticate Using Your WebAuthn Security Key") }}</h1>
   {% if not credential_options %}
     <form action="{{ url_for_security('wan_verify') }}{{ prop_next() }}" method="post" name="wan_verify_form">
       {{ wan_verify_form.hidden_tag() }}

--- a/flask_security/translations/af_ZA/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/af_ZA/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Michael Bosch <michael@lonelyviking.com>\n"
 "Language: af_ZA\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Intekening Benodig"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Welkom"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Twee-faktoor Intekening"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Twee-faktoor Redding"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -86,7 +82,7 @@ msgstr "Insette nie geskik vir die versoekte API nie"
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Jy moet herverifieer om toegang te kry tot hierdie eindpunt"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr ""
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s is reeds geassosieer met 'n rekening."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -146,7 +142,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr "Bevestigings instruksies is gestuur na %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -280,7 +276,7 @@ msgstr "Jy het met sukses in geteken"
 msgid "Forgot password?"
 msgstr "Wagwoord vergeet?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -288,7 +284,7 @@ msgstr ""
 "Jy het met sukses jou wagwoord teruggestel en jy het automaties in "
 "geteken."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -343,8 +339,8 @@ msgid "Marked method is not valid"
 msgstr "Gemerkde metode is nie geldig nie"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Jy het met sukses twee-faktoor verifikasie afgeskakel"
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -370,14 +366,14 @@ msgstr "Jy moet 'n valiede identiteit spesifiseer om in te teken"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Gebruik hierdie kode om in te teken: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -464,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -475,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr "Stel op deur midde van verifikasie toep (bv. google, lastpass, authy)"
 
@@ -484,6 +480,8 @@ msgid "Change Method"
 msgstr "Verander Metode"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Verander Wagwoord"
 
@@ -512,8 +510,10 @@ msgid "Identity"
 msgstr "Identiteit"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Teken In"
 
@@ -542,7 +542,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registreer"
 
@@ -571,8 +572,8 @@ msgid "Send Code"
 msgstr "Stuur Kode"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Teken In"
 
@@ -620,19 +621,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Beskikbare Metodes"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -656,11 +657,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -676,15 +677,15 @@ msgstr "Via e-pos"
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -700,11 +701,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -721,12 +722,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -749,164 +752,171 @@ msgstr "Wagwoord vergeet"
 msgid "Confirm account"
 msgstr "Bevestig rekening"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Verander wagwoord"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Stuur wagwoord herstel instruksies"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Stel wagwoord terug"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Stuur weer bevestigings instruksies"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr "Twee-faktoor verifikasie voeg 'n ekstra laag sekuriteit by jou rekening"
-
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Twee-faktoor verifikasie kode"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Twee-faktoor Verifikasie"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Die kode vir verifikasie is gestuur na jou e-pos adres"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -923,25 +933,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Kode is gestuur"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -965,6 +979,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -974,31 +992,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1025,14 +1041,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Bevestig asseblief jou e-pos adres deur die skakel hieronder:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Bevestig my rekening"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1059,10 +1079,19 @@ msgstr "Klik hier om jou wagwoord te herstel"
 msgid "Click the link below to reset your password:"
 msgstr "Klik die skakel hieronder om jou wagwoord te herstel:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Jy kan inteken op jou rekening deur gebruik van die volgende kode:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1070,14 +1099,24 @@ msgid "can not access mail account"
 msgstr "kan nie e-pos rekening bereik nie"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Jy kan inteken op jou rekening deur gebruik van die volgende kode:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Of gebruik die skakel hieronder:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1099,11 +1138,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Jy kan jou e-pos adres bevestig deur die skakel hieronder:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1128,11 +1162,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1143,7 +1176,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1269,3 +1305,92 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Dankie. Bevestigings instruksies is gestuur na %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Twee-faktoor Intekening"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Twee-faktoor Redding"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Jy moet herverifieer om toegang te kry tot hierdie eindpunt"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Jy het met sukses twee-faktoor verifikasie afgeskakel"
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr "Twee-faktoor verifikasie voeg 'n ekstra laag sekuriteit by jou rekening"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Twee-faktoor verifikasie kode"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Twee-faktoor Verifikasie"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Verander wagwoord"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Bevestig my rekening"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Jy kan inteken op jou rekening deur gebruik van die volgende kode:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Jy kan inteken op jou rekening deur gebruik van die volgende kode:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Of gebruik die skakel hieronder:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Bevestig asseblief jou e-pos adres deur die skakel hieronder:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Jy kan jou e-pos adres bevestig deur die skakel hieronder:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Gebruik hierdie kode om in te teken: %(code)s."

--- a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 3.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2019-06-16 00:12+0200\n"
 "Last-Translator: Orestes Sanchez <miceno.atreides@gmail.com>\n"
 "Language: ca_ES\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Per poder veure la pàgina sol·licitada és necessari iniciar la sessió"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Benvingut"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
+msgid "You must reauthenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr "Token de confirmació no vàlid."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ja es associat amb un compte."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -144,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr "Les instruccions de confirmació s'han enviat a %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -280,7 +276,7 @@ msgstr "La sessió s'ha iniciat amb èxit."
 msgid "Forgot password?"
 msgstr "Has oblidat la teva contrasenya?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -288,7 +284,7 @@ msgstr ""
 "Has restablert la teva contrasenya amb èxit i s'ha iniciat la sessió "
 "automàticament."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -343,7 +339,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -370,14 +366,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -464,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -475,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -484,6 +480,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Canvi de contrasenya"
 
@@ -512,8 +510,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Iniciar sessió"
 
@@ -542,7 +542,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registrar-se"
 
@@ -571,8 +572,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -620,19 +621,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -656,11 +657,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -676,15 +677,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -700,11 +701,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -721,12 +722,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -749,164 +752,171 @@ msgstr "Contrasenya oblidada"
 msgid "Confirm account"
 msgstr "Confirmació de compte"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Canviar la contrasenya"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Enviar instruccions per restablir la contrasenya"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Restablir la contrasenya"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Reenviar instruccions de confirmació"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -923,25 +933,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -965,6 +979,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -974,31 +992,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1023,14 +1039,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Confirma el teu correu electrònic fent clic aquí:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Confirmeu el compte"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1057,9 +1077,18 @@ msgstr "Feu clic aquí per restablir la contrasenya"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1068,13 +1097,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1097,11 +1136,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Confirmeu el vostre correu electrònic fent clic a continuació:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1126,11 +1160,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1141,7 +1174,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1275,3 +1311,92 @@ msgstr ""
 #~ "Moltes gràcies. S'ha enviat un correu"
 #~ " electrònic a %(email)s amb instruccions"
 #~ " per confirmar el teu compte."
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr ""
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr ""
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Canviar la contrasenya"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Confirmeu el compte"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Confirma el teu correu electrònic fent clic aquí:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Confirmeu el vostre correu electrònic fent clic a continuació:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2017-03-23 14:04+0100\n"
 "Last-Translator: Leonhard Printz <leonhardprintz@protonmail.ch>\n"
 "Language: da_DK\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Login påkræveet"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Velkommen"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
+msgid "You must reauthenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr "Ugyldig bekræftigelsestoken."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s er allerede brugt af en anden konto."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -144,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr "Bekræftigelsesinstruktioner er blevet sendt til %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -280,7 +276,7 @@ msgstr "Du er hermed blevet logget ind."
 msgid "Forgot password?"
 msgstr "Glemt adgangskode?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -288,7 +284,7 @@ msgstr ""
 "Du har hermed nulstillet din adgangskode og er blevet automatisk logget "
 "ind."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -343,7 +339,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -370,14 +366,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -464,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -475,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -484,6 +480,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Ændre adgangskode"
 
@@ -512,8 +510,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Login"
 
@@ -542,7 +542,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registrer"
 
@@ -571,8 +572,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -620,19 +621,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -656,11 +657,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -676,15 +677,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -700,11 +701,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -721,12 +722,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -749,164 +752,171 @@ msgstr "Glemt din adgangskode"
 msgid "Confirm account"
 msgstr "Bekræft konto"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Ændre adgangskode"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Send adgangskode nulstillingsinstruktioner"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Nulstil adgangskode"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Gensend bekræftelsesinstruktioner"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -923,25 +933,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -965,6 +979,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -974,31 +992,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1023,14 +1039,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Bekræft venligst din email gennem nedenstående link:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Bekræft ny konto"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1057,9 +1077,18 @@ msgstr "Klik her for at nulstille din adgangskode"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1068,13 +1097,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1097,11 +1136,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Bekræft venligst din email gennem nedenstående link:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1126,11 +1160,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1141,7 +1174,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1272,3 +1308,92 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Mange tak. Bekræftelsesinstruktioner er blevet sendt til %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr ""
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr ""
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Ændre adgangskode"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Bekræft ny konto"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Bekræft venligst din email gennem nedenstående link:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Bekræft venligst din email gennem nedenstående link:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.1.3\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2022-04-05 13:50+0200\n"
 "Last-Translator: Pascua Theus <pascua@identeco.de>\n"
 "Language: de_DE\n"
@@ -19,7 +19,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -30,10 +30,6 @@ msgid "Login Required"
 msgstr "Anmeldung erforderlich"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Willkommen"
 
@@ -69,12 +65,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Zwei-Faktor-Anmeldung"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Zwei-Faktor-Wiederherstellung"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -90,7 +86,7 @@ msgstr ""
 "Authentifizierung fehlgeschlagen – Identität oder Passwort/Passcode "
 "ungültig"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -111,11 +107,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Bitte neu authentisieren, um auf diese Seite zuzugreifen."
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -141,7 +136,7 @@ msgstr "Ungültiger Bestätigungscode."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ist bereits mit einem Konto verknüpft."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -155,7 +150,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr "Benutzer %(id)s nicht registriert"
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -216,7 +211,7 @@ msgstr ""
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Sie haben Ihre E-Mail-Adresse nich innerhalb von $(within)s bestätigt."
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -295,7 +290,7 @@ msgstr "Sie wurden angemeldet."
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -303,7 +298,7 @@ msgstr ""
 "Das Passwort wurde erfolgreich wiederhergestellt und die Anmeldung "
 "erfolgte automatisch."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -362,8 +357,8 @@ msgid "Marked method is not valid"
 msgstr "Ausgewählte Methode ist nicht gültig"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Zwei-Faktor-Authentisierung wurde deaktiviert"
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -391,14 +386,14 @@ msgstr "Sie müssen eine gültige Identität auswählen, um sich anzumelden"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Code zur Anmeldung: %(code)s"
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -489,7 +484,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -500,7 +495,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr "Einrichtung via Authentisierungs-App"
 
@@ -509,6 +504,8 @@ msgid "Change Method"
 msgstr "Methode ändern"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Passwort ändern"
 
@@ -537,8 +534,10 @@ msgid "Identity"
 msgstr "Identität"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Anmelden"
 
@@ -567,7 +566,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registrieren"
 
@@ -596,8 +596,8 @@ msgid "Send Code"
 msgstr "Sende Code"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Anmeldung"
 
@@ -645,19 +645,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Verfügbare Methoden"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
-msgstr "Deaktiviere Zwei-Faktor-Authentisierung"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
+msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Probleme beim Zugriff auf Ihr Konto / Smartphone verloren?"
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr "Kontaktiere einen Administrator"
 
@@ -681,11 +681,11 @@ msgstr "Verfügbare Zwei-Faktor-Methoden:"
 msgid "Select"
 msgstr "Auswählen"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr "Sende code per E-Mail"
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr "Zuvor heruntergeladenen Wiederherstellungscode verwenden"
 
@@ -701,15 +701,15 @@ msgstr "Via E-Mail"
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Richte weitere Single-User-Login-Option ein"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr "Löschen der aktivierten Anmeldeoption"
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Nickname"
 
@@ -725,11 +725,11 @@ msgstr "Als ersten Faktor benutzen"
 msgid "Use as a secondary authentication factor"
 msgstr "Als zweiten Faktor benutzen"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Start"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr "WebAuthn"
 
@@ -746,13 +746,15 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
-msgstr "Zwei-Faktor-Einrichtung"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
+msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
 msgid "Unified Signin Setup"
@@ -774,68 +776,69 @@ msgstr "Passwort vergessen"
 msgid "Confirm account"
 msgstr "Konto bestätigen"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Passwort ändern"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr "Sie haben noch kein Passwort – hier können Sie eines setzen."
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Anleitung zur Passwortzurücksetzung versenden"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr "oder"
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "Nutze WebAuthn zur Anmeldung"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Anmelden mit WebAuthn"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr "Nutze Social OAuth zur Anmeldung"
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
-msgstr "Anmelden mit "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
+msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr "Wiederherstellungscode eingeben"
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr "Wiederherstellungscodes"
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
@@ -843,42 +846,44 @@ msgstr ""
 "Kopieren Sie diese unbedingt und bewahren Sie die Codes an einem sicheren"
 " Ort auf. Jeder Code kann nur einmal verwendet werden."
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr "Erzeuge neue Wiederherstellungscodes"
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Bestätigungslink erneut versenden"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Zwei-Faktor-Methode auswählen"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-"Zwei-Faktor-Authentisierung bietet eine zusätzliche Sicherheitsebene für "
-"Ihr Benutzerkonto"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr "Sie müssen zusätzlich zu Benutzername und Passwort einen Code angeben"
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Aktivierte Zwei-Faktor-Methode: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -888,59 +893,61 @@ msgstr ""
 " Sie den folgenden QR-Code (oder geben Sie den unten stehenden Code ein),"
 " um den Empfang von Codes zu beginnen"
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Zwei-Faktor-Authentisierungscode"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr "Diese Anwendung unterstützt die Einrichtung von Wiederherstellungscodes."
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Sie können diese hier einrichten."
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr "WebAuthn"
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Diese Anwendung unterstützt WebAuthn-Sicherheitsschlüssel."
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Zwei-Faktor-Authentisierung"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 "Bitte geben Sie den Authentisierungscode ein, den Sie via %(method)s "
 "erhalten haben."
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Der Authentisierungscode wurde an Ihre E-Mail-Adresse gesendet"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Single-User-Login einrichten"
@@ -957,27 +964,31 @@ msgstr "Keine Methode ausgewählt – keine Einrichtung erfolgt"
 msgid "Enter code here to complete setup"
 msgstr "Geben Sie den Code hier ein, um die Einrichtung abzuschließen"
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Senden eines einmaligen Codes anfordern"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Bitte authentisieren Sie sich erneut"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Der Code wurde verschickt"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 "Bitte nutzen Sie ein WebAuthn-Sicherheitsschlüssel, um sich erneut zu "
 "authentisieren"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Neuen WebAuthn-Sicherheitsschlüssel einrichten"
@@ -1003,6 +1014,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Lösche existierenden WebAuth-Sicherheitsschlüssel"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Mit WebAuthn-Sicherheitsschlüssel anmelden"
@@ -1012,31 +1027,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr "Verwenden Sie Ihren WebAuthn-Sicherheitsschlüssel als zweiten Faktor"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
-msgstr "Bitte authentisieren Sie sich mit Ihrem WebAuthn-Sicherheitsschlüssel"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
+msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1063,14 +1076,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Bitte die E-Mail-Adresse durch den Link unten bestätigen:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Mein Konto bestätigen"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1097,10 +1114,19 @@ msgstr "Klicken Sie hier, um das Passwort zurückzusetzen"
 msgid "Click the link below to reset your password:"
 msgstr "Klicken Sie auf den unten stehenden Link, um Ihr Passwort zurückzusetzen:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Sie können sich mit folgendem Code in Ihr Benutzerkonto anmelden:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1108,14 +1134,24 @@ msgid "can not access mail account"
 msgstr "kann E-Mail-Konto nicht erreichen"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Sie können sich mit folgendem Code in Ihr Benutzerkonto anmelden:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Oder nutzen Sie den folgenden Link:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1137,11 +1173,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Bestätigen Sie Ihre E-Mail-Adresse, indem Sie auf den Link unten klicken:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1168,12 +1199,11 @@ msgid ""
 msgstr "Dieses Konto hat auch den folgenden Benutzernamen: %(username)s."
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr "Wenn Sie Ihr Passwort vergessen habne, können Sie es"
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
-msgstr " hier zurücksetzen."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
 #, python-format
@@ -1183,10 +1213,11 @@ msgid ""
 msgstr "Dieses Konto hat auch den folgenden Benutzernamen: %(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
-"Sollten Sie Ihr Passwort vergessen haben, können Sie es unter folgendem "
-"Link zurücksetzen:"
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
@@ -1349,3 +1380,101 @@ msgstr ""
 #~ "bitte auf den Link in der E-Mail,"
 #~ " die wir gerade an Sie gesendet "
 #~ "haben."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Zwei-Faktor-Anmeldung"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Zwei-Faktor-Wiederherstellung"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Bitte neu authentisieren, um auf diese Seite zuzugreifen."
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Zwei-Faktor-Authentisierung wurde deaktiviert"
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Deaktiviere Zwei-Faktor-Authentisierung"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Zwei-Faktor-Einrichtung"
+
+#~ msgid "Sign in with "
+#~ msgstr "Anmelden mit "
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Zwei-Faktor-Methode auswählen"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "Zwei-Faktor-Authentisierung bietet eine "
+#~ "zusätzliche Sicherheitsebene für Ihr "
+#~ "Benutzerkonto"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Zwei-Faktor-Authentisierungscode"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Zwei-Faktor-Authentisierung"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Bitte authentisieren Sie sich erneut"
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr "Bitte authentisieren Sie sich mit Ihrem WebAuthn-Sicherheitsschlüssel"
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Passwort ändern"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Mein Konto bestätigen"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Sie können sich mit folgendem Code in Ihr Benutzerkonto anmelden:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Sie können sich mit folgendem Code in Ihr Benutzerkonto anmelden:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Oder nutzen Sie den folgenden Link:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Bitte die E-Mail-Adresse durch den Link unten bestätigen:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr ""
+#~ "Bestätigen Sie Ihre E-Mail-Adresse, "
+#~ "indem Sie auf den Link unten "
+#~ "klicken:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr "Wenn Sie Ihr Passwort vergessen habne, können Sie es"
+
+#~ msgid " here."
+#~ msgstr " hier zurücksetzen."
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+#~ "Sollten Sie Ihr Passwort vergessen "
+#~ "haben, können Sie es unter folgendem "
+#~ "Link zurücksetzen:"
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Code zur Anmeldung: %(code)s"

--- a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.6.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2025-02-07 19:33+0100\n"
 "Last-Translator: Giorgio Stampa <giorgio.stampa@sanofi.com>\n"
 "Language: es_ES\n"
@@ -19,7 +19,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -30,10 +30,6 @@ msgid "Login Required"
 msgstr "Inicio de sesión necesario"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Bienvenido·a"
 
@@ -69,12 +65,12 @@ msgid "Your requested username"
 msgstr "Tu nombre de usuario solicitado"
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Inicio de sesión de dos factores"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Recuperación de sesión de dos factores"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -90,7 +86,7 @@ msgstr ""
 "Fallo de autenticación - identidad o contraseña/código de acceso no "
 "válidos"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -112,10 +108,10 @@ msgid "You must sign in to view this resource."
 msgstr "Debes autenticarte para acceder a este recurso."
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Debes volver a autenticarte para acceder a este recurso"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -141,7 +137,7 @@ msgstr "Autentificador de confirmación inválido."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -155,7 +151,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr "Identidad %(id)s no registrada"
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -214,7 +210,7 @@ msgstr "Las instrucciones de confirmación se han enviado a %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr "No has confirmado tu correo electrónico dentro de %(within)s. "
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -293,13 +289,13 @@ msgstr "Has iniciado sesión."
 msgid "Forgot password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Has restablecido tu contraseña y has iniciado sesión automáticamente."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -354,8 +350,8 @@ msgid "Marked method is not valid"
 msgstr "El método marcado no es válido"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Has deshabilitado la autorización de dos factores."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -383,14 +379,14 @@ msgstr "Debes especificar una identidad válida para iniciar sesión"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Utiliza este código para iniciar sesión: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr "Has cambiado tu nombre de usuario"
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -483,7 +479,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr "Cambio de dirección de correo electrónico confirmado"
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -496,7 +492,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr "Si registrado, tu nombre de usuario se enviará a tu correo electrónico."
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Configurar con una aplicación de autenticación (p.ej. google, lastpass, "
@@ -507,6 +503,8 @@ msgid "Change Method"
 msgstr "Método de cambio"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Cambiar la contraseña"
 
@@ -535,8 +533,10 @@ msgid "Identity"
 msgstr "Identidad"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Iniciar sesión"
 
@@ -565,7 +565,8 @@ msgid "Recover Username"
 msgstr "Recuperar nombre de usuario"
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registrarse"
 
@@ -594,8 +595,8 @@ msgid "Send Code"
 msgstr "Enviar código"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Iniciar sesión"
 
@@ -643,19 +644,19 @@ msgstr "contraseña"
 msgid "none"
 msgstr "ninguno"
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Métodos disponibles"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
-msgstr "Deshabilitar la autenticación de dos factores"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
+msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "¿Problemas para acceder a tu cuenta/has perdido tu dispositivo móvil?"
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr "Contactar con el administrador"
 
@@ -679,11 +680,11 @@ msgstr "Métodos de segundo factor disponibles:"
 msgid "Select"
 msgstr "Selecciona"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr "Enviar el código por correo electrónico"
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr "Usar código de recuperación descargado anteriormente"
 
@@ -699,15 +700,15 @@ msgstr "Vía correo electrónico"
 msgid "Via SMS"
 msgstr "Vía SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Configurar una opción de inicio de sesión adicional"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr "Eliminar la opción de inicio de sesión activa"
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Nombre"
 
@@ -723,11 +724,11 @@ msgstr "Uso como factor de autenticación primario"
 msgid "Use as a secondary authentication factor"
 msgstr "Uso como factor de autenticación secundario"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Iniciar"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -744,13 +745,15 @@ msgid "Change Registered Email"
 msgstr "Cambiar el correo electrónico registrado"
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr "Cambiar el nombre de usuario"
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
-msgstr "Configuración de dos factores"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
+msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
 msgid "Unified Signin Setup"
@@ -772,11 +775,12 @@ msgstr "Contraseña olvidada"
 msgid "Confirm account"
 msgstr "Confirmar cuenta"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
-msgstr "Cambiar el correo electrónico"
-
+#: flask_security/templates/security/change_email.html:1
 #: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
+msgstr ""
+
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
@@ -784,58 +788,58 @@ msgstr ""
 "Un mensaje de confirmación se enviará a esta nueva dirección de correo "
 "electrónico."
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Cambiar la contraseña"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr "Actualmente no tienes una contraseña - esto añadirá una."
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr "El nombre de usuario actual es: %(username)s"
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Enviar instrucciones para restablecer la contraseña"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr "o"
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "Usar WebAuthn para iniciar sesión"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Iniciar sesión con WebAuthn"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr "Iniciar sesión con social OAuth"
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
-msgstr "Iniciar sesión con "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
+msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr "Introducir código de recuperación"
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr "Códigos de recuperación"
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
@@ -843,42 +847,44 @@ msgstr ""
 "Asegúrate de copiarlos y guardarlos en un lugar seguro. Cada código sólo "
 "puede utilizarse una vez."
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr "Generar nuevos códigos de recuperación"
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
-msgstr "Recuperación del nombre de usuario"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
+msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Restablecer contraseña"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Reenviar instrucciones de confirmación"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Selecciona un método de dos factores"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-"La autenticación de dos factores añade una capa adicional de seguridad a "
-"tu cuenta"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr "Además de tu nombre de usuario y contraseña, deberás utilizar un código."
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Método de dos factores actualmente configurado: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -888,59 +894,61 @@ msgstr ""
 "siguiente código QR (o ingresa manualmente el código que aparece a "
 "continuación) para comenzar a recibir códigos:"
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Código de autenticación de dos factores"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr "Introduce el código para completar la configuración"
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr "introduce el código numérico"
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr "Esta aplicación permite establecer códigos de recuperación."
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Se pueden configurar aquí."
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr "WebAuthn"
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Esta aplicación es compatible con las claves de seguridad de WebAuthn."
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Autenticación de dos factores"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Introduce tu código de autenticación generado a través de: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "El código de autenticación se envió a tu dirección de correo electrónico"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 "Se nos envió un correo electrónico para restablecer tu cuenta de "
 "aplicación"
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Configurar el inicio de sesión unificado"
@@ -957,25 +965,29 @@ msgstr "No se ha habilitado ningún método, no hay nada que configurar"
 msgid "Enter code here to complete setup"
 msgstr "Introduce el código aquí para completar la configuración"
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Solicitar que se envíe un código de un solo uso"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Por favor vuelve a autenticarte"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Se envió el código"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr "Utilizar una clave de seguridad de WebAuthn para reautenticarse"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Configurar una nueva clave de seguridad de WebAuthn"
@@ -1004,6 +1016,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Eliminar la clave de seguridad de WebAuthn existente"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Iniciar sesión con la clave de seguridad de WebAuthn"
@@ -1013,34 +1029,30 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr "Utiliza tu clave de seguridad de WebAuthn como segundo factor"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
-msgstr "Por favor vuelve a autenticarte con tu clave de seguridad de WebAuthn"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
+msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
-"Confirma tu nueva dirección de correo electrónico a través del enlace de "
-"abajo:"
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr "Confirma mi nuevo correo electrónico"
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr "Este enlace caducará dentro de %(within)s."
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr "Tu correo electrónico registrado actualmente es %(email)s."
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
-msgstr "Confirma tu nuevo correo electrónico a través del enlace de abajo:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
+msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
 #: flask_security/templates/security/email/change_notice.txt:1
@@ -1066,14 +1078,18 @@ msgid "Your username has been changed."
 msgstr "Tu nombre de usuario ha sido cambiado."
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Confirma tu correo electrónico a través del enlace de abajo:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Confirmar mi cuenta"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1100,10 +1116,19 @@ msgstr "Haz clic aquí para restablecer la contraseña"
 msgid "Click the link below to reset your password:"
 msgstr "Haz clic en el enlace de abajo para restablecer la contraseña:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Puedes iniciar sesión en tu cuenta utilizando el siguiente código:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1111,14 +1136,24 @@ msgid "can not access mail account"
 msgstr "no puede acceder a la cuenta de correo"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Puedes iniciar sesión en tu cuenta con el siguiente código:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "O a través del enlace de abajo:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1140,11 +1175,6 @@ msgstr "Tu nombre de usuario es: %(username)s"
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr "Si no has iniciado esta solicitud, puedes ignorar este mensaje."
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Puedes confirmar tu correo electrónico a través del enlace de abajo:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1173,12 +1203,11 @@ msgstr ""
 "%(username)s."
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr "Si has olvidado tu contraseña, puedes restablecerla"
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
-msgstr " aquí."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
 #, python-format
@@ -1190,10 +1219,11 @@ msgstr ""
 "%(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
-"Si has olvidado tu contraseña, puedes restablecerla a través del "
-"siguiente enlace:"
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
@@ -1211,3 +1241,101 @@ msgid "Please restart the registration process with a different username."
 msgstr ""
 "Por favor reinicia el proceso de registro con un nombre de usuario "
 "diferente."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Inicio de sesión de dos factores"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Recuperación de sesión de dos factores"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Debes volver a autenticarte para acceder a este recurso"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Has deshabilitado la autorización de dos factores."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Deshabilitar la autenticación de dos factores"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Configuración de dos factores"
+
+#~ msgid "Sign in with "
+#~ msgstr "Iniciar sesión con "
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Selecciona un método de dos factores"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "La autenticación de dos factores añade"
+#~ " una capa adicional de seguridad a"
+#~ " tu cuenta"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Código de autenticación de dos factores"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Autenticación de dos factores"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Por favor vuelve a autenticarte"
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr "Por favor vuelve a autenticarte con tu clave de seguridad de WebAuthn"
+
+#~ msgid "Change email"
+#~ msgstr "Cambiar el correo electrónico"
+
+#~ msgid "Change password"
+#~ msgstr "Cambiar la contraseña"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+#~ "Confirma tu nueva dirección de correo"
+#~ " electrónico a través del enlace de"
+#~ " abajo:"
+
+#~ msgid "Confirm my new email"
+#~ msgstr "Confirma mi nuevo correo electrónico"
+
+#~ msgid "Confirm my account"
+#~ msgstr "Confirmar mi cuenta"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Puedes iniciar sesión en tu cuenta utilizando el siguiente código:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Puedes iniciar sesión en tu cuenta con el siguiente código:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "O a través del enlace de abajo:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr "Confirma tu nuevo correo electrónico a través del enlace de abajo:"
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Confirma tu correo electrónico a través del enlace de abajo:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Puedes confirmar tu correo electrónico a través del enlace de abajo:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr "Si has olvidado tu contraseña, puedes restablecerla"
+
+#~ msgid " here."
+#~ msgstr " aquí."
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+#~ "Si has olvidado tu contraseña, puedes"
+#~ " restablecerla a través del siguiente "
+#~ "enlace:"
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Utiliza este código para iniciar sesión: %(code)s."

--- a/flask_security/translations/eu_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/eu_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2020-11-28 13:41+0100\n"
 "Last-Translator: Martin Mozos <martinmozos@gmail.com>\n"
 "Language: eu_ES\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Saioa hasi behar da"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Ongi etorri"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Bi faktoreko saioa hastea"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Bi faktoreko saioa berreskuratzea"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -86,7 +82,7 @@ msgstr "Sarrera ez da egokia eskatutako APIarentzat"
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Baliabide honetara sartzeko berriro autentifikatu behar duzu"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr "Berrespen token baliogabea."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s dagoeneko kontu batekin lotuta dago."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -146,7 +142,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr "Baieztapen argibideak %(email)s helbidera bidali dira."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -280,13 +276,13 @@ msgstr "Behar bezala hasi duzu saioa."
 msgid "Forgot password?"
 msgstr "Pasahitza ahaztua?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Pasahitza berrezarri duzunez automatikoki hasi duzu saioa."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -341,8 +337,8 @@ msgid "Marked method is not valid"
 msgstr "Markatutako metodoak ez du balio"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Bi faktoreren baimena behar bezala desgaitu duzu."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -368,14 +364,14 @@ msgstr "Saioa hasteko identitate baliagarria zehaztu behar duzu"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Erabili kode hau saioa hasteko: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -464,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -475,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Konfiguratu autentifikatzaile aplikazio bat erabiliz (google, lastpass "
@@ -486,6 +482,8 @@ msgid "Change Method"
 msgstr "Aldatzeko metodoa"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Aldatu pasahitza"
 
@@ -514,8 +512,10 @@ msgid "Identity"
 msgstr "Identitatea"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Hasi saioa"
 
@@ -544,7 +544,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Izena eman"
 
@@ -573,8 +574,8 @@ msgid "Send Code"
 msgstr "Bidali kodea"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Hasi saioa"
 
@@ -622,19 +623,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Eskuragarri dauden metodoak"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -658,11 +659,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -678,15 +679,15 @@ msgstr "Posta elektronikoaren bidez"
 msgid "Via SMS"
 msgstr "SMS bidez"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -702,11 +703,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -723,12 +724,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -751,109 +754,112 @@ msgstr "Pasahitza ahaztua"
 msgid "Confirm account"
 msgstr "Berretsi kontua"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Aldatu pasahitza"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Bidali pasahitza berrezartzeko argibideak"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Pasahitza berrezarri"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Bidali berrespen argibideak"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr ""
-"Bi faktoreko autentifikazioak segurtasun geruza gehigarri bat esleitzen "
-"dio zure kontuari"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -862,57 +868,59 @@ msgstr ""
 "Ireki autentifikazio aplikazio bat zure gailuan eta eskaneatu QR kode hau"
 " (edo idatzi beheko kodea eskuz) kodeak jasotzen hasteko:"
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Bi faktoretako autentifikazio kodea"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Bi faktoretako autentifikazioa"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Autentifikaziorako kodea zure helbide elektronikora bidali da"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -929,25 +937,29 @@ msgstr "Ez da metodorik gaitu, ez dago ezer konfiguratzeko"
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Eskatu erabilera-bakarreko kodea bidaltzeko"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Kodea bidali da"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -971,6 +983,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -980,31 +996,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1029,14 +1043,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Mesedez, berretsi zure posta elektronikoa beheko estekaren bidez:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Berretsi nire kontua"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1063,10 +1081,19 @@ msgstr "Egin klik hemen zure pasahitza berrezartzeko"
 msgid "Click the link below to reset your password:"
 msgstr "Egin klik beheko estekan zure pasahitza berrezartzeko:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Zure kontuan saioa has dezakezu kode hau erabiliz:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1074,14 +1101,24 @@ msgid "can not access mail account"
 msgstr "ezin da posta kontura sartu"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Zure kontuan saioa has dezakezu kode hau erabiliz:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Edo erabili beheko esteka:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1103,11 +1140,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Zure posta elektronikoa beheko estekaren bidez baiezta dezakezu:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1132,11 +1164,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1147,7 +1178,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1273,3 +1307,95 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Eskerrik asko. Baieztapen argibideak %(email)s helbidera bidali dira."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Bi faktoreko saioa hastea"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Bi faktoreko saioa berreskuratzea"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Baliabide honetara sartzeko berriro autentifikatu behar duzu"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Bi faktoreren baimena behar bezala desgaitu duzu."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "Bi faktoreko autentifikazioak segurtasun "
+#~ "geruza gehigarri bat esleitzen dio zure"
+#~ " kontuari"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Bi faktoretako autentifikazio kodea"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Bi faktoretako autentifikazioa"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Aldatu pasahitza"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Berretsi nire kontua"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Zure kontuan saioa has dezakezu kode hau erabiliz:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Zure kontuan saioa has dezakezu kode hau erabiliz:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Edo erabili beheko esteka:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Mesedez, berretsi zure posta elektronikoa beheko estekaren bidez:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Zure posta elektronikoa beheko estekaren bidez baiezta dezakezu:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Erabili kode hau saioa hasteko: %(code)s."

--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.6.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -27,10 +27,6 @@ msgid "Login Required"
 msgstr ""
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr ""
 
@@ -66,11 +62,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -85,7 +81,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -104,10 +100,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
+msgid "You must reauthenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -131,7 +127,7 @@ msgstr ""
 msgid "%(email)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -143,7 +139,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -198,7 +194,7 @@ msgstr ""
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -275,13 +271,13 @@ msgstr ""
 msgid "Forgot password?"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -336,7 +332,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -363,14 +359,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -457,7 +453,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -468,7 +464,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -477,6 +473,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr ""
 
@@ -505,8 +503,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr ""
 
@@ -535,7 +535,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr ""
 
@@ -564,8 +565,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -613,19 +614,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -649,11 +650,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -669,15 +670,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -693,11 +694,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -714,12 +715,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -742,164 +745,171 @@ msgstr ""
 msgid "Confirm account"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr ""
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr ""
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -916,25 +926,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -958,6 +972,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -967,31 +985,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1016,13 +1032,17 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
 msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
 msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
@@ -1050,9 +1070,18 @@ msgstr ""
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1061,13 +1090,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1089,11 +1128,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.html:8
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
-msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:11
@@ -1119,11 +1153,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1134,7 +1167,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13

--- a/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2017-06-08 10:13+0200\n"
 "Last-Translator: Alexandre Bulté <alexandre@bulte.net>\n"
 "Language: fr_FR\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Connexion requise"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Bienvenue"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
+msgid "You must reauthenticate to access this endpoint"
 msgstr "Merci de vous reconnecter pour accéder à cette page."
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr "Token de confirmation non valide."
 msgid "%(email)s is already associated with an account."
 msgstr "L'adresse %(email)s est déjà utilisée."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -144,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr "Les instructions de confirmation ont été envoyées à %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -280,7 +276,7 @@ msgstr "Vous êtes bien connecté."
 msgid "Forgot password?"
 msgstr "Mot de passe oublié&thinsp;?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -288,7 +284,7 @@ msgstr ""
 "Vous avez bien réinitialisé votre mot de passe et avez été "
 "automatiquement connecté."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -343,7 +339,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -370,14 +366,14 @@ msgstr "Vous devez spécifier une identité valide pour vous connecter"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -464,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -475,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Configuration à l'aide d'une application d'authentification (par exemple,"
@@ -486,6 +482,8 @@ msgid "Change Method"
 msgstr "Changer de méthode"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Changer le mot de passe"
 
@@ -514,8 +512,10 @@ msgid "Identity"
 msgstr "Identité"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Connexion"
 
@@ -544,7 +544,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Inscription"
 
@@ -573,8 +574,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Sign In"
 
@@ -622,19 +623,19 @@ msgstr "mot de passe"
 msgid "none"
 msgstr "aucune"
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Méthodes disponibles"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr "Désactiver l'authentification à deux facteurs"
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -658,11 +659,11 @@ msgstr "Méthodes de second facteur disponibles:"
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -678,15 +679,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr "Par SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Configurer une option de connexion supplémentaire"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Surnom"
 
@@ -702,11 +703,11 @@ msgstr "Utiliser comme premier facteur d'authentification"
 msgid "Use as a secondary authentication factor"
 msgstr "Utiliser comme facteur d'authentification secondaire"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Démarrer"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -723,12 +724,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr "Configuration à deux facteurs"
 
 #: flask_security/templates/security/_menu.html:34
@@ -751,168 +754,173 @@ msgstr "Mot de passe oublié"
 msgid "Confirm account"
 msgstr "Confirmer le compte"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Changer de mot de passe"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Envoyer les instructions de réinitialisation de mot de passe"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "Utiliser WebAuthn pour se connecter"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Connectez-vous avec WebAuthn"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Réinitialiser le mot de passe"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Renvoyer les instructions de confirmation"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Sélectionnez la méthode à deux facteurs"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-"L'authentification à deux facteurs ajoute une couche de sécurité "
-"supplémentaire à votre compte"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 "En plus de votre nom d'utilisateur et de votre mot de passe, vous devrez "
 "utiliser un code."
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Méthode à deux facteurs actuellement configurée : %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Vous pouvez les paramétrer ici."
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Cette application prend en charge les clés de sécurité WebAuthn."
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr "Authentification à deux facteurs"
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Veuillez saisir votre code d'authentification généré via: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Configurer la connexion unifiée"
@@ -929,25 +937,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Demander l'envoi d'un code à usage unique"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Merci de vous reconnecter pour accéder à cette page."
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Le code a été envoyé"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr "Utiliser une clé de sécurité WebAuthn pour réauthentifier"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Configurer une nouvelle clé de sécurité WebAuthn"
@@ -971,6 +983,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Supprimer la clé de sécurité WebAuthn existante"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Se connecter à l'aide de la clé de sécurité WebAuthn"
@@ -980,33 +996,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr "Utilisez votre clé de sécurité WebAuthn comme deuxième facteur"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
-"Veuillez vous authentifier à nouveau à l'aide de votre clé de sécurité "
-"WebAuthn"
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1031,14 +1043,20 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Merci de confirmer votre adresse email via le lien ci-dessous:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
+"Utilisez <a href=\"%(confirmation_link)s\">ce lien</a> pour confirmer "
+"votre adresse e-mail adresse."
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Confirmer mon compte"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1065,9 +1083,18 @@ msgstr "Cliquez pour réinitialiser votre mot de passe"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1076,13 +1103,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1105,11 +1142,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Vous pouvez confirmer votre votre adresse email via le lien ci-dessous:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1134,11 +1166,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1149,7 +1180,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1225,3 +1259,98 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Merci. Les instructions de confirmation ont été envoyées à %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Merci de vous reconnecter pour accéder à cette page."
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Désactiver l'authentification à deux facteurs"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Configuration à deux facteurs"
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Sélectionnez la méthode à deux facteurs"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "L'authentification à deux facteurs ajoute "
+#~ "une couche de sécurité supplémentaire à"
+#~ " votre compte"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Authentification à deux facteurs"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Merci de vous reconnecter pour accéder à cette page."
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+#~ "Veuillez vous authentifier à nouveau à"
+#~ " l'aide de votre clé de sécurité "
+#~ "WebAuthn"
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Changer de mot de passe"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Confirmer mon compte"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Merci de confirmer votre adresse email via le lien ci-dessous:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Vous pouvez confirmer votre votre adresse email via le lien ci-dessous:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/hu_HU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/hu_HU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hu_HU\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Bejelentkezés szükséges"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Üdvözöljük"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Kétfaktoros Bejelentkezés"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Kétfaktoros Visszaállítás"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -86,7 +82,7 @@ msgstr "A bemenet nem megfelelő a kért API-hoz"
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Sikertelen hitelesítés - azonosító vagy jelszó/kód érvénytelen"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -107,10 +103,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "A végpont eléréséhez újra hitelesíteni kell"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -134,7 +130,7 @@ msgstr "Érvénytelen megerősítő token."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s már társítva van egy fiókhoz."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -148,7 +144,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -205,7 +201,7 @@ msgstr "A megerősítő utasításokat elküldtük a következő címre: %(email
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -286,13 +282,13 @@ msgstr "Sikeresen bejelentkezett."
 msgid "Forgot password?"
 msgstr "Elfelejtette jelszavát?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Sikeresen visszaállította jelszavát, és automatikusan be is jelentkezett."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -347,8 +343,8 @@ msgid "Marked method is not valid"
 msgstr "A megjelölt metódus nem érvényes"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Sikeresen letiltotta a kétfaktoros hitelesítést."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -374,14 +370,14 @@ msgstr "A bejelentkezéshez érvényes azonositót kell megadnia"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Használja ezt a kódot a bejelentkezéshez: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -476,7 +472,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -487,7 +483,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr "Beállítás hitelesítő alkalmazás segítségével (pl. google, lastpass, authy)"
 
@@ -496,6 +492,8 @@ msgid "Change Method"
 msgstr "Módszer módosítása"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Jelszó módosítása"
 
@@ -524,8 +522,10 @@ msgid "Identity"
 msgstr "Azonosító"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Bejelentkezés"
 
@@ -554,7 +554,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Regisztráció"
 
@@ -583,8 +584,8 @@ msgid "Send Code"
 msgstr "Kód küldése"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Bejelentkezés"
 
@@ -632,19 +633,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Elérhető módszerek"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
-msgstr "Kétfaktoros hitelesítés letiltása"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
+msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -668,11 +669,11 @@ msgstr "Elérhető második faktoros módszerek:"
 msgid "Select"
 msgstr "Kiválasztás"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -688,15 +689,15 @@ msgstr "E-mailben"
 msgid "Via SMS"
 msgstr "SMS-ben"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Kiegészítő bejelentkezési lehetőség beállítása"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr "Az aktív bejelentkezési opció törlése"
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Becenév"
 
@@ -712,11 +713,11 @@ msgstr "Használat első hitelesítési lépésként"
 msgid "Use as a secondary authentication factor"
 msgstr "Használat másodlagos hitelesítési lépésként"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -733,13 +734,15 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
-msgstr "Kétfaktoros beállítás"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
+msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
 msgid "Unified Signin Setup"
@@ -761,68 +764,69 @@ msgstr "Elfelejtett jelszó"
 msgid "Confirm account"
 msgstr "Fiók megerősítése"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Jelszó módosítása"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr "Jelenleg nincs jelszava – ez hozzáad egyet."
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Jelszó visszaállítási utasítások küldése"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr "vagy"
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "A WebAuthn használata a bejelentkezéshez"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Bejelentkezés WebAuthn segítségével"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr "Adja meg a helyreállítási kódot"
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr "Helyreállítási kódok"
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
@@ -830,40 +834,44 @@ msgstr ""
 "Mindenképpen másolja át ezeket, és tárolja biztonságos helyen. Minden kód"
 " csak egyszer használható."
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Jelszó visszaállítása"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Megerősítő utasítások újraküldése"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Kétfaktoros módszer kiválasztása"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr "A kétfaktoros hitelesítés extra biztonsági réteget ad fiókjához"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
+msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr "A felhasználóneve és a jelszava mellett egy kódot is kell használnia."
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -873,59 +881,61 @@ msgstr ""
 "következő QR-kódot (vagy írja be kézzel az alábbi kódot), hogy megkezdje "
 "a kódok fogadását:"
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Kétfaktoros hitelesítési kód"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr "Ez az alkalmazás támogatja a helyreállítási kódok beállítását."
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Itt állíthatja be."
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Ez az alkalmazás támogatja a WebAuthn biztonsági kulcsokat."
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Kétfaktoros Hitelesítés"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 "Kérjük, adja meg hitelesítési kódját, amelyet a következővel generált: "
 "%(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "A hitelesítési kódot elküldtük az Ön e-mail címére"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Egységes bejelentkezés beállítása"
@@ -942,25 +952,29 @@ msgstr "Nincs engedélyezve metódus – nincs mit beállítani"
 msgid "Enter code here to complete setup"
 msgstr "A beállítás befejezéséhez írja be ide a kódot"
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Kérje egyszeri kód küldését"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Kérem hitelesítse újra"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "A kód elküldve"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr "Használjon WebAuthn biztonsági kulcsot az újrahitelesítéshez"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Új WebAuthn biztonsági kulcs beállítása"
@@ -987,6 +1001,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Meglévő WebAuthn biztonsági kulcs törlése"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Bejelentkezés WebAuthn biztonsági kulcs használatával"
@@ -996,31 +1014,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr "Használja a WebAuthn biztonsági kulcsát második lépésként"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
-msgstr "Kérjük, hitelesítsen újra a WebAuthn biztonsági kulcs használatával"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
+msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1047,14 +1063,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Kérjük, erősítse meg e-mail címét az alábbi linken keresztül:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Fiók megerősítése"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1081,10 +1101,19 @@ msgstr "Kattintson ide a jelszó visszaállításához"
 msgid "Click the link below to reset your password:"
 msgstr "Kattintson az alábbi linkre a jelszó visszaállításához:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "A következő kóddal jelentkezhet be fiókjába:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1092,14 +1121,24 @@ msgid "can not access mail account"
 msgstr "nem tud hozzáférni a mail fiókhoz"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "A következő kóddal jelentkezhet be fiókjába:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Vagy használja az alábbi linket:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1121,11 +1160,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Megerősítheti e-mailjét az alábbi linken keresztül:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1152,12 +1186,11 @@ msgid ""
 msgstr "Ehhez a fiókhoz a következő felhasználónév is tartozik: %(username)s."
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr "Ha elfelejtette jelszavát, visszaállíthatja"
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
-msgstr " ezen a linken."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
 #, python-format
@@ -1167,8 +1200,11 @@ msgid ""
 msgstr "Ehhez a fiókhoz a következő felhasználónév is tartozik: \"%(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
-msgstr "Ha elfelejtette jelszavát, a következő linken visszaállíthatja:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
@@ -1246,3 +1282,92 @@ msgstr ""
 #~ msgstr ""
 #~ "Köszönjük. A megerősítő utasításokat elküldtük"
 #~ " a következő címre: %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Kétfaktoros Bejelentkezés"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Kétfaktoros Visszaállítás"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "A végpont eléréséhez újra hitelesíteni kell"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Sikeresen letiltotta a kétfaktoros hitelesítést."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Kétfaktoros hitelesítés letiltása"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Kétfaktoros beállítás"
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Kétfaktoros módszer kiválasztása"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr "A kétfaktoros hitelesítés extra biztonsági réteget ad fiókjához"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Kétfaktoros hitelesítési kód"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Kétfaktoros Hitelesítés"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Kérem hitelesítse újra"
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr "Kérjük, hitelesítsen újra a WebAuthn biztonsági kulcs használatával"
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Jelszó módosítása"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Fiók megerősítése"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "A következő kóddal jelentkezhet be fiókjába:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "A következő kóddal jelentkezhet be fiókjába:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Vagy használja az alábbi linket:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Kérjük, erősítse meg e-mail címét az alábbi linken keresztül:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Megerősítheti e-mailjét az alábbi linken keresztül:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr "Ha elfelejtette jelszavát, visszaállíthatja"
+
+#~ msgid " here."
+#~ msgstr " ezen a linken."
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr "Ha elfelejtette jelszavát, a következő linken visszaállíthatja:"
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Használja ezt a kódot a bejelentkezéshez: %(code)s."

--- a/flask_security/translations/hy_AM/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/hy_AM/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2020-12-01 11:47+0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hy_AM\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Անհրաժեշտ է մուտք գործել"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Բարի գալուստ"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Երկու գործոնով մուտք"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Երկու գործոնով վերականգնում"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -86,7 +82,7 @@ msgstr "Մուտքը չի համապատասխանում հայցվող API֊ի�
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Նույնականացումը ձախողվեց. ինքնությունը կամ գաղտնաբառը/ծածկագիրը անվավեր է"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -107,10 +103,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Դուք պետք է կրկին նույնականցվեք որպեսզի այստեղ մուտք գործեք"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -134,7 +130,7 @@ msgstr "Հաստատման տոկենը անվավեր է։"
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s արդեն կապված է այլ օգտահաշվի հետ։"
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -148,7 +144,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr "«%(id)s» ինքնությունը գրանցված չէ"
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -203,7 +199,7 @@ msgstr "Հաստատման հրահանգները ուղարկվել են %(emai
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Դուք չեք հաստատել ձեր էլ․փոստի հասցեն %(within)s-ի ընթացքում:"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -282,7 +278,7 @@ msgstr "Դուք բարեհաջող մուտք էք գործել։"
 msgid "Forgot password?"
 msgstr "Մոռացել ե՞ք գաղտնաբառը"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -290,7 +286,7 @@ msgstr ""
 "Դուք հաջողությամբ վերականգնել եք ձեր գաղտնաբառը եւ մուտք էք գործել "
 "համակարգ ինքնաբերաբար։"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -347,8 +343,8 @@ msgid "Marked method is not valid"
 msgstr "Նշված տարբերակը վավեր չէ"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Դուք հաջողությամբ անջատել եք երկու գործոնի թույլտվությունը"
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -374,14 +370,14 @@ msgstr "Մուտք գործելու համար պետք է նշեք վավեր �
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Մուտքի համար օգտագործեք այս ծածկագիրը․ %(code)s։"
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -468,7 +464,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -479,7 +475,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Կարգավորեք օգտագործելով վավերացման ծրագիր (ինչպիսիք են՝ google, lastpass,"
@@ -490,6 +486,8 @@ msgid "Change Method"
 msgstr "Փոխել տարբերակը"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Փոխել գաղտնաբառը"
 
@@ -518,8 +516,10 @@ msgid "Identity"
 msgstr "Ինքնություն"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Մուտք"
 
@@ -548,7 +548,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Գրանցվել"
 
@@ -577,8 +578,8 @@ msgid "Send Code"
 msgstr "Ուղարկել ծածկագիր"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Մուտք գործել"
 
@@ -626,19 +627,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Առկա տարբերակներ"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
-msgstr "Անջատել երկու գործոնով նույնականացումը"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
+msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -662,11 +663,11 @@ msgstr "Երկրորդ գործոնի հասանելի մեթոդներ."
 msgid "Select"
 msgstr "Ընտրել"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -682,15 +683,15 @@ msgstr "Էլ․ Փոստով"
 msgid "Via SMS"
 msgstr "SMS հաղորդագրությամբ"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Կարգավորեք մուտքի լրացուցիչ տարբերակ"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr "Ջնջել ակտիվ մուտքի տարբերակը"
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Մականուն"
 
@@ -706,11 +707,11 @@ msgstr "Օգտագործեք որպես նույնականացման առաջի�
 msgid "Use as a secondary authentication factor"
 msgstr "Օգտագործեք որպես նույնականացման երկրորդական գործոն"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Սկսել"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -727,13 +728,15 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
-msgstr "Երկու գործոնի կարգավորում"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
+msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
 msgid "Unified Signin Setup"
@@ -755,68 +758,69 @@ msgstr "Մոռացել եք գաղտնաբառը"
 msgid "Confirm account"
 msgstr "Հաստատել օգտահաշիվը"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Փոխել գաղտնաբառը"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr "Դուք ներկայումս գաղտնաբառ չունեք, սա կավելացվի:"
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Ուղարկել գաղտնաբառի վերականգնման հրահանգները"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr "կամ"
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "Օգտագործել WebAuthn մուտք գործելու համար"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Մուտք գործել WebAuthn֊ի միջոցով"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr "Օգտագործել Social Oauth մուտք գործելու համար"
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
-msgstr "Մուտք գործեք "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
+msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr "Մուտքագրեք վերականգնման ծածկագիրը"
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr "Վերականգնման ծածկագրեր"
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
@@ -824,42 +828,44 @@ msgstr ""
 "Համոզվեք, որ պատճենեք դրանք և պահեք ապահով տեղում: Յուրաքանչյուր ծածկագիր"
 " կարող է օգտագործվել միայն մեկ անգամ:"
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr "Ստեղծեք վերականգնման նոր ծածկագրեր"
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Վերականգնել գաղտնաբառը"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Ուղարկել օգտահաշվի վերահաստատման հրահանգները"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Ընտրեք «երկու գործոնի» տարբերակը"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-"Երկու գործոնով նույնականացումը ձեր հաշվին ավելացնում է անվտանգության "
-"լրացուցիչ շերտ"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr "Բացի ձեր օգտանունից և գաղտնաբառից, դուք պետք է օգտագործեք ծածկագիր:"
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Ներկայիս կարգավորված երկգործոն մեթոդը. %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -868,59 +874,61 @@ msgstr ""
 "Բացեք վավերացնող հավելվածը ձեր սարքում և սկանավորեք հետևյալ QRcode-ը (կամ"
 " մուտքագրեք ստորև նշված ծածկագիրը) ծածկագրեր ստանալու համար."
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Երկու գործոն նույնականացման ծածկագիր"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr "Այս հավելվածն օժանդակում է վերականգնման ծածկագրերի կարգավորումը:"
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Դուք կարող եք դրանք կարգավորել այստեղ:"
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr "WebAuthn"
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Այս հավելվածն օժանդակում է WebAuthn անվտանգության բանալիներին:"
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Երկու գործոն նույնականացում"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 "Խնդրում ենք մուտքագրել ձեր նույնականացման ծածկագիրը, որը ստեղծվել է "
 "%(method)s միջոցով."
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Նույնականացման ծածկագիրն ուղարկվել է Ձեր էլ․հասցեին"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Կարգավորեք միասնական մուտքը"
@@ -937,25 +945,29 @@ msgstr "Ոչ մի տարբերակի հնարավորություն տրված �
 msgid "Enter code here to complete setup"
 msgstr "Մուտքագրեք ծածկագիրն այստեղ՝ կարգավորումն ավարտելու համար"
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Հայցեք միանգամյա ծածկագրի ուղարկում"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Խնդրում եմ նորից վերանույնականցվեք:"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Ծածկագիրն ուղարկվել է"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr "Վերանույնականցվելու համար օգտագործեք WebAuthn անվտանգության բանալին"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Կարգավորեք նոր WebAuthn անվտանգության բանալի"
@@ -982,6 +994,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Ջնջել գոյություն ունեցող WebAuthn անվտանգության բանալին"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Մուտք գործեք՝ օգտագործելով WebAuthn անվտանգության բանալին"
@@ -991,33 +1007,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr "Օգտագործեք ձեր WebAuthn անվտանգության բանալին որպես երկրորդ գործոն"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
-"Խնդրում ենք վերանույնականցվեք՝ օգտագործելով ձեր WebAuthn անվտանգության "
-"բանալին"
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1042,14 +1054,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Ստորև բերված հղումով հաստատեք ձեր էլ. փոստի հասցեն․"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Հաստատել իմ օգտահաշիվը"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1076,10 +1092,19 @@ msgstr "Ձեր գաղտնաբառը վերականգնելու համար սեղ
 msgid "Click the link below to reset your password:"
 msgstr "Ձեր գաղտնաբառը վերականգնելու համար սեղմեք սեղմեք հղումին"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Դուք կարող եք մտնել Ձեր օգտահաշիվ՝ օգտագործելով հետևյալ ծածկագիրը."
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1087,14 +1112,24 @@ msgid "can not access mail account"
 msgstr "Օգտահաշիվ հնարավոր չէ մուտք գործել"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Կարող եք մուտք գործել Ձեր օգտահաշիվ՝ օգտագործելով հետևյալ ծածկագիրը."
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Կամ օգտագործեք ստորեւ նշված հղումը"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1116,11 +1151,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Դուք կարող եք հաստատել ձեր էլ. փոստի հասցեն ստորև նշված հղումով."
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1147,12 +1177,11 @@ msgid ""
 msgstr "Այս հաշիվը ունի նաև հետևյալ օգտվողի անունը՝ կապված դրա հետ. %(username)s։"
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr "Եթե մոռացել եք ձեր գաղտնաբառը, կարող եք վերականգնել այն"
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
-msgstr " այստեղ։"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
 #, python-format
@@ -1162,8 +1191,11 @@ msgid ""
 msgstr "Այս հաշիվը ունի նաև հետևյալ օգտվողի անունը՝ կապված իրա հետ. %(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
-msgstr "Եթե մոռացել եք ձեր գաղտնաբառը, կարող եք վերականգնել այն հետևյալ հղումով."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
@@ -1217,3 +1249,98 @@ msgstr "Խնդրում ենք վերսկսել գրանցման գործընթա
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Շնորհակալություն. Հաստատման հրահանգներն ուղարկվել են %(email)s հասցեին։"
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Երկու գործոնով մուտք"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Երկու գործոնով վերականգնում"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Դուք պետք է կրկին նույնականցվեք որպեսզի այստեղ մուտք գործեք"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Դուք հաջողությամբ անջատել եք երկու գործոնի թույլտվությունը"
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Անջատել երկու գործոնով նույնականացումը"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Երկու գործոնի կարգավորում"
+
+#~ msgid "Sign in with "
+#~ msgstr "Մուտք գործեք "
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Ընտրեք «երկու գործոնի» տարբերակը"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "Երկու գործոնով նույնականացումը ձեր հաշվին "
+#~ "ավելացնում է անվտանգության լրացուցիչ շերտ"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Երկու գործոն նույնականացման ծածկագիր"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Երկու գործոն նույնականացում"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Խնդրում եմ նորից վերանույնականցվեք:"
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+#~ "Խնդրում ենք վերանույնականցվեք՝ օգտագործելով "
+#~ "ձեր WebAuthn անվտանգության բանալին"
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Փոխել գաղտնաբառը"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Հաստատել իմ օգտահաշիվը"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Դուք կարող եք մտնել Ձեր օգտահաշիվ՝ օգտագործելով հետևյալ ծածկագիրը."
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Կարող եք մուտք գործել Ձեր օգտահաշիվ՝ օգտագործելով հետևյալ ծածկագիրը."
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Կամ օգտագործեք ստորեւ նշված հղումը"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Ստորև բերված հղումով հաստատեք ձեր էլ. փոստի հասցեն․"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Դուք կարող եք հաստատել ձեր էլ. փոստի հասցեն ստորև նշված հղումով."
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr "Եթե մոռացել եք ձեր գաղտնաբառը, կարող եք վերականգնել այն"
+
+#~ msgid " here."
+#~ msgstr " այստեղ։"
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+#~ "Եթե մոռացել եք ձեր գաղտնաբառը, կարող "
+#~ "եք վերականգնել այն հետևյալ հղումով."
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Մուտքի համար օգտագործեք այս ծածկագիրը․ %(code)s։"

--- a/flask_security/translations/is_IS/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/is_IS/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2022-04-23 17:04+0000\n"
 "Last-Translator: \n"
 "Language: is_IS\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Innskráningar er þörf"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Velkomin(n)"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Tveggja þátta innskráning"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
+msgid "You must reauthenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr "Ógildur staðfestingarkóði."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s er þegar í notkun á öðrum reikningi."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -144,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr ""
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -278,7 +274,7 @@ msgstr "Þér tókst að skrá þig inn."
 msgid "Forgot password?"
 msgstr "Gleymt lykilorð?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -286,7 +282,7 @@ msgstr ""
 "Þér tókst að endurstilla lykilorðið þitt og þú hefur verið skráð(ur) inn "
 "sjálfkrafa."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -341,7 +337,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -368,14 +364,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -464,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -475,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -484,6 +480,8 @@ msgid "Change Method"
 msgstr "Breyta um aðferð"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Breyta lykilorði"
 
@@ -512,8 +510,10 @@ msgid "Identity"
 msgstr "Auðkenni"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Innskráning"
 
@@ -542,7 +542,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Skrá mig"
 
@@ -571,8 +572,8 @@ msgid "Send Code"
 msgstr "Senda kóða"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Innskráning"
 
@@ -620,19 +621,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -656,11 +657,11 @@ msgstr ""
 msgid "Select"
 msgstr "Velja"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -676,15 +677,15 @@ msgstr "Með tölvupósti"
 msgid "Via SMS"
 msgstr "Með SMS skilaboði"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Gælunafn"
 
@@ -700,11 +701,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Byrja"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -721,12 +722,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -749,164 +752,171 @@ msgstr "Gleymt lykilorð"
 msgid "Confirm account"
 msgstr "Staðfesta reikning"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Breyta lykilorði"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Senda leiðbeiningar fyrir endurstillingu lykilorðs"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Endurstilla lykilorð"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Tveggja-þátta auðkenning"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -923,25 +933,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Kóði hefur verið sendur"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -965,6 +979,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -974,31 +992,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1025,14 +1041,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Vinsamlegast staðfestu netfangið þitt á eftirfarandi slóð:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Staðfesta reikninginn minn"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1059,9 +1079,18 @@ msgstr "Smelltu hér til að endurstilla lykilorðið þitt"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1070,13 +1099,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1098,11 +1137,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.html:8
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
-msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:11
@@ -1128,11 +1162,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1143,7 +1176,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1232,3 +1268,92 @@ msgstr ""
 #~ "Þakka þér fyrir. Leiðbeiningar fyrir "
 #~ "staðfestingu hafa verið sendar á "
 #~ "%(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Tveggja þátta innskráning"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr ""
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Tveggja-þátta auðkenning"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Breyta lykilorði"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Staðfesta reikninginn minn"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Vinsamlegast staðfestu netfangið þitt á eftirfarandi slóð:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/it_IT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/it_IT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.6.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2025-02-07 19:38+0100\n"
 "Last-Translator: Giorgio Stampa <giorgio.stampa@sanofi.com>\n"
 "Language: it_IT\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Accesso richiesto"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Benvenuto/a"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr "Il tuo nome utente richiesto"
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Accesso a due fattori"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Recupero dell'accesso a due fattori"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -86,7 +82,7 @@ msgstr "Input non appropriato per l'API richiesta"
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Autenticazione fallita - identità o password/passcode non validi"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -107,10 +103,10 @@ msgid "You must sign in to view this resource."
 msgstr "È necessario accedere per accedere a questa risorsa."
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "È necessario riautenticarsi per accedere a questa risorsa"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -136,7 +132,7 @@ msgstr "Token di conferma non valido."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s è già associata ad un account."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -150,7 +146,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr "Identità %(id)s non registrata"
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -207,7 +203,7 @@ msgstr "Le istruzioni di conferma sono state inviate a %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Non hai confermato la tua email entro %(within)s. "
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -288,7 +284,7 @@ msgstr "Hai effettuato l'accesso."
 msgid "Forgot password?"
 msgstr "Password dimenticata?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -296,7 +292,7 @@ msgstr ""
 "Hai reimpostato la tua password e l'accesso è stato effettuato "
 "automaticamente."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -353,8 +349,8 @@ msgid "Marked method is not valid"
 msgstr "Il metodo selezionato non è valido"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Hai disabilitato l'autorizzazione a due fattori."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -382,14 +378,14 @@ msgstr "Devi specificare un'identità valida per accedere"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Utilizza questo codice per accedere: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr "Hai cambiato il tuo nome utente"
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -482,7 +478,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr "Cambio di indirizzo email confermato"
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -495,7 +491,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr "Se registrato, il nome utente verrà inviato al tuo indirizzo e-mail."
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Configurazione tramite app di autenticazione (ad es. google, lastpass, "
@@ -506,6 +502,8 @@ msgid "Change Method"
 msgstr "Cambia metodo"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Cambia password"
 
@@ -534,8 +532,10 @@ msgid "Identity"
 msgstr "Identità"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Accedi"
 
@@ -564,7 +564,8 @@ msgid "Recover Username"
 msgstr "Recupera il nome utente"
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registrati"
 
@@ -593,8 +594,8 @@ msgid "Send Code"
 msgstr "Invia codice"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Accedi"
 
@@ -642,19 +643,19 @@ msgstr "password"
 msgid "none"
 msgstr "nessuno"
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Metodi disponibili"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
-msgstr "Disabilitare l'autenticazione a due fattori"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
+msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Problemi di accesso al tuo account?/Dispositivo mobile smarrito?"
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr "Contatta l'amministratore"
 
@@ -678,11 +679,11 @@ msgstr "Metodi di autenticazione a due fattori disponibili:"
 msgid "Select"
 msgstr "Seleziona"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr "Invia codice tramite email"
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr "Utilizza codice di ripristino scaricato in precedenza"
 
@@ -698,15 +699,15 @@ msgstr "Tramite email"
 msgid "Via SMS"
 msgstr "Tramite SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Imposta opzione di accesso aggiuntiva"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr "Elimina l'opzione di accesso attiva"
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Nome"
 
@@ -722,11 +723,11 @@ msgstr "Utilizzare come fattore di autenticazione primario"
 msgid "Use as a secondary authentication factor"
 msgstr "Utilizzare come fattore di autenticazione secondario"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Inizio"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -743,13 +744,15 @@ msgid "Change Registered Email"
 msgstr "Cambia email registrata"
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr "Cambia nome utente"
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
-msgstr "Imposta autenticazione a due fattori"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
+msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
 msgid "Unified Signin Setup"
@@ -771,68 +774,69 @@ msgstr "Password dimenticata"
 msgid "Confirm account"
 msgstr "Conferma account"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
-msgstr "Cambia email"
-
+#: flask_security/templates/security/change_email.html:1
 #: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
+msgstr ""
+
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr "Un messaggio di conferma sarà mandato a questo nuovo indirizzo email."
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Cambia password"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr "Al momento non hai una password: ne verrà aggiunta una."
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr "Il nome utente attuale è: %(username)s"
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Invia istruzioni per reimpostare la password"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr "o"
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "Usa WebAuthn per accedere"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Accedi con WebAuthn"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr "Usa social OAuth per accedere"
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
-msgstr "Accedi con "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
+msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr "Inserisci codice di ripristino"
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr "Codici di ripristino"
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
@@ -840,42 +844,44 @@ msgstr ""
 "Assicurati di copiarli e conservarli in un luogo sicuro. Ogni codice può "
 "essere utilizzato una sola volta."
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr "Genera nuovi codici di ripristino"
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
-msgstr "Recupero del nome utente"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
+msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Reimposta password"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Invia nuovamente istruzioni di conferma"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Seleziona metodo a due fattori"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-"L'autenticazione a due fattori aggiunge un ulteriore livello di sicurezza"
-" al tuo account"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr "Oltre al nome utente e alla password, dovrai utilizzare un codice."
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Metodo a due fattori attualmente attivo: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -885,57 +891,59 @@ msgstr ""
 " codice QR (o inserisci manualmente il codice sottostante) per iniziare a"
 " ricevere i codici:"
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Codice di autenticazione a due fattori"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr "Inserisci il codice per completare la configurazione"
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr "inserisci il codice numerico"
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr "Questa applicazione supporta l'impostazione dei codici di ripristino."
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Si possono impostare qui."
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr "WebAuthn"
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Questa applicazione supporta le chiavi di sicurezza WebAuthn."
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Autenticazione a due fattori"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Inserisci il tuo codice di autenticazione generato tramite: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Il codice per l'autenticazione è stato inviato al tuo indirizzo email"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr "Ci è stata inviata un'email per reimpostare l'account dell'applicazione"
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Configurazione dell'accesso unificato"
@@ -952,27 +960,31 @@ msgstr "Nessun metodo è stato abilitato - niente da impostare"
 msgid "Enter code here to complete setup"
 msgstr "Inserisci qui il codice per completare la configurazione"
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Richiedere l'invio del codice monouso"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Per favore autenticati nuovamente"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Il codice è stato inviato"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 "Utilizzare una chiave di sicurezza WebAuthn per eseguire nuovamente "
 "l'autenticazione"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Imposta una nuova chiave di sicurezza WebAuthn"
@@ -998,6 +1010,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Elimina la chiave di sicurezza WebAuthn esistente"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Accedi utilizzando la chiave di sicurezza WebAuthn"
@@ -1007,34 +1023,30 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr "Utilizza la chiave di sicurezza WebAuthn come secondo fattore"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
-"Per favore autenticati nuovamente utilizzando la chiave di sicurezza "
-"WebAuthn"
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
-msgstr "Conferma il tuo nuovo indirizzo email tramite il link sottostante:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
+msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr "Conferma la mia nuova email"
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr "Questo link scadrá entro %(within)s."
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr "La tua email registrata attualmente è %(email)s."
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
-msgstr "Conferma la tua nuova email tramite il link sottostante:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
+msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
 #: flask_security/templates/security/email/change_notice.txt:1
@@ -1060,14 +1072,18 @@ msgid "Your username has been changed."
 msgstr "Il tuo nome utente è stato cambiato."
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Conferma la tua email tramite il link sottostante:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Conferma il mio account"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1094,10 +1110,19 @@ msgstr "Clicca qui per reimpostare la password"
 msgid "Click the link below to reset your password:"
 msgstr "Clicca sul link sottostante per reimpostare la password:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Puoi accedere al tuo account utilizzando il seguente codice:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1105,14 +1130,24 @@ msgid "can not access mail account"
 msgstr "impossibile accedere all'account email"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Puoi accedere al tuo account con il seguente codice:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Oppure tramite il link sottostante:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1136,11 +1171,6 @@ msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
 "Se non hai avviato tu questa richiesta, puoi tranquillamente ignorare "
 "questo messaggio."
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Puoi confermare la tua email tramite il link sottostante:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1167,12 +1197,11 @@ msgid ""
 msgstr "A questo account è associato anche il seguente nome utente: %(username)s."
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr "Se hai dimenticato la password puoi reimpostarla"
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
-msgstr " qui."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
 #, python-format
@@ -1182,8 +1211,11 @@ msgid ""
 msgstr "A questo account è associato anche il seguente nome utente: %(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
-msgstr "Se hai dimenticato la password puoi reimpostarla tramite il seguente link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
@@ -1201,3 +1233,99 @@ msgid "Please restart the registration process with a different username."
 msgstr ""
 "Per favore riavvia il processo di registrazione con un nome utente "
 "diverso."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Accesso a due fattori"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Recupero dell'accesso a due fattori"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "È necessario riautenticarsi per accedere a questa risorsa"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Hai disabilitato l'autorizzazione a due fattori."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Disabilitare l'autenticazione a due fattori"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Imposta autenticazione a due fattori"
+
+#~ msgid "Sign in with "
+#~ msgstr "Accedi con "
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Seleziona metodo a due fattori"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "L'autenticazione a due fattori aggiunge "
+#~ "un ulteriore livello di sicurezza al "
+#~ "tuo account"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Codice di autenticazione a due fattori"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Autenticazione a due fattori"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Per favore autenticati nuovamente"
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+#~ "Per favore autenticati nuovamente utilizzando"
+#~ " la chiave di sicurezza WebAuthn"
+
+#~ msgid "Change email"
+#~ msgstr "Cambia email"
+
+#~ msgid "Change password"
+#~ msgstr "Cambia password"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr "Conferma il tuo nuovo indirizzo email tramite il link sottostante:"
+
+#~ msgid "Confirm my new email"
+#~ msgstr "Conferma la mia nuova email"
+
+#~ msgid "Confirm my account"
+#~ msgstr "Conferma il mio account"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Puoi accedere al tuo account utilizzando il seguente codice:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Puoi accedere al tuo account con il seguente codice:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Oppure tramite il link sottostante:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr "Conferma la tua nuova email tramite il link sottostante:"
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Conferma la tua email tramite il link sottostante:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Puoi confermare la tua email tramite il link sottostante:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr "Se hai dimenticato la password puoi reimpostarla"
+
+#~ msgid " here."
+#~ msgstr " qui."
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+#~ "Se hai dimenticato la password puoi "
+#~ "reimpostarla tramite il seguente link:"
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Utilizza questo codice per accedere: %(code)s."

--- a/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2018-01-25 14:12+0900\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "ログインが必要です"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "ようこそ"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,11 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "再度ログインしてください"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -133,7 +128,7 @@ msgstr "リンクが無効です"
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s のアカウントは既に作成されています"
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -145,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -200,7 +195,7 @@ msgstr "%(email)sにメールアドレス検証手順が再送信されました
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -277,13 +272,13 @@ msgstr "ログインしました"
 msgid "Forgot password?"
 msgstr "パスワードを忘れた場合"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "パスワードの再設定が完了しました。"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -338,7 +333,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -365,14 +360,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -459,7 +454,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -470,7 +465,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -479,6 +474,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "変更"
 
@@ -507,8 +504,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "ログイン"
 
@@ -537,7 +536,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "ユーザ登録"
 
@@ -566,8 +566,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -615,19 +615,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -651,11 +651,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -671,15 +671,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -695,11 +695,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -716,12 +716,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -744,164 +746,171 @@ msgstr "パスワードを忘れた場合"
 msgid "Confirm account"
 msgstr "メールアドレスの検証"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "パスワードの変更"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "パスワード再設定手順の送信"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "パスワード再設定"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "検証手順の再送信"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -918,25 +927,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -960,6 +973,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -969,31 +986,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1018,14 +1033,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "以下のリンクからメールアドレスを検証してください："
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "メールアドレスの検証"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1052,9 +1071,18 @@ msgstr "パスワードを再設定するためにこのリンクを開いてく
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1063,13 +1091,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1092,11 +1130,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "以下のリンクによりメールアドレスを検証できます。"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1121,11 +1154,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1136,7 +1168,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1261,3 +1296,92 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "ご登録ありがとうございます。%(email)sにメールアドレス検証手順が送信されました。"
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "再度ログインしてください"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr ""
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "パスワードの変更"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "メールアドレスの検証"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "以下のリンクからメールアドレスを検証してください："
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "以下のリンクによりメールアドレスを検証できます。"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2017-05-01 17:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl_NL\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Inloggen Verplicht"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Welkom"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Dubbele Authenticatie Aanmelding"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Dubbele Authenticatie Herstellen"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 #, fuzzy
@@ -87,7 +83,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -106,11 +102,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Gelieve opnieuw in te loggen om deze pagina te zien."
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -134,7 +129,7 @@ msgstr "Ongeldige bevestiging token."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s is al gelinkt aan een ander account."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -146,7 +141,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -203,7 +198,7 @@ msgstr ""
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -283,13 +278,13 @@ msgstr "U bent succesvol ingelogd."
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "U heeft uw wachtwoord succesvol gereset en bent nu automatisch ingelogd."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -344,8 +339,8 @@ msgid "Marked method is not valid"
 msgstr "De gemarkeerde methode is niet valide"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "U heeft succesvol Dubbele Authenticatie uitgeschakeld."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -372,14 +367,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -466,7 +461,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -477,7 +472,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -486,6 +481,8 @@ msgid "Change Method"
 msgstr "Verander Methode"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Verander wachtwoord"
 
@@ -514,8 +511,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Aanmelden"
 
@@ -545,7 +544,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registreer"
 
@@ -574,8 +574,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -623,19 +623,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -659,11 +659,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -679,15 +679,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -703,11 +703,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -724,12 +724,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -752,166 +754,171 @@ msgstr "Wachtwoord vergeten"
 msgid "Confirm account"
 msgstr "Bevestig account"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Verander wachtwoord"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Verzend wachtwoord reset instructies"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Reset wachtwoord"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Verzend bevestiging instructies opnieuw"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr ""
-"Dubbele Authenticatie voegt een extra laag van beveiliging toe aan uw "
-"account"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Dubbele Authenticatie code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Dubbele Authenticatie"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "The code voor authenticatie is naar uw e-mail adres verzonden"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -928,25 +935,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -970,6 +981,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -979,31 +994,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1028,14 +1041,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Gelieve uw e-mailadres te bevestigen via onderstaande link:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Bevestig mijn account"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1062,10 +1079,19 @@ msgstr "Klik hier om uw wachtwoord te resetten"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "U kunt inloggen door de volgende code te gebruiken:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1073,14 +1099,23 @@ msgid "can not access mail account"
 msgstr "kan niet in het e-mail account"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-#, fuzzy
-msgid "You can sign into your account using the following code:"
-msgstr "U kunt inloggen door de volgende code te gebruiken:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1103,11 +1138,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "U kan uw e-mailadres bevestigen via de onderstaande link:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1132,11 +1162,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1147,7 +1176,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1291,3 +1323,95 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Bedankt. Instructies voor bevestiging zijn verzonden naar %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Dubbele Authenticatie Aanmelding"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Dubbele Authenticatie Herstellen"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Gelieve opnieuw in te loggen om deze pagina te zien."
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "U heeft succesvol Dubbele Authenticatie uitgeschakeld."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "Dubbele Authenticatie voegt een extra "
+#~ "laag van beveiliging toe aan uw "
+#~ "account"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Dubbele Authenticatie code"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Dubbele Authenticatie"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Verander wachtwoord"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Bevestig mijn account"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "U kunt inloggen door de volgende code te gebruiken:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "U kunt inloggen door de volgende code te gebruiken:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Gelieve uw e-mailadres te bevestigen via onderstaande link:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "U kan uw e-mailadres bevestigen via de onderstaande link:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/pl_PL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pl_PL/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2020-11-28 10:19+0100\n"
 "Last-Translator: Kamil Daniewski <kamil.daniewski@gmail.com>\n"
 "Language: pl_PL\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Logowanie jest wymagane"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Witamy"
 
@@ -67,12 +63,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Logowanie dwuskładnikowe"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Pomoc w logowaniu dwuskładnikowym"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -86,7 +82,7 @@ msgstr "Nieprawidłowe dane dla żądanego API"
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,10 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Musisz zalogować się ponownie, aby wyświetlić tę stronę"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +128,7 @@ msgstr "Nieprawidłowy token potwierdzania adresu e-mail."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s jest już powiązany z kontem."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -146,7 +142,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -201,7 +197,7 @@ msgstr "Instrukcje potwierdzenia adresu e-mail zostały wysłane na adres %(emai
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -282,13 +278,13 @@ msgstr "Zostałeś zalogowany pomyślnie."
 msgid "Forgot password?"
 msgstr "Zapomniałeś hasło?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Ustawiono nowe hasło i zostałeś zalogowany pomyślnie."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -343,8 +339,8 @@ msgid "Marked method is not valid"
 msgstr "Wybrana metoda jest niewłaściwa"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Pomyślnie wyłączyłeś logowanie dwuskładnikowe."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -372,14 +368,14 @@ msgstr "Musisz ustawić prawidłowy identyfikator, aby się zalogować"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Użyj tego kodu, aby się zalogować: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -466,7 +462,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -477,7 +473,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Ustaw przy pomocy zewnętrznej aplikacji uwierzytelniania (np. Google, "
@@ -488,6 +484,8 @@ msgid "Change Method"
 msgstr "Zmień metodę"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Zmień hasło"
 
@@ -516,8 +514,10 @@ msgid "Identity"
 msgstr "Identyfikator"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Zaloguj"
 
@@ -546,7 +546,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Zarejestruj"
 
@@ -575,8 +576,8 @@ msgid "Send Code"
 msgstr "Wyślij kod"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Zaloguj"
 
@@ -624,19 +625,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Dostępne metody"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -660,11 +661,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -680,15 +681,15 @@ msgstr "Poprzez adres e-mail"
 msgid "Via SMS"
 msgstr "Poprzez wiadomość SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -704,11 +705,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -725,12 +726,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -753,166 +756,171 @@ msgstr "Zapomniałem hasło"
 msgid "Confirm account"
 msgstr "Potwierdź konto"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Zmień hasło"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Wyślij instrukcje resetowania hasła"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Resetuj hasło"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Ponownie wyślij instrukcje potwierdzania rejestracji"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr ""
-"Uwierzytelnianie dwuskładnikowe jest dodatkową warstwą bezpieczeństwa dla"
-" Twojego konta"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Kod uwierzytelniania dwuskładnikowego"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Uwierzytelnianie dwuskładnikowe"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Kod uwierzytelniania został do Ciebie wysłany na adres e-mail"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -929,25 +937,29 @@ msgstr "Żadna z metod nie została włączona"
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Zażądaj jednorazowego wysłania kodu"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Kod został wysłany"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -971,6 +983,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -980,31 +996,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1031,14 +1045,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Prosimy o potwierdzenie Twojego adresu e-mail poprzez poniższy link:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Potwierdź moje konto"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1065,10 +1083,19 @@ msgstr "Kliknij tutaj, aby zresetować swoje hasło"
 msgid "Click the link below to reset your password:"
 msgstr "Kliknij na poniższy link, aby zresetować swoje hasło:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Możesz logować się na swoje konto używając poniższego kodu:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1076,14 +1103,24 @@ msgid "can not access mail account"
 msgstr "brak dostępu do konta mailowego"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Możesz logować się na swoje konto używając poniższego kodu:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Lub używając poniższego linku:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1105,11 +1142,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Możesz potwierdzić swój adres e-mail poprzez poniższy link:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1134,11 +1166,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1149,7 +1180,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1290,3 +1324,94 @@ msgstr ""
 #~ msgstr ""
 #~ "Dziękujemy. Instrukcje potwierdzenia rejestracji "
 #~ "zostały wysłane na adres %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Logowanie dwuskładnikowe"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Pomoc w logowaniu dwuskładnikowym"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Musisz zalogować się ponownie, aby wyświetlić tę stronę"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Pomyślnie wyłączyłeś logowanie dwuskładnikowe."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "Uwierzytelnianie dwuskładnikowe jest dodatkową "
+#~ "warstwą bezpieczeństwa dla Twojego konta"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Kod uwierzytelniania dwuskładnikowego"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Uwierzytelnianie dwuskładnikowe"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Zmień hasło"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Potwierdź moje konto"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Możesz logować się na swoje konto używając poniższego kodu:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Możesz logować się na swoje konto używając poniższego kodu:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Lub używając poniższego linku:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Prosimy o potwierdzenie Twojego adresu e-mail poprzez poniższy link:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Możesz potwierdzić swój adres e-mail poprzez poniższy link:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Użyj tego kodu, aby się zalogować: %(code)s."

--- a/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2017-09-27 23:39-0300\n"
 "Last-Translator: José Neto <josenetodino@gmail.com>\n"
 "Language: pt_BR\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Login obrigatório"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Bem-vindo"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,11 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Por favor, reautentique-se para acessar esta página."
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -133,7 +128,7 @@ msgstr "Token de confirmação inválido."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s já está associado a uma conta."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -145,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -200,7 +195,7 @@ msgstr "As instruções de confirmaç foram enviadas para %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -280,13 +275,13 @@ msgstr "Você logou com sucesso."
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Você redefiniu sua senha com sucesso e foi logado automaticamente."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -341,7 +336,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -368,14 +363,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -462,7 +457,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -473,7 +468,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -482,6 +477,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Alterar senha"
 
@@ -510,8 +507,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Login"
 
@@ -540,7 +539,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registro"
 
@@ -569,8 +569,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -618,19 +618,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -654,11 +654,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -674,15 +674,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -698,11 +698,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -719,12 +719,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -747,164 +749,171 @@ msgstr "Esqueceu a senha"
 msgid "Confirm account"
 msgstr "Confirmar conta"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Alterar senha"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Enviar instruções para redefinir a senha"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Redefinir senha"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Reenviar instruções de confirmação"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -921,25 +930,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -963,6 +976,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -972,31 +989,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1021,14 +1036,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Por favor, confirme seu email através do link abaixo:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Confirmar minha conta"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1055,9 +1074,18 @@ msgstr "Clique aqui para redefinir sua senha"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1066,13 +1094,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1095,11 +1133,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Você pode confirmar seu email através do link abaixo:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1124,11 +1157,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1139,7 +1171,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1272,3 +1307,92 @@ msgstr ""
 #~ msgstr ""
 #~ "Obrigado. As instruções para a "
 #~ "confirmação foram enviadas para %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Por favor, reautentique-se para acessar esta página."
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr ""
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Alterar senha"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Confirmar minha conta"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Por favor, confirme seu email através do link abaixo:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Você pode confirmar seu email através do link abaixo:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2018-04-27 14:00+0100\n"
 "Last-Translator: Micael Grilo <micael.grilo@outlook.com>\n"
 "Language: pt_PT\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "Login obrigatório"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Bem-vindo"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,11 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Por favor, reautentique-se para aceder esta página."
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -133,7 +128,7 @@ msgstr "Token de confirmação inválido."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s já está associado a uma conta."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -145,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -202,7 +197,7 @@ msgstr "As instruções de confirmação foram enviadas para %(email)s."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -281,7 +276,7 @@ msgstr "Sessão iniciada com sucesso."
 msgid "Forgot password?"
 msgstr "Esqueceu a palavra-passe?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -289,7 +284,7 @@ msgstr ""
 "Redefiniu a sua palavra-passe com sucesso e iniciou sessão "
 "automaticamente."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -344,7 +339,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -371,14 +366,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -465,7 +460,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -476,7 +471,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -485,6 +480,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Alterar palavra-passe"
 
@@ -513,8 +510,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Login"
 
@@ -543,7 +542,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Registo"
 
@@ -572,8 +572,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -621,19 +621,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -657,11 +657,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -677,15 +677,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -701,11 +701,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -722,12 +722,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -750,164 +752,171 @@ msgstr "Esqueceu a palavra-passe"
 msgid "Confirm account"
 msgstr "Confirmar conta"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Alterar palavra-passe"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Enviar instruções para redefinir a palavra-passe"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Redefinir palavra-passe"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Reenviar instruções de confirmação"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -924,25 +933,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -966,6 +979,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -975,31 +992,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1024,14 +1039,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Por favor, confirme o seu email através do endereço abaixo:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Confirmar minha conta"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1058,9 +1077,18 @@ msgstr "Clique aqui para redefinir a sua palavra-passe"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1069,13 +1097,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1098,11 +1136,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Você pode confirmar o seu email através do endereço abaixo:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1127,11 +1160,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1142,7 +1174,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1275,3 +1310,92 @@ msgstr ""
 #~ msgstr ""
 #~ "Obrigado. As instruções para a "
 #~ "confirmação foram enviadas para %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Por favor, reautentique-se para aceder esta página."
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr ""
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Alterar palavra-passe"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Confirmar minha conta"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Por favor, confirme o seu email através do endereço abaixo:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Você pode confirmar o seu email através do endereço abaixo:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2024-05-26 04:58+0530\n"
 "Last-Translator: Ivan Fedorov <inbox@titaniumhocker.ru>\n"
 "Language: ru_RU\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -29,10 +29,6 @@ msgid "Login Required"
 msgstr "Требуется авторизация"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
@@ -68,12 +64,12 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "Двухфакторный вход"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
-msgstr "Двухфакторное восстановление"
+msgid "Two-Factor Rescue"
+msgstr ""
 
 #: flask_security/core.py:350
 msgid "Verification Code"
@@ -89,7 +85,7 @@ msgstr ""
 "Аутентификация не удалась — идентификатор или пароль/код доступа "
 "недействительны"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -110,10 +106,10 @@ msgid "You must sign in to view this resource."
 msgstr "Вы должны авторизоваться, чтобы просмотреть этот ресурс."
 
 #: flask_security/core.py:418
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Пожалуйста, войдите повторно чтобы получить доступ к этой странице"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -139,7 +135,7 @@ msgstr "Неверный токен для подтверждения аккау
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s уже привязан к другому аккаунту."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -153,7 +149,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr "Идентификация %(id)s не зарегистрирована"
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -210,7 +206,7 @@ msgstr "Инструкции по подтверждению были отпра
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Вы не подтвердили свое письмо в пределах %(within)s. "
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -289,13 +285,13 @@ msgstr "Вы успешно вошли в систему."
 msgid "Forgot password?"
 msgstr "Забыли пароль?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Вы успешно сбросили пароль и автоматически вошли в систему."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -352,8 +348,8 @@ msgid "Marked method is not valid"
 msgstr "Отмеченный метод недействителен"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "Вы успешно отключили двухфакторную авторизацию."
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -381,14 +377,14 @@ msgstr "Вы должны указать действительный идент
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "Используйте данный код для входа: %(code)s."
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -483,7 +479,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr "Изменение email адреса подтверждено"
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -496,7 +492,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 "Настроить с помощью приложения для аутентификации (например google, "
@@ -507,6 +503,8 @@ msgid "Change Method"
 msgstr "Изменить метод"
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Сменить пароль"
 
@@ -535,8 +533,10 @@ msgid "Identity"
 msgstr "Идентификатор"
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Войти"
 
@@ -565,7 +565,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Зарегистрироваться"
 
@@ -594,8 +595,8 @@ msgid "Send Code"
 msgstr "Отправить код"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Войти"
 
@@ -643,19 +644,19 @@ msgstr "пароль"
 msgid "none"
 msgstr "ничего"
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr "Доступные методы"
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
-msgstr "Отключить двухфакторную аутентификацию"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
+msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Проблемы с доступом к аккаунту?/Утеряно мобильное устройство?"
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr "Связаться с администратором"
 
@@ -679,11 +680,11 @@ msgstr "Доступные методы двухфакторной аутент�
 msgid "Select"
 msgstr "Выбрать"
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr "Отправить код по email"
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr "Использовать ранее загруженный код восстановления"
 
@@ -699,15 +700,15 @@ msgstr "По электронной почте"
 msgid "Via SMS"
 msgstr "По СМС"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr "Настроить дополнительный метод входа"
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr "Удаление активной опции входа"
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr "Псевдоним"
 
@@ -723,11 +724,11 @@ msgstr "Использовать как первичный метод аутен
 msgid "Use as a secondary authentication factor"
 msgstr "Использовать как вторичный метод аутентификации"
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr "Начать"
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -744,13 +745,15 @@ msgid "Change Registered Email"
 msgstr "Изменить зарегистрированный Email"
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
-msgstr "Настройка двухфакторной аутентификации"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
+msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
 msgid "Unified Signin Setup"
@@ -772,68 +775,69 @@ msgstr "Забыли пароль"
 msgid "Confirm account"
 msgstr "Подтвердить аккаунт"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
-msgstr "Изменить email"
-
+#: flask_security/templates/security/change_email.html:1
 #: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
+msgstr ""
+
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr "После отправки, на этот новый email адрес будет отправлено подтверждение."
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Сменить пароль"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr "В настоящее время у вас нет пароля — это добавит его."
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Отправить инструкции по сбросу пароля"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr "или"
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr "Использовать WebAuthn для входа"
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr "Войти с помощью WebAuthn"
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr "Использовать Social Oauth для входа"
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
-msgstr "Войти с помощью "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
+msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr "Введите код восстановления"
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr "Коды восстановления"
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
@@ -841,42 +845,44 @@ msgstr ""
 "Обязательно скопируйте их и храните в надёжном месте. Каждый код может "
 "быть использован только один раз."
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr "Генерация новых кодов восстановления"
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Сбросить пароль"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Заново отправить инструкции по подтверждению"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr "Выбрать метод двухфакторной аутентификации"
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
-"Двухфакторная аутентификация добавляет дополнительный уровень "
-"безопасности для вашей учётной записи"
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr "Помимо имени пользователя и пароля, вам нужно будет использовать код."
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Текущий настроенный двухфакторный метод: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -886,57 +892,59 @@ msgstr ""
 "следующий QR-код (или введите код ниже вручную), чтобы начать получать "
 "коды:"
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "Код двухфакторной аутентификации"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr "Введите код, чтобы завершить настройку"
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr "введите цифровой код"
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr "Это приложение поддерживает настройку кодов восстановления."
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr "Вы можете настроить их здесь."
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr "WebAuthn"
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr "Это приложение поддерживает ключи безопасности WebAuthn."
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "Двухфакторная аутентификация"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Пожалуйста, введите код аутентификации, сгенерированный через: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "Код аутентификации был отправлен вам на адрес электронной почты"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr "Нам было отправлен email, чтобы сбросить настройки вашей учетной записи"
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Настроить единый вход"
@@ -953,25 +961,29 @@ msgstr "Никакие методы не были включены — нече�
 msgid "Enter code here to complete setup"
 msgstr "Введите код, чтобы завершить настройку"
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "Запросить одноразовый код"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
-msgstr "Пожалуйста, повторите аутентификацию"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
+msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "Код отправлен"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr "Использовать ключ безопасности WebAuthn для повторной аутентификации"
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr "Настроить новый ключ WebAuthn"
@@ -1000,6 +1012,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr "Удалить существующий ключ безопасности WebAuthn"
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr "Войти с помощью ключа безопасности WebAuthn"
@@ -1011,32 +1027,30 @@ msgstr ""
 "духфакторной аутентификации"
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
-msgstr "Пожалуйста, повторите аутентификацию, используя ключ безопасности WebAuthn"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
+msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
-msgstr "Пожалуйста, подтвердите свой новый email адрес, нажав на ссылку ниже:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
+msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr "Подтвердить мой новый email"
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr "Срок действия этой ссылки истекает через %(within)s."
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr "Ваш текущий зарегистрированный email адрес — %(email)s."
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
-msgstr "Пожалуйста, подтвердите свой новый email по ссылке ниже:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
+msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
 #: flask_security/templates/security/email/change_notice.txt:1
@@ -1062,14 +1076,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Пожалуйста, подтвердите свой email перейдя по ссылке:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Подтвердить аккаунт"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1096,10 +1114,19 @@ msgstr "Нажмите, чтобы сбросить свой пароль"
 msgid "Click the link below to reset your password:"
 msgstr "Нажмите на ссылку ниже для сброса пароля:"
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "Вы можете войти в свою учётную запись с помощью следующего кода:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1107,14 +1134,24 @@ msgid "can not access mail account"
 msgstr "не может получить доступ к почтовой учетной записи"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "Вы можете войти в свою учетную запись с помощью следующего кода:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "Или используйте ссылку:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1136,11 +1173,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "Вы можете подтвердить свой почтовый адрес перейдя по ссылке:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1169,12 +1201,11 @@ msgstr ""
 "%(username)s."
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr "Если вы забыли свой пароль, вы можете восстановить его"
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
-msgstr " тут."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
+msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
 #, python-format
@@ -1186,10 +1217,11 @@ msgstr ""
 "%(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
-"Если вы забыли свой пароль, вы можете восстановить его по следующей "
-"ссылке:"
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
@@ -1316,3 +1348,100 @@ msgstr "Пожалуйста, повторите процесс регистра
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "Спасибо. Инструкции по подтверждению были отправлены на %(email)s."
+
+#~ msgid "Two-factor Login"
+#~ msgstr "Двухфакторный вход"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr "Двухфакторное восстановление"
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Пожалуйста, войдите повторно чтобы получить доступ к этой странице"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "Вы успешно отключили двухфакторную авторизацию."
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr "Отключить двухфакторную аутентификацию"
+
+#~ msgid "Two Factor Setup"
+#~ msgstr "Настройка двухфакторной аутентификации"
+
+#~ msgid "Sign in with "
+#~ msgstr "Войти с помощью "
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr "Выбрать метод двухфакторной аутентификации"
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+#~ "Двухфакторная аутентификация добавляет "
+#~ "дополнительный уровень безопасности для вашей"
+#~ " учётной записи"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "Код двухфакторной аутентификации"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "Двухфакторная аутентификация"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr "Пожалуйста, повторите аутентификацию"
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+#~ "Пожалуйста, повторите аутентификацию, используя "
+#~ "ключ безопасности WebAuthn"
+
+#~ msgid "Change email"
+#~ msgstr "Изменить email"
+
+#~ msgid "Change password"
+#~ msgstr "Сменить пароль"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr "Пожалуйста, подтвердите свой новый email адрес, нажав на ссылку ниже:"
+
+#~ msgid "Confirm my new email"
+#~ msgstr "Подтвердить мой новый email"
+
+#~ msgid "Confirm my account"
+#~ msgstr "Подтвердить аккаунт"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "Вы можете войти в свою учётную запись с помощью следующего кода:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "Вы можете войти в свою учетную запись с помощью следующего кода:"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "Или используйте ссылку:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr "Пожалуйста, подтвердите свой новый email по ссылке ниже:"
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Пожалуйста, подтвердите свой email перейдя по ссылке:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "Вы можете подтвердить свой почтовый адрес перейдя по ссылке:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr "Если вы забыли свой пароль, вы можете восстановить его"
+
+#~ msgid " here."
+#~ msgstr " тут."
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+#~ "Если вы забыли свой пароль, вы "
+#~ "можете восстановить его по следующей "
+#~ "ссылке:"
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "Используйте данный код для входа: %(code)s."

--- a/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2018-12-20 18:48+0300\n"
 "Last-Translator: Ecmel B. Canlıer <me@ecmelberk.com>\n"
 "Language: tr_TR\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -27,10 +27,6 @@ msgid "Login Required"
 msgstr "Giriş yapmanız gerekmektedir"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "Hoş Geldiniz"
 
@@ -66,11 +62,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
+msgid "Two-Factor Login"
 msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -85,7 +81,7 @@ msgstr ""
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -104,11 +100,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "Bu sayfaya erişebilmek için lütfen tekrardan giriş yapın."
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -132,7 +127,7 @@ msgstr "Yanlış onaylama kodu."
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s başka bir hesaba bağlı."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -144,7 +139,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -199,7 +194,7 @@ msgstr "Onaylama talimatları %(email)s adresine gönderilmiştir."
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -278,13 +273,13 @@ msgstr "Başarıyla giriş yaptınız."
 msgid "Forgot password?"
 msgstr "Şifrenizi mi unuttunuz?"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Şifreniz yenilenmiştir ve otomatik olarak giriş yapmış bulunmaktasınız."
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -339,7 +334,7 @@ msgid "Marked method is not valid"
 msgstr ""
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
+msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
@@ -366,14 +361,14 @@ msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
+msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -460,7 +455,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -471,7 +466,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
 
@@ -480,6 +475,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "Şifre Değiştir"
 
@@ -508,8 +505,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "Giriş Yap"
 
@@ -538,7 +537,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "Kayıt Ol"
 
@@ -567,8 +567,8 @@ msgid "Send Code"
 msgstr ""
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr ""
 
@@ -616,19 +616,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -652,11 +652,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -672,15 +672,15 @@ msgstr ""
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -696,11 +696,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -717,12 +717,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -745,164 +747,171 @@ msgstr "Şifremi unuttum"
 msgid "Confirm account"
 msgstr "Hesabı onayla"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "Şifre değiştir"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "Şifre değiştirme talimatlarını gönder"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "Şifre yenile"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "Onaylama talimatlarını tekrar gönder"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
+#: flask_security/templates/security/two_factor_verify_code.html:1
+#: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:7
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -919,25 +928,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -961,6 +974,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -970,31 +987,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1019,14 +1034,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "Lütfen e-posta adresinizi aşağıdaki linkten onaylayınız:"
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "Hesabımı onayla"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1053,9 +1072,18 @@ msgstr "Şifreni yenilemek için buraya tıkla"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
@@ -1064,13 +1092,23 @@ msgid "can not access mail account"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
@@ -1093,11 +1131,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "E-posta adresinizi aşağıdaki linkten onaylayabilirsiniz:"
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1122,11 +1155,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1137,7 +1169,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1270,3 +1305,92 @@ msgstr ""
 #~ msgstr ""
 #~ "Teşekkür ederiz. Onaylama talimatları "
 #~ "%(email)s adresine gönderilmiştir."
+
+#~ msgid "Two-factor Login"
+#~ msgstr ""
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "Bu sayfaya erişebilmek için lütfen tekrardan giriş yapın."
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr ""
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr ""
+
+#~ msgid "Two factor authentication code"
+#~ msgstr ""
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr ""
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "Şifre değiştir"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "Hesabımı onayla"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr ""
+
+#~ msgid "Or use the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "Lütfen e-posta adresinizi aşağıdaki linkten onaylayınız:"
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "E-posta adresinizi aşağıdaki linkten onaylayabilirsiniz:"
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr ""

--- a/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2025-01-14 08:09-0800\n"
+"POT-Creation-Date: 2025-02-08 07:02-0800\n"
 "PO-Revision-Date: 2018-08-02 19:55+0800\n"
 "Last-Translator: SteinKuo <guoming054@gmail.com>\n"
 "Language: zh_CN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: flask_security/core.py:245
 msgid "Confirm your new email address"
@@ -28,10 +28,6 @@ msgid "Login Required"
 msgstr "需要登录"
 
 #: flask_security/core.py:297
-#: flask_security/templates/security/email/two_factor_instructions.html:1
-#: flask_security/templates/security/email/two_factor_instructions.txt:1
-#: flask_security/templates/security/email/us_instructions.html:9
-#: flask_security/templates/security/email/us_instructions.txt:9
 msgid "Welcome"
 msgstr "欢迎"
 
@@ -67,11 +63,11 @@ msgid "Your requested username"
 msgstr ""
 
 #: flask_security/core.py:307
-msgid "Two-factor Login"
-msgstr "双因素认证登录"
+msgid "Two-Factor Login"
+msgstr ""
 
 #: flask_security/core.py:308
-msgid "Two-factor Rescue"
+msgid "Two-Factor Rescue"
 msgstr ""
 
 #: flask_security/core.py:350
@@ -86,7 +82,7 @@ msgstr "输入信息不适合所请求的API"
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:403
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -105,11 +101,10 @@ msgid "You must sign in to view this resource."
 msgstr ""
 
 #: flask_security/core.py:418
-#, fuzzy
-msgid "You must re-authenticate to access this endpoint"
-msgstr "请重新进行身份验证，以访问此页面。"
+msgid "You must reauthenticate to access this endpoint"
+msgstr ""
 
-#: flask_security/core.py:422
+#: flask_security/core.py:423
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -133,7 +128,7 @@ msgstr "无效验证码！"
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s 已关联账户。"
 
-#: flask_security/core.py:437
+#: flask_security/core.py:438
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -145,7 +140,7 @@ msgstr ""
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:448
+#: flask_security/core.py:449
 #, python-format
 msgid ""
 "An error occurred while communicating with the Oauth provider: "
@@ -200,7 +195,7 @@ msgstr "激活邮件已发送到  %(email)s。"
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:480
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -278,13 +273,13 @@ msgstr "你已成功登录！"
 msgid "Forgot password?"
 msgstr "忘记密码？"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:513
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "你的密码已成功重置，并已自动登录。"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:520
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -339,8 +334,8 @@ msgid "Marked method is not valid"
 msgstr "选择的方法无效"
 
 #: flask_security/core.py:551
-msgid "You successfully disabled two factor authorization."
-msgstr "你成功地禁用了双因素授权。"
+msgid "You successfully disabled two-factor authorization."
+msgstr ""
 
 #: flask_security/core.py:555 flask_security/core.py:564
 #, python-format
@@ -366,14 +361,14 @@ msgstr "您必须指定一个有效的身份才能登录"
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Use this code to sign in: %(code)s."
-msgstr "使用此代码登录：%(code)s"
+msgid "Use this code to sign in: %(code)s"
+msgstr ""
 
 #: flask_security/core.py:570
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:572
+#: flask_security/core.py:573
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -460,7 +455,7 @@ msgstr ""
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:648
+#: flask_security/core.py:649
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -471,7 +466,7 @@ msgstr ""
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
-#: flask_security/forms.py:61
+#: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr "设置一个认证的app（例如：google、lastpass、authy）"
 
@@ -480,6 +475,8 @@ msgid "Change Method"
 msgstr ""
 
 #: flask_security/forms.py:65 flask_security/templates/security/_menu.html:14
+#: flask_security/templates/security/change_password.html:1
+#: flask_security/templates/security/change_password.html:7
 msgid "Change Password"
 msgstr "更改密码"
 
@@ -508,8 +505,10 @@ msgid "Identity"
 msgstr ""
 
 #: flask_security/forms.py:72 flask_security/templates/security/_menu.html:45
-#: flask_security/templates/security/login_user.html:6
-#: flask_security/templates/security/send_login.html:6
+#: flask_security/templates/security/login_user.html:1
+#: flask_security/templates/security/login_user.html:7
+#: flask_security/templates/security/send_login.html:1
+#: flask_security/templates/security/send_login.html:7
 msgid "Login"
 msgstr "登录"
 
@@ -538,7 +537,8 @@ msgid "Recover Username"
 msgstr ""
 
 #: flask_security/forms.py:79 flask_security/templates/security/_menu.html:55
-#: flask_security/templates/security/register_user.html:6
+#: flask_security/templates/security/register_user.html:1
+#: flask_security/templates/security/register_user.html:7
 msgid "Register"
 msgstr "注册"
 
@@ -567,8 +567,8 @@ msgid "Send Code"
 msgstr "发送代码"
 
 #: flask_security/forms.py:86
-#: flask_security/templates/security/email/us_instructions.html:14
-#: flask_security/templates/security/us_signin.html:6
+#: flask_security/templates/security/us_signin.html:1
+#: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "登录"
 
@@ -616,19 +616,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:929 flask_security/unified_signin.py:167
+#: flask_security/forms.py:947 flask_security/unified_signin.py:167
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:931
-msgid "Disable two factor authentication"
+#: flask_security/forms.py:949
+msgid "Disable two-factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:1015
+#: flask_security/forms.py:1040
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:1017
+#: flask_security/forms.py:1042
 msgid "Contact Administrator"
 msgstr ""
 
@@ -652,11 +652,11 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: flask_security/twofactor.py:135
+#: flask_security/twofactor.py:137
 msgid "Send code via email"
 msgstr ""
 
-#: flask_security/twofactor.py:147
+#: flask_security/twofactor.py:150
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
@@ -672,15 +672,15 @@ msgstr "通过邮件"
 msgid "Via SMS"
 msgstr "通过SMS"
 
-#: flask_security/unified_signin.py:298
+#: flask_security/unified_signin.py:301
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:311
+#: flask_security/unified_signin.py:314
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:122 flask_security/webauthn.py:356
+#: flask_security/webauthn.py:122 flask_security/webauthn.py:367
 msgid "Nickname"
 msgstr ""
 
@@ -696,11 +696,11 @@ msgstr ""
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:218
+#: flask_security/webauthn.py:223
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:934
+#: flask_security/webauthn.py:947
 msgid "webauthn"
 msgstr ""
 
@@ -717,12 +717,14 @@ msgid "Change Registered Email"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:24
-#: flask_security/templates/security/change_username.html:6
+#: flask_security/templates/security/change_username.html:1
+#: flask_security/templates/security/change_username.html:7
 msgid "Change Username"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:29
-msgid "Two Factor Setup"
+#: flask_security/templates/security/two_factor_setup.html:21
+msgid "Two-Factor Setup"
 msgstr ""
 
 #: flask_security/templates/security/_menu.html:34
@@ -745,164 +747,171 @@ msgstr "忘记密码"
 msgid "Confirm account"
 msgstr "激活账户"
 
-#: flask_security/templates/security/change_email.html:6
-msgid "Change email"
+#: flask_security/templates/security/change_email.html:1
+#: flask_security/templates/security/change_email.html:7
+msgid "Change Email"
 msgstr ""
 
-#: flask_security/templates/security/change_email.html:7
+#: flask_security/templates/security/change_email.html:8
 msgid ""
 "Once submitted, an email confirmation will be sent to this new email "
 "address."
 msgstr ""
 
-#: flask_security/templates/security/change_password.html:6
-msgid "Change password"
-msgstr "更改密码"
-
-#: flask_security/templates/security/change_password.html:13
+#: flask_security/templates/security/change_password.html:14
 msgid "You do not currently have a password - this will add one."
 msgstr ""
 
-#: flask_security/templates/security/change_username.html:8
+#: flask_security/templates/security/change_username.html:9
 #, python-format
 msgid "Current username is: %(username)s"
 msgstr ""
 
-#: flask_security/templates/security/forgot_password.html:6
+#: flask_security/templates/security/forgot_password.html:1
+#: flask_security/templates/security/forgot_password.html:7
 msgid "Send password reset instructions"
 msgstr "发送密码重置邮件"
 
-#: flask_security/templates/security/login_user.html:13
+#: flask_security/templates/security/login_user.html:14
 msgid "or"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:23
-#: flask_security/templates/security/us_signin.html:25
+#: flask_security/templates/security/login_user.html:24
+#: flask_security/templates/security/us_signin.html:26
 msgid "Use WebAuthn to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:26
-#: flask_security/templates/security/us_signin.html:28
+#: flask_security/templates/security/login_user.html:27
+#: flask_security/templates/security/us_signin.html:29
 msgid "Sign in with WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:32
-#: flask_security/templates/security/us_signin.html:34
+#: flask_security/templates/security/login_user.html:33
+#: flask_security/templates/security/us_signin.html:35
 msgid "Use Social Oauth to Sign In"
 msgstr ""
 
-#: flask_security/templates/security/login_user.html:36
-#: flask_security/templates/security/us_signin.html:38
-msgid "Sign in with "
+#: flask_security/templates/security/login_user.html:37
+#: flask_security/templates/security/us_signin.html:39
+#, python-format
+msgid "Sign in with %(provider)s"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery.html:6
+#: flask_security/templates/security/mf_recovery.html:1
+#: flask_security/templates/security/mf_recovery.html:7
 msgid "Enter Recovery Code"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:79
-#: flask_security/templates/security/wan_register.html:75
+#: flask_security/templates/security/mf_recovery_codes.html:1
+#: flask_security/templates/security/mf_recovery_codes.html:7
+#: flask_security/templates/security/two_factor_setup.html:81
+#: flask_security/templates/security/wan_register.html:76
 msgid "Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:12
+#: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
 "Be sure to copy these and store in a safe place. Each code can be used "
 "only once."
 msgstr ""
 
-#: flask_security/templates/security/mf_recovery_codes.html:20
+#: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
 msgstr ""
 
-#: flask_security/templates/security/recover_username.html:6
-msgid "Username recovery"
+#: flask_security/templates/security/recover_username.html:1
+#: flask_security/templates/security/recover_username.html:7
+msgid "Username Recovery"
 msgstr ""
 
-#: flask_security/templates/security/reset_password.html:6
+#: flask_security/templates/security/reset_password.html:1
+#: flask_security/templates/security/reset_password.html:7
 msgid "Reset password"
 msgstr "重置密码"
 
-#: flask_security/templates/security/send_confirmation.html:6
+#: flask_security/templates/security/send_confirmation.html:1
+#: flask_security/templates/security/send_confirmation.html:7
 msgid "Resend confirmation instructions"
 msgstr "重新发送激活邮件"
 
-#: flask_security/templates/security/two_factor_select.html:6
-msgid "Select Two Factor Method"
+#: flask_security/templates/security/two_factor_select.html:1
+#: flask_security/templates/security/two_factor_select.html:7
+msgid "Select Two-Factor Method"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:27
-msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr "双因素认证为您的账户增加了一层额外的安全保障。"
-
 #: flask_security/templates/security/two_factor_setup.html:28
+msgid "Two-Factor authentication adds an extra layer of security to your account"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:32
+#: flask_security/templates/security/two_factor_setup.html:33
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:51
+#: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr "打开设备上的身份验证应用，扫描以下二维码(或手动输入以下代码)开始接收代码："
 
-#: flask_security/templates/security/two_factor_setup.html:54
-msgid "Two factor authentication code"
-msgstr "双因素验证代码"
+#: flask_security/templates/security/two_factor_setup.html:55
+msgid "Two-Factor authentication code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:65
+#: flask_security/templates/security/two_factor_setup.html:66
 msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:73
-#: flask_security/templates/security/two_factor_verify_code.html:10
+#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_verify_code.html:11
 msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:81
-#: flask_security/templates/security/wan_register.html:77
+#: flask_security/templates/security/two_factor_setup.html:83
+#: flask_security/templates/security/wan_register.html:78
 msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:82
-#: flask_security/templates/security/two_factor_setup.html:90
-#: flask_security/templates/security/us_setup.html:89
-#: flask_security/templates/security/wan_register.html:78
+#: flask_security/templates/security/two_factor_setup.html:84
+#: flask_security/templates/security/two_factor_setup.html:92
+#: flask_security/templates/security/us_setup.html:90
+#: flask_security/templates/security/wan_register.html:79
 msgid "You can set them up here."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:87
+#: flask_security/templates/security/two_factor_setup.html:89
 msgid "WebAuthn"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:89
-#: flask_security/templates/security/us_setup.html:88
+#: flask_security/templates/security/two_factor_setup.html:91
+#: flask_security/templates/security/us_setup.html:89
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:6
-msgid "Two-factor Authentication"
-msgstr "双因素授权"
-
+#: flask_security/templates/security/two_factor_verify_code.html:1
 #: flask_security/templates/security/two_factor_verify_code.html:7
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_verify_code.html:8
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:19
+#: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "The code for authentication was sent to your email address"
 msgstr "认证代码已发送至您的电子邮件地址。"
 
-#: flask_security/templates/security/two_factor_verify_code.html:22
+#: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
+#: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
@@ -919,25 +928,29 @@ msgstr ""
 msgid "Enter code here to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/us_signin.html:15
-#: flask_security/templates/security/us_verify.html:12
+#: flask_security/templates/security/us_signin.html:16
+#: flask_security/templates/security/us_verify.html:13
 msgid "Request one-time code be sent"
 msgstr "要求发送一次性代码"
 
-#: flask_security/templates/security/us_verify.html:6
-#: flask_security/templates/security/verify.html:6
-msgid "Please Reauthenticate"
+#: flask_security/templates/security/us_verify.html:1
+#: flask_security/templates/security/us_verify.html:7
+#: flask_security/templates/security/verify.html:1
+#: flask_security/templates/security/verify.html:7
+#: flask_security/templates/security/wan_verify.html:9
+msgid "Reauthenticate"
 msgstr ""
 
-#: flask_security/templates/security/us_verify.html:17
+#: flask_security/templates/security/us_verify.html:18
 msgid "Code has been sent"
 msgstr "代码已经发送"
 
-#: flask_security/templates/security/us_verify.html:25
-#: flask_security/templates/security/verify.html:14
+#: flask_security/templates/security/us_verify.html:26
+#: flask_security/templates/security/verify.html:15
 msgid "Use a WebAuthn Security Key to Reauthenticate"
 msgstr ""
 
+#: flask_security/templates/security/wan_register.html:4
 #: flask_security/templates/security/wan_register.html:16
 msgid "Setup New WebAuthn Security Key"
 msgstr ""
@@ -961,6 +974,10 @@ msgstr ""
 msgid "Delete Existing WebAuthn Security Key"
 msgstr ""
 
+#: flask_security/templates/security/wan_signin.html:4
+msgid "WebAuthn Security Key"
+msgstr ""
+
 #: flask_security/templates/security/wan_signin.html:17
 msgid "Sign In Using WebAuthn Security Key"
 msgstr ""
@@ -970,31 +987,29 @@ msgid "Use Your WebAuthn Security Key as a Second Factor"
 msgstr ""
 
 #: flask_security/templates/security/wan_verify.html:21
-msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+msgid "Reauthenticate Using Your WebAuthn Security Key"
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.html:8
-msgid "Please confirm your new email address by clicking on the link below:"
+#, python-format
+msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:10
-msgid "Confirm my new email"
-msgstr ""
-
-#: flask_security/templates/security/email/change_email_instructions.html:12
-#: flask_security/templates/security/email/change_email_instructions.txt:11
+#: flask_security/templates/security/email/change_email_instructions.html:9
+#: flask_security/templates/security/email/change_email_instructions.txt:9
 #, python-format
 msgid "This link will expire in %(within)s."
 msgstr ""
 
-#: flask_security/templates/security/email/change_email_instructions.html:13
-#: flask_security/templates/security/email/change_email_instructions.txt:13
+#: flask_security/templates/security/email/change_email_instructions.html:10
+#: flask_security/templates/security/email/change_email_instructions.txt:10
 #, python-format
 msgid "Your currently registered email is %(email)s."
 msgstr ""
 
 #: flask_security/templates/security/email/change_email_instructions.txt:8
-msgid "Please confirm your new email through the link below:"
+#, python-format
+msgid "Use %(link)s to confirm your new email address."
 msgstr ""
 
 #: flask_security/templates/security/email/change_notice.html:1
@@ -1019,14 +1034,18 @@ msgid "Your username has been changed."
 msgstr ""
 
 #: flask_security/templates/security/email/confirmation_instructions.html:8
-#: flask_security/templates/security/email/confirmation_instructions.txt:8
-msgid "Please confirm your email through the link below:"
-msgstr "请通过下面链接激活的你的邮箱："
+#: flask_security/templates/security/email/welcome.html:10
+#, python-format
+msgid ""
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
+" address."
+msgstr ""
 
-#: flask_security/templates/security/email/confirmation_instructions.html:10
-#: flask_security/templates/security/email/welcome.html:12
-msgid "Confirm my account"
-msgstr "激活账户"
+#: flask_security/templates/security/email/confirmation_instructions.txt:8
+#: flask_security/templates/security/email/welcome.txt:11
+#, python-format
+msgid "Use %(confirmation_link)s to confirm your email address."
+msgstr ""
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1053,10 +1072,19 @@ msgstr "点击这里重置密码"
 msgid "Click the link below to reset your password:"
 msgstr ""
 
+#: flask_security/templates/security/email/two_factor_instructions.html:1
+#: flask_security/templates/security/email/two_factor_instructions.txt:1
+#: flask_security/templates/security/email/us_instructions.html:9
+#: flask_security/templates/security/email/us_instructions.txt:9
+#, python-format
+msgid "Welcome %(username)s!"
+msgstr ""
+
 #: flask_security/templates/security/email/two_factor_instructions.html:2
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
-msgid "You can log into your account using the following code:"
-msgstr "您可以使用以下代码登录您的账户:"
+#, python-format
+msgid "You can log into your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1064,14 +1092,24 @@ msgid "can not access mail account"
 msgstr "无法进入邮箱"
 
 #: flask_security/templates/security/email/us_instructions.html:10
-#: flask_security/templates/security/email/us_instructions.txt:11
-msgid "You can sign into your account using the following code:"
-msgstr "您可以使用以下代码登录您的账户。"
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s"
+msgstr ""
 
 #: flask_security/templates/security/email/us_instructions.html:12
-#: flask_security/templates/security/email/us_instructions.txt:15
-msgid "Or use the link below:"
-msgstr "或者使用下面的链接:"
+#, python-format
+msgid "Or use this link: <a href=\"%(login_link)s\">Sign in</a>"
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:10
+#, python-format
+msgid "You can sign in to your account using the following code: %(token)s."
+msgstr ""
+
+#: flask_security/templates/security/email/us_instructions.txt:12
+#, python-format
+msgid "Or use this link: %(login_link)s"
+msgstr ""
 
 #: flask_security/templates/security/email/username_recovery.html:5
 #: flask_security/templates/security/email/username_recovery.txt:5
@@ -1093,11 +1131,6 @@ msgstr ""
 #: flask_security/templates/security/email/username_recovery.txt:8
 msgid "If you did not initiate this request, you can safely ignore this email."
 msgstr ""
-
-#: flask_security/templates/security/email/welcome.html:10
-#: flask_security/templates/security/email/welcome.txt:11
-msgid "You can confirm your email through the link below:"
-msgstr "你可以通过下面链接激活你的邮箱："
 
 #: flask_security/templates/security/email/welcome_existing.html:11
 #: flask_security/templates/security/email/welcome_existing.txt:11
@@ -1122,11 +1155,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.html:20
-msgid "If you forgot your password you can reset it"
-msgstr ""
-
-#: flask_security/templates/security/email/welcome_existing.html:21
-msgid " here."
+#, python-format
+msgid ""
+"If you forgot your password you can reset it <a "
+"href=\"%(recovery_link)s\"> here.</a>"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:16
@@ -1137,7 +1169,10 @@ msgid ""
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing.txt:20
-msgid "If you forgot your password you can reset it with the following link:"
+#, python-format
+msgid ""
+"If you forgot your password you can reset it with the following link: "
+"%(recovery_link)s"
 msgstr ""
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
@@ -1262,3 +1297,92 @@ msgstr ""
 
 #~ msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 #~ msgstr "谢谢你。已发送激活邮件到 %(email)s。"
+
+#~ msgid "Two-factor Login"
+#~ msgstr "双因素认证登录"
+
+#~ msgid "Two-factor Rescue"
+#~ msgstr ""
+
+#~ msgid "You must re-authenticate to access this endpoint"
+#~ msgstr "请重新进行身份验证，以访问此页面。"
+
+#~ msgid "You successfully disabled two factor authorization."
+#~ msgstr "你成功地禁用了双因素授权。"
+
+#~ msgid "Disable two factor authentication"
+#~ msgstr ""
+
+#~ msgid "Two Factor Setup"
+#~ msgstr ""
+
+#~ msgid "Sign in with "
+#~ msgstr ""
+
+#~ msgid "Username recovery"
+#~ msgstr ""
+
+#~ msgid "Select Two Factor Method"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Two-factor authentication adds an extra"
+#~ " layer of security to your account"
+#~ msgstr "双因素认证为您的账户增加了一层额外的安全保障。"
+
+#~ msgid "Two factor authentication code"
+#~ msgstr "双因素验证代码"
+
+#~ msgid "Two-factor Authentication"
+#~ msgstr "双因素授权"
+
+#~ msgid "Please Reauthenticate"
+#~ msgstr ""
+
+#~ msgid "Please Re-Authenticate Using Your WebAuthn Security Key"
+#~ msgstr ""
+
+#~ msgid "Change email"
+#~ msgstr ""
+
+#~ msgid "Change password"
+#~ msgstr "更改密码"
+
+#~ msgid "Please confirm your new email address by clicking on the link below:"
+#~ msgstr ""
+
+#~ msgid "Confirm my new email"
+#~ msgstr ""
+
+#~ msgid "Confirm my account"
+#~ msgstr "激活账户"
+
+#~ msgid "You can log into your account using the following code:"
+#~ msgstr "您可以使用以下代码登录您的账户:"
+
+#~ msgid "You can sign into your account using the following code:"
+#~ msgstr "您可以使用以下代码登录您的账户。"
+
+#~ msgid "Or use the link below:"
+#~ msgstr "或者使用下面的链接:"
+
+#~ msgid "Please confirm your new email through the link below:"
+#~ msgstr ""
+
+#~ msgid "Please confirm your email through the link below:"
+#~ msgstr "请通过下面链接激活的你的邮箱："
+
+#~ msgid "You can confirm your email through the link below:"
+#~ msgstr "你可以通过下面链接激活你的邮箱："
+
+#~ msgid "If you forgot your password you can reset it"
+#~ msgstr ""
+
+#~ msgid " here."
+#~ msgstr ""
+
+#~ msgid "If you forgot your password you can reset it with the following link:"
+#~ msgstr ""
+
+#~ msgid "Use this code to sign in: %(code)s."
+#~ msgstr "使用此代码登录：%(code)s"

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -27,6 +27,7 @@ from .utils import (
     base_render_json,
     config_value as cv,
     do_flash,
+    get_message,
     json_error_response,
     send_mail,
     url_for_security,
@@ -70,11 +71,11 @@ def tf_send_security_token(user, method, totp_secret, phone_number):
             username=user.calc_username(),
         )
     elif method == "sms":
-        msg = f"Use this code to log in: {token_to_be_sent}"
+        m, c = get_message("USE_CODE", code=token_to_be_sent)
         from_number = cv("SMS_SERVICE_CONFIG")["PHONE_NUMBER"]
         to_number = phone_number
         sms_sender = SmsSenderFactory.createSender(cv("SMS_SERVICE"))
-        sms_sender.send_sms(from_number=from_number, to_number=to_number, msg=msg)
+        sms_sender.send_sms(from_number=from_number, to_number=to_number, msg=m)
 
     else:
         # password are generated automatically in the authenticator apps or not needed

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -4,7 +4,7 @@ test_changeable
 
 Changeable tests
 
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.changeable()
 
 
 def test_changeable_flag(app, clients, get_message):
-    client = clients
+    tcl = clients
     recorded = []
 
     @password_changed.connect_via(app)
@@ -42,14 +42,14 @@ def test_changeable_flag(app, clients, get_message):
         assert isinstance(user, UserMixin)
         recorded.append(user)
 
-    authenticate(client)
+    authenticate(tcl)
 
     # Test change view
-    response = client.get("/change", follow_redirects=True)
-    assert b"Change password" in response.data
+    response = tcl.get("/change", follow_redirects=True)
+    assert b"Change Password" in response.data
 
     # Test wrong original password
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={
             "password": "notpassword",
@@ -61,7 +61,7 @@ def test_changeable_flag(app, clients, get_message):
     assert get_message("INVALID_PASSWORD") in response.data
 
     # Test mismatch
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={
             "password": "password",
@@ -73,13 +73,13 @@ def test_changeable_flag(app, clients, get_message):
     assert get_message("RETYPE_PASSWORD_MISMATCH") in response.data
 
     # Test missing password
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={"password": "   ", "new_password": "", "new_password_confirm": ""},
         follow_redirects=True,
     )
     assert get_message("PASSWORD_NOT_PROVIDED") in response.data
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={
             "password": "   ",
@@ -91,7 +91,7 @@ def test_changeable_flag(app, clients, get_message):
     assert get_message("PASSWORD_NOT_PROVIDED") in response.data
 
     # Test bad password
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={"password": "password", "new_password": "a", "new_password_confirm": "a"},
         follow_redirects=True,
@@ -99,7 +99,7 @@ def test_changeable_flag(app, clients, get_message):
     assert get_message("PASSWORD_INVALID_LENGTH", length=8) in response.data
 
     # Test same as previous
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={
             "password": "password",
@@ -111,7 +111,7 @@ def test_changeable_flag(app, clients, get_message):
     assert get_message("PASSWORD_IS_THE_SAME") in response.data
 
     # Test successful submit sends email notification
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={
             "password": "password",
@@ -129,7 +129,7 @@ def test_changeable_flag(app, clients, get_message):
     assert "Your password has been changed" in outbox[0].body
 
     # Test leading & trailing whitespace not stripped
-    response = client.post(
+    response = tcl.post(
         "/change",
         data={
             "password": "new strong password",
@@ -146,7 +146,7 @@ def test_changeable_flag(app, clients, get_message):
         '"new_password": "new stronger password2", '
         '"new_password_confirm": "new stronger password2"}'
     )
-    response = client.post(
+    response = tcl.post(
         "/change", data=data, headers={"Content-Type": "application/json"}
     )
     assert response.status_code == 200
@@ -154,7 +154,7 @@ def test_changeable_flag(app, clients, get_message):
 
     # Test JSON errors
     data = '{"password": "newpassword"}'
-    response = client.post(
+    response = tcl.post(
         "/change", data=data, headers={"Content-Type": "application/json"}
     )
     assert response.status_code == 400
@@ -333,7 +333,7 @@ def test_xlation(app, client, get_message_local):
     with app.test_request_context():
         # Check header
         assert (
-            f'<h1>{localize_callback("Change password")}</h1>'.encode() in response.data
+            f'<h1>{localize_callback("Change Password")}</h1>'.encode() in response.data
         )
         submit = localize_callback(_default_field_labels["change_password"])
         assert f'value="{submit}"'.encode() in response.data

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,7 @@ test_misc
 Lots of tests
 
 :copyright: (c) 2012 by Matt Wright.
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -767,7 +767,7 @@ def test_per_request_xlate(app, client):
     response = client.get("/change", follow_redirects=True)
     assert response.status_code == 200
     assert b"Nouveau mot de passe" in response.data
-    assert b"<h1>Changer de mot de passe</h1>" in response.data
+    assert b"<h1>Changer le mot de passe</h1>" in response.data
 
     # try JSON
     response = client.post(

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -4,7 +4,7 @@ test_two_factor
 
 two_factor tests
 
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -239,7 +239,7 @@ def test_tf_reset_invalidates_cookie(app, client):
     data = dict(email="gal@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
 
-    assert b"Two-factor authentication adds an extra layer of security" in response.data
+    assert b"Two-Factor authentication adds an extra layer of security" in response.data
 
     client.delete_cookie("tf_validity")
     # Test JSON
@@ -344,7 +344,7 @@ def test_two_factor_flag(app, clients, get_message):
     # Test two-factor authentication first login
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
-    message = b"Two-factor authentication adds an extra layer of security"
+    message = b"Two-Factor authentication adds an extra layer of security"
     assert message in response.data
     response = client.post(
         "/tf-setup", data=dict(setup="not_a_method"), follow_redirects=True
@@ -464,7 +464,7 @@ def test_two_factor_flag(app, clients, get_message):
     # Test two-factor authentication first login
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
-    message = b"Two-factor authentication adds an extra layer of security"
+    message = b"Two-Factor authentication adds an extra layer of security"
     assert message in response.data
 
     # check availability of qrcode when this option is not picked
@@ -540,7 +540,7 @@ def test_no_rescue_email(app, client):
 def test_setup_bad_phone(app, client, get_message):
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
-    message = b"Two-factor authentication adds an extra layer of security"
+    message = b"Two-Factor authentication adds an extra layer of security"
     assert message in response.data
 
     sms_sender = SmsSenderFactory.createSender("test")
@@ -684,7 +684,7 @@ def test_rescue_json(app, client):
 
     assert outbox[0].to == ["gal2@lp.com"]
     assert outbox[0].from_email == "no-reply@localhost"
-    assert outbox[0].subject == "Two-factor Login"
+    assert outbox[0].subject == "Two-Factor Login"
     matcher = re.match(r".*code: ([0-9]+).*", outbox[0].body, re.IGNORECASE | re.DOTALL)
     response = client.post("/tf-validate", json=dict(code=matcher.group(1)))
     assert response.status_code == 200
@@ -699,7 +699,7 @@ def test_rescue_json(app, client):
 
     assert outbox[1].to == ["helpme@myapp.com"]
     assert outbox[1].from_email == "no-reply@localhost"
-    assert outbox[1].subject == "Two-factor Rescue"
+    assert outbox[1].subject == "Two-Factor Rescue"
     assert "gal2@lp.com" in outbox[1].body
 
 
@@ -856,7 +856,7 @@ def test_opt_in(app, client, get_message):
     # Now opt back out.
     data = dict(setup="disable")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
-    assert b"You successfully disabled two factor authorization." in response.data
+    assert b"You successfully disabled two-factor authorization." in response.data
 
     # Log out
     logout(client)
@@ -992,7 +992,7 @@ def test_opt_in_state_token(app, client, get_message):
     assert not tf_in_session(session)
 
     response = client.get("/tf-setup")
-    assert b"Disable two factor" in response.data
+    assert b"Disable two-factor" in response.data
     assert b"Currently setup two-factor method: SMS" in response.data
 
 
@@ -1199,7 +1199,7 @@ def test_totp_secret_generation(app, client):
     # Finally opt back out and check that tf_totp_secret is None
     data = dict(setup="disable")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
-    assert b"You successfully disabled two factor authorization." in response.data
+    assert b"You successfully disabled two-factor authorization." in response.data
     with app.app_context():
         user = app.security.datastore.find_user(email="jill@lp.com")
         assert user.tf_totp_secret is None
@@ -1419,7 +1419,7 @@ def test_propagate_next(app, client):
 
 @pytest.mark.settings(freshness=timedelta(minutes=0))
 def test_verify(app, client, get_message):
-    # Test setup when re-authenticate required
+    # Test setup when reauthenticate required
     authenticate(client)
     response = client.get("tf-setup", follow_redirects=False)
     assert check_location(app, response.location, "/verify?next=/tf-setup")
@@ -1457,7 +1457,7 @@ def test_verify(app, client, get_message):
 
 
 def test_verify_json(app, client, get_message):
-    # Test setup when re-authenticate required
+    # Test setup when reauthenticate required
     # N.B. with freshness=0 we never set a grace period and should never be able to
     # get to /tf-setup
     authenticate(client)

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -4,7 +4,7 @@ test_unified_signin
 
 Unified signin tests
 
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
 """
@@ -718,10 +718,10 @@ def test_verify_link_spa(app, client, get_message):
 
 
 def test_setup(app, clients, get_message):
-    client = clients
+    tcl = clients
     set_email(app)
-    us_authenticate(client)
-    response = client.get("us-setup")
+    us_authenticate(tcl)
+    response = tcl.get("us-setup")
     # Email should be in delete options since we just set that up.
     assert all(
         i in response.data
@@ -729,16 +729,16 @@ def test_setup(app, clients, get_message):
     )
 
     # test not supplying anything to do
-    response = client.post("us-setup", data=dict(phone="6505551212"))
+    response = tcl.post("us-setup", data=dict(phone="6505551212"))
     assert get_message("API_ERROR") in response.data
 
     # test missing phone
-    response = client.post("us-setup", data=dict(chosen_method="sms", phone=""))
+    response = tcl.post("us-setup", data=dict(chosen_method="sms", phone=""))
     assert response.status_code == 200
     assert get_message("PHONE_INVALID") in response.data
 
     # test invalid phone
-    response = client.post(
+    response = tcl.post(
         "us-setup", data=dict(chosen_method="sms", phone="NOT-A-NUMBER")
     )
     assert response.status_code == 200
@@ -746,7 +746,7 @@ def test_setup(app, clients, get_message):
     assert b"Enter code here to complete setup" not in response.data
 
     sms_sender = SmsSenderFactory.createSender("test")
-    response = client.post(
+    response = tcl.post(
         "us-setup", data=dict(chosen_method="sms", phone="650-555-1212")
     )
     assert response.status_code == 200
@@ -756,11 +756,11 @@ def test_setup(app, clients, get_message):
     verify_url = get_form_action(response, 1)
 
     # Try invalid code
-    response = client.post(verify_url, data=dict(passcode=12345), follow_redirects=True)
+    response = tcl.post(verify_url, data=dict(passcode=12345), follow_redirects=True)
     assert get_message("INVALID_PASSWORD_CODE") in response.data
 
     code = sms_sender.messages[0].split()[-1].strip(".")
-    response = client.post(verify_url, data=dict(passcode=code), follow_redirects=True)
+    response = tcl.post(verify_url, data=dict(passcode=code), follow_redirects=True)
     assert response.status_code == 200
     assert get_message("US_SETUP_SUCCESSFUL") in response.data
 
@@ -1496,7 +1496,7 @@ def test_tf(app, client, get_message):
         follow_redirects=True,
     )
     assert response.status_code == 200
-    message = b"Two-factor authentication adds an extra layer of security"
+    message = b"Two-Factor authentication adds an extra layer of security"
     assert message in response.data
     assert b"Set up using SMS" in response.data
 
@@ -1530,7 +1530,7 @@ def test_tf_link(app, client, get_message):
     magic_link = matcher.group(1)
     response = client.get(magic_link, follow_redirects=True)
     assert get_message("PASSWORDLESS_LOGIN_SUCCESSFUL") not in response.data
-    message = b"Two-factor authentication adds an extra layer of security"
+    message = b"Two-Factor authentication adds an extra layer of security"
     assert message in response.data
 
 

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -22,9 +22,11 @@ data and a mail sender that flashes what mail would be sent!
 """
 from __future__ import annotations
 
+import base64
 from datetime import timedelta
 import os
 import typing as t
+import webbrowser
 
 from flask import Flask, flash, render_template_string, request, session
 from flask_wtf import CSRFProtect
@@ -75,6 +77,10 @@ class FlashMailUtil(MailUtil):
         **kwargs: t.Any,
     ) -> None:
         flash(f"Email body: {body}")
+        if html:
+            hb = html.encode()
+            url = "data:text/html;base64," + base64.b64encode(hb).decode()
+            webbrowser.open(url, new=1)
 
 
 SET_LANG = False


### PR DESCRIPTION
- Two-Factor not Two Factor
- Reauthenticate not Re-authenticate
- For email templates - include link as part of translatable string
- Titles and heading should be capital case