### PR TITLE
Flip USE_REGISTER_V2 to true.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,14 @@ Fixes
 
 Docs and Chores
 +++++++++++++++
- - (:pr:`xx`) Drop support for Python 3.9. This removes the dependency on importlib_resources,
+- (:pr:`1106`) Drop support for Python 3.9. This removes the dependency on importlib_resources,
    updates pypy to 3.10, and uses 3.12 as base python for tests/tox.
+- (:pr:`xx`) Flip :py:data:`SECURITY_USE_REGISTER_V2` default to ``True``.
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+As mentioned above - the default RegisterForm is now the new RegisterFormV2 - Please read :ref:`register_form_migration`.
+Flask-Security will emit a DeprecationWarning if the :py:data:`SECURITY_USE_REGISTER_V2` is set to False.
 
 Version 5.6.2
 -------------

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,5 +10,3 @@ coverage:
         if_ci_failed: error #success, failure, error, ignore
         informational: false
         only_pulls: false
-        ignore:
-          - "flask_security/flask_security/templates"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -958,12 +958,18 @@ Registerable
 
     The :py:class:`flask_security.RegisterFormV2` is a single form used for registration. This is replacing the
     RegisterForm and ConfirmRegisterForm (over a few releases). Setting this option
-    to ``True`` will set both registration forms to RegisterFormV2. Note that this
+    to ``False`` will revert behavior to prior releases with register_form=RegisterForm and
+    confirm_register_form=ConfirmRegisterForm. Note that this
     option is ignored if the application has sub-classed the registration form.
 
-    Default: ``False``
+    Default: ``True``
 
     .. versionadded:: 5.6.0
+    .. versionchanged:: 5.7.0
+      Default set to ``True``
+    .. deprecated:: 5.7.0
+      In a future release the old RegisterForm and ConfirmRegisterForm will be removed which
+      will make this option obsolete.
 
 
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -104,11 +104,11 @@ replacement class. This allows you to add extra fields to any
 form or override validators. For example it is often desired to add additional
 personal information fields to the registration form::
 
-    from flask_security import RegisterForm
+    from flask_security import RegisterFormV2
     from wtforms import StringField
     from wtforms.validators import DataRequired
 
-    class ExtendedRegisterForm(RegisterForm):
+    class ExtendedRegisterForm(RegisterFormV2):
         first_name = StringField('First Name', [DataRequired()])
         last_name = StringField('Last Name', [DataRequired()])
 
@@ -200,7 +200,7 @@ The following is a list of all the available form overrides:
 Register Form Migration
 ++++++++++++++++++++++++
 Since early in Flask Security releases, there have been 2 different forms used for
-registration: RegisterForm and ConfirmRegisterForm. The difference between them is only
+registration: RegisterForm and ConfirmRegisterForm. The only difference between them is
 that the ConfirmRegisterForm doesn't require password confirmation (i.e. asking the user to
 re-type their password). This wasn't a config option but rather based on whether :py:data:`SECURITY_CONFIRMABLE` was
 set or whether the request was form-based or JSON. This has always been a huge source of
@@ -218,6 +218,8 @@ ConfirmRegisterForm will raise a deprecation warning. The new RegisterFormV2 can
 The new RegisterFormV2 will add a ``password_confirm`` field if :py:data:`SECURITY_PASSWORD_CONFIRM_REQUIRED`
 is set to ``True`` (the default). Additionally, JSON requests will need to provide a value for ``password_confirm``
 if configured.
+
+In release 5.7 the default is flipped - :py:data:`SECURITY_USE_REGISTER_V2` is ``True`` and RegisterFormV2 is the default form.
 
 .. _form_instantiation:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2298,7 +2298,7 @@ components:
         password_confirm:
           type: string
           description: >
-            If present, must re-type in password. This will not be present if the __SECURITY_CONFIRM__ configuration is true.
+            If present, must re-type in password. This will not be present if the __SECURITY_PASSWORD_CONFIRM_REQUIRED__ configuration is False.
         next:
           type: string
           description: >

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -5,7 +5,7 @@ flask_security.cli
 Command Line Interface for managing accounts and roles.
 
 :copyright: (c) 2016 by CERN.
