### PR TITLE
Add types and docstrings to utils module

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -474,7 +474,7 @@ def hash_data(data: t.Union[str, bytes]) -> str:
     """Hashes input data after ensuring proper encoding.
 
     :param data: Input data to hash (will be encoded if not already bytes)
-    :return: Hashed data as bytes
+    :return: Hashed data as a string
 
     Note: Uses application's configured _hashing_context
     """
@@ -1279,7 +1279,9 @@ class SmsSenderBaseClass(metaclass=abc.ABCMeta):
 
 
 class DummySmsSender(SmsSenderBaseClass):
-    def send_sms(self, from_number: str, to_number: str, msg: str) -> None:  # pragma: no cover
+    def send_sms(
+        self, from_number: str, to_number: str, msg: str
+    ) -> None:  # pragma: no cover
         """Do nothing."""
         return None
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -470,7 +470,7 @@ def encode_string(string: t.Union[str, bytes]) -> bytes:
     return string
 
 
-def hash_data(data: t.Union[str, bytes]) -> bytes:
+def hash_data(data: t.Union[str, bytes]) -> str:
     """Hashes input data after ensuring proper encoding.
 
     :param data: Input data to hash (will be encoded if not already bytes)


### PR DESCRIPTION
To fix a problem in my project, I dove into the utils module. Just because I was there, I added some docstrings and type hints that were missing. Please let me know if I understood the functions correctly.

I would also suggest splitting the utils file into submodules within `utils/`. That way we could keep the current interface, but make it easier to get around in the code. Let me know, if I should spend some time to do so. If you want, I can make a suggestion which function to place in which submodule beforehand.

Best
Pascua