### PR TITLE
Use libpass for Python >=3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.2
+    rev: 7.2.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,23 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.6.2
+-------------
+
+Released XXX, 2025
+
+Fixes
++++++
+- (:issue:`1032`) Use libpass for python >= 3.13
+- (:pr:`1086`) Fix FR translation test for Change Password (nickcuenca)
+
+Notes
++++++
+Since Python 3.13 no longer contains setuptools - the old passlib failed to import.
+Rather than require setuptools, for Python 3.13 we now depend on the new fork libpass (https://pypi.org/project/libpass/)
+This is a very new package and rather than possibly cause backwards compat issues for projects
+not using Python 3.13 - older versions of Python still depend on passlib.
+
 Version 5.6.1
 -------------
 

--- a/pyproject-too.toml
+++ b/pyproject-too.toml
@@ -43,13 +43,16 @@ dependencies = [
     "Flask-WTF>=1.1.2",
     "email-validator>=2.0.0",
     "markupsafe>=2.1.0",
-    "passlib>=1.7.4",
+    "passlib>=1.7.4;python_version<'3.13'",
+    # passlib requires setuptools
+    "setuptools;python_version<'3.13'",
+    "libpass>=1.9.0;python_version>='3.13'",
     "wtforms>=3.0.0",  # for form-level errors
     "importlib_resources>=5.10.0",
 ]
 
 [project.optional-dependencies]
-babel = ["babel>=2.12.1", "flask_babel>=3.1.0"]
+babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
 fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18", "sqlalchemy-utils>=0.41.1"]
 common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mailman>=0.3.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
@@ -72,15 +75,13 @@ low = [
     "jinja2==3.1.2",
     "itsdangerous==2.1.2",
     "markupsafe==2.1.2",
-    "mongoengine==0.27.0",
+    "mongoengine==0.29.1",
     "mongomock==4.1.2",
     "pony==0.7.16;python_version<'3.11'",
     "phonenumberslite==8.13.11",
     "qrcode==7.4.2",
     # authlib requires requests
     "requests",
-    # passlib required setuptools
-    "setuptools",
     "sqlalchemy==2.0.18",
     "sqlalchemy-utils==0.41.1",
     "webauthn==2.0.0",
@@ -104,6 +105,8 @@ include = [
     ".git-blame-ignore-revs",
     ".gitignore",
     ".pre-commit-config.yaml",
+    ".readthedocs.yml",
+    "pyproject.toml",
     "babel.ini",
     "codecov.yml",
     "mypy.ini",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,16 @@ dependencies = [
     "Flask-WTF>=1.1.2",
     "email-validator>=2.0.0",
     "markupsafe>=2.1.0",
-    "passlib>=1.7.4",
+    "passlib>=1.7.4;python_version<'3.13'",
+    # passlib requires setuptools
+    "setuptools;python_version<'3.13'",
+    "libpass>=1.9.0;python_version>='3.13'",
     "wtforms>=3.0.0",  # for form-level errors
     "importlib_resources>=5.10.0",
 ]
 
 [project.optional-dependencies]
-babel = ["babel>=2.12.1", "flask_babel>=3.1.0"]
+babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
 fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18", "sqlalchemy-utils>=0.41.1"]
 common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mailman>=0.3.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
@@ -79,8 +82,6 @@ low = [
     "qrcode==7.4.2",
     # authlib requires requests
     "requests",
-    # passlib required setuptools
-    "setuptools",
     "sqlalchemy==2.0.18",
     "sqlalchemy-utils==0.41.1",
     "webauthn==2.0.0",
@@ -104,6 +105,8 @@ include = [
     ".git-blame-ignore-revs",
     ".gitignore",
     ".pre-commit-config.yaml",
+    ".readthedocs.yml",
+    "pyproject-too.toml",
     "babel.ini",
     "codecov.yml",
     "mypy.ini",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,17 +7,15 @@ psycopg2-binary
 pymysql
 pre-commit
 tox
-sqlalchemy
 types-requests
 
 # for dev - might not install Flask-Security - list those dependencies here
 flask
 flask-wtf
 flask-login
-wtforms
+flask-principal
 markupsafe
-passlib
-blinker
+passlib>=1.7.4;python_version<'3.13'
+libpass>=1.9.0;python_version>='3.13'
 email_validator
-itsdangerous
 importlib_resources>=5.10.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,8 +2,6 @@ Pallets-Sphinx-Themes
 Sphinx
 sphinx-issues
 packaging
-Flask-Login
 Flask-SQLAlchemy
 sqlalchemy
 sqlalchemy-utils
-setuptools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,8 +1,6 @@
 Flask-Babel
 Babel
-Flask-Login
 Flask-Mailman
-Flask-Principal
 peewee; python_version < '3.12'
 Flask-SQLAlchemy
 Flask-SQLAlchemy-Lite; python_version >= '3.10'
@@ -10,7 +8,6 @@ argon2-cffi
 authlib
 bcrypt
 bleach
-check-manifest
 coverage
 cryptography
 djlint
@@ -18,7 +15,6 @@ freezegun
 mongoengine
 mongomock
 msgcheck
-passlib
 pony
 phonenumberslite
 pydocstyle
@@ -28,10 +24,7 @@ pytest
 qrcode
 # authlib requires requests
 requests
-# passlib requires setuptools which is deprecated
-setuptools
 sqlalchemy
 sqlalchemy-utils
 webauthn
-werkzeug
 zxcvbn


### PR DESCRIPTION
Minor tweaks to dependencies to not have duplicates among the different requirements files.

Remove check-manifest - we don't use it and it requires setuptools. Now, 3.13 tests no longer have setuptools installed.

Add a couple missing files to our sdist.
Add pyproject.toml to the flask-security-too sdist.

close #1056
close #1032