### PR TITLE
Add confirmation_link and reset_link to welcome_existing email template.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Fixes
 - (:issue:`1032`) Use libpass for python >= 3.13
 - (:pr:`1086`) Fix FR translation test for Change Password (nickcuenca)
 - (:issue:`1090`) Properly document context variables available in email templates.
+- (:issue:`1093`) Add confirmation link/token and reset link/token to welcome_existing email template.
 
 Notes
 +++++

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -485,6 +485,10 @@ us_instructions                 N/A                                  SECURITY_US
                                                                                                                        - username
 welcome_existing                SECURITY_SEND_REGISTER_EMAIL         SECURITY_EMAIL_SUBJECT_REGISTER                   - user                 user_not_registered
                                 SECURITY_RETURN_GENERIC_RESPONSES                                                      - recovery_link
+                                                                                                                       - confirmation_link
+                                                                                                                       - confirmation_token
+                                                                                                                       - reset_link
+                                                                                                                       - reset_token
 welcome_existing_username       SECURITY_SEND_REGISTER_EMAIL         SECURITY_EMAIL_SUBJECT_REGISTER                   - email                user_not_registered
                                 SECURITY_RETURN_GENERIC_RESPONSES                                                      - username
 username_recovery               SECURITY_USERNAME_RECOVERY           SECURITY_EMAIL_SUBJECT_USERNAME_RECOVERY          - user                 username_recovery_email_sent

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1150,9 +1150,10 @@ class Security:
     :param verify_form: set form for reauthentication due to freshness check
     :param change_email_form: set form for changing email address
     :param register_form: set form for the register view when
-            :data:`SECURITY_CONFIRMABLE` is false
+            :data:`SECURITY_CONFIRMABLE` is false (deprecated) or for the register view
+            when :data:`SECURITY_USE_REGISTER_V2` is true.
     :param confirm_register_form: set form for the register view when
-            :data:`SECURITY_CONFIRMABLE` is true
+            :data:`SECURITY_CONFIRMABLE` is true (deprecated)
     :param forgot_password_form: set form for the forgot password view
     :param reset_password_form: set form for the reset password view
     :param change_password_form: set form for the change password view

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -5,7 +5,7 @@ flask_security.recoverable
 Flask-Security recoverable module
 
 :copyright: (c) 2012 by Matt Wright.
-:copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -27,13 +27,17 @@ from .utils import (
 )
 
 
+def generate_reset_link(user):
+    token = generate_reset_password_token(user)
+    return url_for_security("reset_password", token=token, _external=True), token
+
+
 def send_reset_password_instructions(user):
     """Sends the reset password instructions email for the specified user.
 
     :param user: The user to send the instructions to
     """
-    token = generate_reset_password_token(user)
-    reset_link = url_for_security("reset_password", token=token, _external=True)
+    reset_link, token = generate_reset_link(user)
 
     if config_value("SEND_PASSWORD_RESET_EMAIL"):
         send_mail(

--- a/flask_security/templates/security/email/welcome_existing.html
+++ b/flask_security/templates/security/email/welcome_existing.html
@@ -2,7 +2,12 @@
 
   user - the entire user model object
   security - the Flask-Security configuration
-  recovery_link - forgot password link if enabled
+  recovery_link - forgot password link if enabled (reset_link below is more useful)
+  reset_link - reset link if enabled
+  reset_token - this token is part of reset link - but can be used to
+    construct arbitrary URLs for redirecting.
+  confirmation_link - confirmation link is user not yet confirmed (and enabled)
+  confirmation_token
 
   This template is used when returning generic responses and don't/can't
   provide detailed errors as part of form validation to avoid email/username
@@ -15,8 +20,9 @@
     {{ _fsdomain('This account also has the following username associated with it: %(username)s.', username=user.username) }}
   </div>
 {% endif %}
-{% if recovery_link %}
-  <div>
-    {{ _fsdomain('If you forgot your password you can reset it <a href="%(recovery_link)s"> here.</a>', recovery_link=recovery_link)|safe }}
-  </div>
+{% if reset_link %}
+  <div>{{ _fsdomain('You can use <a href="%(reset_link)s">this link</a> to reset your password.', reset_link=reset_link)|safe }}</div>
+{% endif %}
+{% if confirmation_link %}
+  <div>{{ _fsdomain('You have not confirmed your email address yet - use <a href="%(confirmation_link)s">this link</a> to do so now.', confirmation_link=confirmation_link)|safe }}</div>
 {% endif %}

--- a/flask_security/templates/security/email/welcome_existing.txt
+++ b/flask_security/templates/security/email/welcome_existing.txt
@@ -3,6 +3,11 @@
   user - the entire user model object
   security - the Flask-Security configuration
   recovery_link - if enabled.
+  reset_link - reset link if enabled
+  reset_token - this token is part of reset link - but can be used to
+    construct arbitrary URLs for redirecting.
+  confirmation_link - confirmation link is user not yet confirmed (and enabled)
+  confirmation_token
 
   This template is used when returning generic responses and don't/can't
   provide detailed errors as part of form validation to avoid email/username
@@ -16,6 +21,10 @@
 {{ _fsdomain('This account also has the following username associated with it: %(username)s', username=user.username) }}
 {% endif %}
 
-{% if recovery_link %}
-    {{ _fsdomain('If you forgot your password you can reset it with the following link: %(recovery_link)s', recovery_link=recovery_link) }}
+{% if reset_link %}
+{{ _fsdomain('You can use this link %(reset_link)s to reset your password.', reset_link=reset_link)|safe }}
+{% endif %}
+
+{% if confirmation_link %}
+{{ _fsdomain('You have not confirmed your email address yet - use this link: %(confirmation_link)s to do so now.', confirmation_link=confirmation_link)|safe }}
 {% endif %}

--- a/tests/templates/security/email/welcome_existing.txt
+++ b/tests/templates/security/email/welcome_existing.txt
@@ -1,0 +1,22 @@
+{# This template receives the following context:
+
+  user - the entire user model object
+  security - the Flask-Security configuration
+  recovery_link - if enabled.
+  reset_link - reset link if enabled
+  reset_token - this token is part of reset link - but can be used to
+    construct arbitrary URLs for redirecting.
+  confirmation_link - confirmation link is user not yet confirmed (and enabled)
+  confirmation_token
+
+  This template is used when returning generic responses and don't/can't
+  provide detailed errors as part of form validation to avoid email/username
+  enumeration.
+#}
+Email:{{ user.email }}
+User:{{ user.username }}
+RegisterBlueprint:{{ security.register_blueprint }}
+ResetLink:{{ reset_link }}
+ResetToken:{{ reset_token }}
+ConfirmationLink:{{ confirmation_link }}
+ConfirmationToken:{{ confirmation_token }}


### PR DESCRIPTION
Improve usability by providing the email template when someone tries to register with the same email. Both the link and token for both confirmation and resetting password are provided. The confirmation link of course will only be provided is `confirmable` is set AND the user hasn't yet confirmed.

Note that previously - the recovery link was sent (it still is) but the reset_link is much easier and friendlier

close #1093