-:copyright: (c) 2019-2024 by J. Christopher Wagner
+:copyright: (c) 2019-2025 by J. Christopher Wagner
 :license: MIT, see LICENSE for more details.
 """
 
@@ -153,8 +153,12 @@ def users_create(attributes, password, active, username):
     # it already asked for confirmation.
     # if they used inline keywords, there really isn't any reason to make them type
     # it in twice.
+    if _security.forms["confirm_register_form"].cls:
+        form_name = "confirm_register_form"
+    else:
+        form_name = "register_form"
     form = build_form(
-        "confirm_register_form" if _security._use_confirm_form else "register_form",
+        form_name,
         meta={"csrf": False},
         **kwargs,
         password_confirm=password,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -675,6 +675,9 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
     to still return important bad-password messages.
     In the case of an existing email or username - we set form.existing_xx so that
     the view can decide how to match responses (e.g. json responses always return 200).
+
+    .. deprecated:: 5.6.0
+        Replaced with RegisterFormV2
     """
 
     # Password optional when Unified Signin enabled.
@@ -723,6 +726,12 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
 
 
 class RegisterForm(ConfirmRegisterForm, NextFormMixin):
+    """Register Form
+
+    .. deprecated:: 5.6.0
+        Replaced with RegisterFormV2
+    """
+
     # Password optional when Unified Signin enabled.
     password_confirm = PasswordField(
         get_form_field_label("retype_password"),

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -290,11 +290,9 @@ def logout():
 def register() -> ResponseValue:
     """View function which handles a registration request."""
 
-    # For some unknown historic reason - if you don't require confirmation
-    # (via email) then you need to type in your password twice. That might
-    # make sense if you can't reset your password but in modern (2020) UX models
-    # don't ask twice.
-    if (_security.confirmable or request.is_json) and _security._use_confirm_form:
+    if (_security.confirmable or request.is_json) and _security.forms[
+        "confirm_register_form"
+    ].cls:
         form_name = "confirm_register_form"
     else:
         form_name = "register_form"

--- a/pytest.ini
+++ b/pytest.ini
@@ -35,3 +35,4 @@ filterwarnings =
     ignore::DeprecationWarning:pony:0
     ignore:.*'sms' was enabled in SECURITY_US_ENABLED_METHODS;.*:UserWarning:flask_security:0
     ignore:.*'get_token_status' is deprecated.*:DeprecationWarning:flask_security:0
+    ignore:.*The SECURITY_USE_REGISTER_V2 configuration option is deprecated.*:DeprecationWarning:flask_security:0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ Test fixtures and what not
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import sqlite3
 import gc
 import os
@@ -64,6 +65,12 @@ try:
     from flask_babel import Babel
 except ImportError:
     NO_BABEL = True
+
+# enable testing both register form options
+v2_param = [
+    pytest.param(dict(use_register_v2=True), id="use_register_v2-True"),
+    pytest.param(dict(use_register_v2=False), id="use_register_v2-False"),
+]
 
 
 class FastHash(PasswordHash):
@@ -171,6 +178,11 @@ def app(request):
     flask_async_test = marker_getter("flask_async")
     if flask_async_test is not None:
         pytest.importorskip("asgiref")  # from flask[async]
+
+    # allow parameterized tests to set security config variables
+    if hasattr(request, "param") and isinstance(request.param, Mapping):
+        for key, value in request.param.items():
+            app.config["SECURITY_" + key.upper()] = value
 
     # Override config settings as requested for this test
     settings = marker_getter("settings")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,6 +21,7 @@ from flask_security.decorators import auth_required
 from flask_principal import identity_loaded
 from freezegun import freeze_time
 
+from tests.conftest import v2_param
 from tests.test_utils import (
     authenticate,
     capture_flashes,
@@ -337,6 +338,7 @@ def test_generic_response(app, client, get_message):
     assert len(flashes) == 0
 
 
+@pytest.mark.parametrize("app", v2_param, indirect=True)
 @pytest.mark.registerable()
 @pytest.mark.settings(username_enable=True, return_generic_responses=True)
 def test_generic_response_username(app, client, get_message):
@@ -344,6 +346,7 @@ def test_generic_response_username(app, client, get_message):
         email="dude@lp.com",
         username="dude",
         password="awesome sunset",
+        password_confirm="awesome sunset",
     )
     response = client.post("/register", json=data)
     assert response.headers["Content-Type"] == "application/json"
@@ -351,7 +354,12 @@ def test_generic_response_username(app, client, get_message):
     logout(client)
 
     response = client.post(
-        "/login", data=dict(username="dude2", password="awesome sunset")
+        "/login",
+        data=dict(
+            username="dude2",
+            password="awesome sunset",
+            password_confirm="awesome sunset",
+        ),
     )
     assert get_message("GENERIC_AUTHN_FAILED") in response.data
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -385,8 +385,8 @@ def test_cli_change_password(script_info):
     assert "User not found" in result.output
 
 
-@pytest.mark.settings(use_register_v2=True)
-def test_cli_createuserV2(script_info):
+@pytest.mark.settings(use_register_v2=False)
+def test_cli_createuser_old(script_info):
     """Test create user CLI."""
     runner = CliRunner()
 
@@ -399,8 +399,8 @@ def test_cli_createuserV2(script_info):
     assert result.exit_code == 0
 
 
-@pytest.mark.settings(use_register_v2=True)
-def test_cli_createuserV2attr(script_info):
+@pytest.mark.settings(use_register_v2=False)
+def test_cli_createuserold_attr(script_info):
     """Test create user CLI passing attr that is in User but not in form."""
     runner = CliRunner()
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -55,7 +55,12 @@ def test_confirmable_flag(app, clients, get_message):
     email = "dude@lp.com"
 
     with capture_registrations() as registrations:
-        data = dict(email=email, password="awesome sunset", next="")
+        data = dict(
+            email=email,
+            password="awesome sunset",
+            password_confirm="awesome sunset",
+            next="",
+        )
         response = clients.post("/register", data=data)
 
     assert response.status_code == 302
@@ -110,7 +115,12 @@ def test_confirmable_flag(app, clients, get_message):
 
     # Test if user was deleted before confirmation
     with capture_registrations() as registrations:
-        data = dict(email="mary27@lp.com", password="awesome sunset", next="")
+        data = dict(
+            email="mary27@lp.com",
+            password="awesome sunset",
+            password_confirm="awesome sunset",
+            next="",
+        )
         clients.post("/register", data=data)
 
     user = registrations[0]["user"]
@@ -141,7 +151,12 @@ def test_confirmation_template(app, client, get_message):
         recorded_tokens_sent.append(kwargs["confirmation_token"])
 
     with capture_registrations() as registrations:
-        data = dict(email="mary@lp.com", password="awesome sunset", next="")
+        data = dict(
+            email="mary@lp.com",
+            password="awesome sunset",
+            password_confirm="awesome sunset",
+            next="",
+        )
         # Register - this will use the welcome template
         client.post("/register", data=data, follow_redirects=True)
         # Explicitly ask for confirmation -
@@ -175,10 +190,14 @@ def test_confirmation_template(app, client, get_message):
 @pytest.mark.registerable()
 @pytest.mark.settings(requires_confirmation_error_view="/confirm")
 def test_requires_confirmation_error_redirect(app, clients):
-    data = dict(email="jyl@lp.com", password="awesome sunset")
+    data = dict(
+        email="jyl@lp.com", password="awesome sunset", password_confirm="awesome sunset"
+    )
     response = clients.post("/register", data=data)
 
-    response = authenticate(clients, **data, follow_redirects=True)
+    response = authenticate(
+        clients, email="jyl@lp.com", password="awesome sunset", follow_redirects=True
+    )
     assert b"send_confirmation_form" in response.data
     assert b"jyl@lp.com" in response.data
 
@@ -189,7 +208,12 @@ def test_expired_confirmation_token(client, get_message):
     # Note that we need relatively new-ish date since session cookies also expire.
     with freeze_time(date.today() + timedelta(days=-1)):
         with capture_registrations() as registrations:
-            data = dict(email="mary@lp.com", password="awesome sunset", next="")
+            data = dict(
+                email="mary@lp.com",
+                password="awesome sunset",
+                password_confirm="awesome sunset",
+                next="",
+            )
             client.post("/register", data=data, follow_redirects=True)
 
         email = registrations[0]["email"]
@@ -203,7 +227,12 @@ def test_expired_confirmation_token(client, get_message):
 @pytest.mark.registerable()
 def test_email_conflict_for_confirmation_token(app, client, get_message):
     with capture_registrations() as registrations:
-        data = dict(email="mary@lp.com", password="awesome sunset", next="")
+        data = dict(
+            email="mary@lp.com",
+            password="awesome sunset",
+            password_confirm="awesome sunset",
+            next="",
+        )
         client.post("/register", data=data, follow_redirects=True)
 
     user = registrations[0]["user"]
@@ -223,12 +252,18 @@ def test_email_conflict_for_confirmation_token(app, client, get_message):
 @pytest.mark.registerable()
 @pytest.mark.settings(login_without_confirmation=True)
 def test_login_when_unconfirmed(client, get_message):
-    data = dict(email="mary@lp.com", password="awesome sunset", next="")
+    data = dict(
+        email="mary@lp.com",
+        password="awesome sunset",
+        password_confirm="awesome sunset",
+        next="",
+    )
     response = client.post("/register", data=data, follow_redirects=True)
     assert b"mary@lp.com" in response.data
 
 
 @pytest.mark.registerable()
+@pytest.mark.settings(password_confirm_required=False)
 def test_no_auth_token(client_nc):
     """Make sure that register doesn't return Authentication Token
     if user isn't confirmed.
@@ -244,7 +279,7 @@ def test_no_auth_token(client_nc):
 
 
 @pytest.mark.registerable()
-@pytest.mark.settings(login_without_confirmation=True)
+@pytest.mark.settings(login_without_confirmation=True, password_confirm_required=False)
 def test_auth_token_unconfirmed(client_nc):
     """Make sure that register returns Authentication Token
     if user isn't confirmed, but the 'login_without_confirmation' flag is set.
@@ -262,7 +297,11 @@ def test_auth_token_unconfirmed(client_nc):
 
 
 @pytest.mark.registerable()
-@pytest.mark.settings(login_without_confirmation=True, auto_login_after_confirm=False)
+@pytest.mark.settings(
+    login_without_confirmation=True,
+    auto_login_after_confirm=False,
+    password_confirm_required=False,
+)
 def test_confirmation_different_user_when_logged_in_no_auto(client, get_message):
     """Default - AUTO_LOGIN == false so shouldn't log in second user."""
     e1 = "dude@lp.com"
@@ -297,7 +336,12 @@ def test_confirmation_different_user_when_logged_in(client, get_message):
 
     with capture_registrations() as registrations:
         for e in e1, e2:
-            data = dict(email=e, password="awesome sunset", next="")
+            data = dict(
+                email=e,
+                password="awesome sunset",
+                password_confirm="awesome sunset",
+                next="",
+            )
             response = client.post("/register", data=data)
             assert is_authenticated(client, get_message)
             logout(client)
@@ -321,7 +365,7 @@ def test_confirmation_different_user_when_logged_in(client, get_message):
 
 
 @pytest.mark.registerable()
-@pytest.mark.settings(recoverable=True)
+@pytest.mark.settings(recoverable=True, password_confirm_required=False)
 def test_cannot_reset_password_when_email_is_not_confirmed(client, get_message):
     email = "dude@lp.com"
 
@@ -333,7 +377,7 @@ def test_cannot_reset_password_when_email_is_not_confirmed(client, get_message):
 
 
 @pytest.mark.registerable()
-@pytest.mark.settings(auto_login_after_confirm=False)
+@pytest.mark.settings(auto_login_after_confirm=False, password_confirm_required=False)
 def test_confirm_redirect(client, get_message):
     with capture_registrations() as registrations:
         data = dict(email="jane@lp.com", password="awesome sunset", next="")
@@ -350,7 +394,9 @@ def test_confirm_redirect(client, get_message):
 
 
 @pytest.mark.registerable()
-@pytest.mark.settings(post_confirm_view="/post_confirm")
+@pytest.mark.settings(
+    post_confirm_view="/post_confirm", password_confirm_required=False
+)
 def test_confirm_redirect_to_post_confirm(client, get_message):
     with capture_registrations() as registrations:
         data = dict(email="john@lp.com", password="awesome sunset", next="")
@@ -368,6 +414,7 @@ def test_confirm_redirect_to_post_confirm(client, get_message):
     redirect_behavior="spa",
     post_confirm_view="/confirm-redirect",
     confirm_error_view="/confirm-error",
+    password_confirm_required=False,
 )
 def test_spa_get(app, client, get_message):
     """
@@ -411,6 +458,7 @@ def test_spa_get(app, client, get_message):
     redirect_host="localhost:8081",
     redirect_behavior="spa",
     confirm_error_view="/confirm-error",
+    password_confirm_required=False,
 )
 def test_spa_get_bad_token(app, client, get_message):
     """Test expired and invalid token"""
@@ -463,7 +511,12 @@ def test_spa_get_bad_token(app, client, get_message):
 @pytest.mark.settings(auto_login_after_confirm=True, post_login_view="/postlogin")
 def test_auto_login(app, client, get_message):
     with capture_registrations() as registrations:
-        data = dict(email="mary@lp.com", password="password", next="")
+        data = dict(
+            email="mary@lp.com",
+            password="password",
+            password_confirm="password",
+            next="",
+        )
         client.post("/register", data=data, follow_redirects=True)
 
     assert not is_authenticated(client, get_message)
@@ -483,7 +536,12 @@ def test_two_factor(app, client, get_message):
     2-factor setup.
     """
     with capture_registrations() as registrations:
