### PR TITLE
make importlib_resources not mandatory with recent Python

### DIFF
--- a/flask_security/babel.py
+++ b/flask_security/babel.py
@@ -16,7 +16,10 @@ is maintained.  If that isn't installed fall back to a Null Domain
 from collections.abc import Iterable
 import atexit
 from contextlib import ExitStack
-from importlib_resources import files, as_file
+try:
+    from importlib_resources import files, as_file
+except ImportError:
+    from importlib.resources import files, as_file
 
 from flask import current_app
 from .utils import config_value as cv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "passlib>=1.7.4;python_version<'3.12'",
     "libpass>=1.9.0;python_version>='3.12'",
     "wtforms>=3.0.0",  # for form-level errors
-    "importlib_resources>=5.10.0",
+    "importlib_resources>=5.10.0;python_version<'3.12'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
importlib.resources is now in the standard library