-        data = dict(email="mary@lp.com", password="password", next="")
+        data = dict(
+            email="mary@lp.com",
+            password="password",
+            password_confirm="password",
+            next="",
+        )
         client.post("/register", data=data, follow_redirects=True)
 
     assert not is_authenticated(client, get_message)
@@ -499,7 +557,9 @@ def test_two_factor(app, client, get_message):
 @pytest.mark.settings(two_factor_required=True, auto_login_after_confirm=True)
 def test_two_factor_json(app, client, get_message):
     with capture_registrations() as registrations:
-        data = dict(email="dude@lp.com", password="password")
+        data = dict(
+            email="dude@lp.com", password="password", password_confirm="password"
+        )
         response = client.post("/register", content_type="application/json", json=data)
         assert response.headers["content-type"] == "application/json"
         assert response.json["meta"]["code"] == 200
@@ -520,6 +580,7 @@ def test_two_factor_json(app, client, get_message):
 @pytest.mark.settings(
     user_identity_attributes=[{"username": {"mapper": lambda x: x}}],
     username_enable=True,
+    password_confirm_required=False,
 )
 def test_email_not_identity(app, client, get_message):
     # Test that can register/confirm with email even if it isn't an IDENTITY_ATTRIBUTE
@@ -674,7 +735,12 @@ def test_confirmable_async(app, client, get_message):
     email = "dude@lp.com"
 
     with capture_registrations() as registrations:
-        data = dict(email=email, password="awesome sunset", next="")
+        data = dict(
+            email=email,
+            password="awesome sunset",
+            password_confirm="awesome sunset",
+            next="",
+        )
         response = client.post("/register", data=data)
     assert response.status_code == 302
     client.post(

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -576,7 +576,7 @@ def test_remember_login_csrf_cookie(app, client):
 
 @pytest.mark.csrf(csrfprotect=True)
 @pytest.mark.registerable()
-@pytest.mark.settings(csrf_header="X-CSRF-Token")
+@pytest.mark.settings(csrf_header="X-CSRF-Token", password_confirm_required=False)
 def test_json_register_csrf_with_ignore_unauth_set_to_false(app, client):
     """
     Test that you are able to register a user when using the JSON api

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -176,11 +176,9 @@ def test_basic_custom_forms(app, sqlalchemy_datastore):
 
 @pytest.mark.registerable()
 @pytest.mark.confirmable()
+@pytest.mark.settings(use_register_v2=False)
 @pytest.mark.filterwarnings("ignore:.*The ConfirmRegisterForm.*:DeprecationWarning")
 def test_confirmable_custom_form(app, sqlalchemy_datastore):
-    app.config["SECURITY_REGISTERABLE"] = True
-    app.config["SECURITY_CONFIRMABLE"] = True
-
     class MyRegisterForm(ConfirmRegisterForm):
         email = EmailField("My Register Email Address Field")
 

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -135,7 +135,9 @@ def test_recoverable_flag(app, clients, get_message):
 @pytest.mark.registerable()
 @pytest.mark.settings(requires_confirmation_error_view="/confirm")
 def test_requires_confirmation_error_redirect(app, clients):
-    data = dict(email="jyl@lp.com", password="awesome sunset")
+    data = dict(
+        email="jyl@lp.com", password="awesome sunset", password_confirm="awesome sunset"
+    )
     clients.post("/register", data=data)
 
     response = clients.post(


### PR DESCRIPTION
This continues the registration form migration to the new RegistrationV2 and deprecating the old RegisterForm and ConfirmRegisterForm.