### PR TITLE
Flip back to Flask-Mail as the default mailer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Version 5.7.0
 
 Released XXX
 
+This release is a set of small backward incompatible changes. Please read these notes carefully.
+
 Fixes
 +++++
 - (:issue:`1109`) Fix broken link in docs and improve docstrings/typing for util classes.
@@ -17,11 +19,17 @@ Docs and Chores
 - (:pr:`1106`) Drop support for Python 3.9. This removes the dependency on importlib_resources,
    updates pypy to 3.10, and uses 3.12 as base python for tests/tox.
 - (:pr:`1112`) Flip :py:data:`SECURITY_USE_REGISTER_V2` default to ``True``.
+- (:pr:`xx`) Flip default mail package back to Flask-Mail (from Flask-Mailman).
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
 As mentioned above - the default RegisterForm is now the new RegisterFormV2 - Please read :ref:`register_form_migration`.
 Flask-Security will emit a DeprecationWarning if the :py:data:`SECURITY_USE_REGISTER_V2` is set to False.
+
+In 5.0 we changed the default mailer package to Flask-Mailman since Flask-Mail was no longer supported.
+Flask-Mail is again supported and is part of Pallets-Eco. Both packages are still supported based on which one
+an application initializes. The only backwards compatibility concern is that if you use the setup extras 'common',
+it will install Flask-Mail rather than Flask-Mailman.
 
 Version 5.6.2
 -------------

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ maintenance of related projects. If you are interested in helping maintain
 this project, please reach out on `the Pallets Discord server <https://discord.gg/pallets>`.
 
 Goals
-+++++
+-----
 
 * Use `OWASP <https://github.com/OWASP/ASVS>`_ to guide best practice and default configurations.
 * Be more opinionated and 'batteries' included by reducing reliance on abandoned projects and
@@ -73,7 +73,7 @@ Goals
 
 
 Contributing
-++++++++++++
+------------
 Issues and pull requests are welcome. Other maintainers are also welcome.
 Please consult these `contributing`_ guidelines.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Many of these features are made possible by integrating various Flask extensions
 and libraries. They include:
 
 * `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_
-* `Flask-Mailman <https://pypi.org/project/Flask-Mailman/>`_
+* `Flask-Mail <https://pypi.org/project/Flask-Mail/>`_
 * `Flask-Principal <https://pypi.org/project/Flask-Principal/>`_
 * `Flask-WTF <https://pypi.org/project/Flask-WTF/>`_
 * `itsdangerous <https://pypi.org/project/itsdangerous/>`_

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,7 +28,7 @@ Supported extras are:
 
 * ``babel`` - Translation services. It will install babel and Flask-Babel.
 * ``fsqla`` - Use flask-sqlalchemy and sqlalchemy as your storage interface.
-* ``common`` - Install Flask-Mailman, argon2 (the default password hash), and bleach.
+* ``common`` - Install Flask-Mail, argon2 (the default password hash), bcrypt (old commonly used password hash) and bleach.
 * ``mfa`` - Install packages used for multi-factor (two-factor, unified signin, WebAuthn):
   cryptography, qrcode, phonenumberslite (note that for SMS you still need
   to pick an SMS provider and install appropriate packages), and webauthn.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,7 +7,7 @@ There are some complete (but simple) examples available in the *examples* direct
 .. note::
     The below quickstarts are just that - they don't enable most of the features (such as registration, reset, etc.).
     They basically create a single user, and you can login as that user... that's it.
-    As you add more features, additional packages (e.g. Flask-Mailman, Flask-Babel, qrcode) might be required
+    As you add more features, additional packages (e.g. Flask-Mail, Flask-Babel, qrcode) might be required
     and will need to be added to your requirements.txt (or equivalent) file.
     Flask-Security does some configuration validation and will output error messages to the console
     for some missing packages.
@@ -561,15 +561,15 @@ Mail Configuration
 
 Flask-Security integrates with an outgoing mail service via the ``mail_util_cls`` which
 is part of initial configuration. The default class :class:`flask_security.MailUtil` utilizes the
-`Flask-Mailman <https://pypi.org/project/flask-mailman/>`_ package. Be sure to add flask_mailman to
-your requirements.txt. The older and no longer maintained package `Flask-Mail <https://pypi.org/project/Flask-Mail/>`_
-is also (still) supported.
+`Flask-Mail <https://pypi.org/project/flask-mail/>`_ package. Be sure to add flask_mail to
+your requirements.txt. The Django inspired package `Flask-Mailman <https://pypi.org/project/Flask-Mailman/>`_
+is also supported.
 
 The following code illustrates a basic setup, which could be added to
 the basic application code in the previous section::
 
     # At top of file
-    from flask_mailman import Mail
+    from flask_mail import Mail
 
     # After 'Create app'
     app.config['MAIL_SERVER'] = 'smtp.example.com'
@@ -579,9 +579,9 @@ the basic application code in the previous section::
     app.config['MAIL_PASSWORD'] = 'password'
     mail = Mail(app)
 
-To learn more about the various Flask-Mailman settings to configure it to
+To learn more about the various Flask-Mail settings to configure it to
 work with your particular email server configuration, please see the
-`Flask-Mailman documentation <https://waynerv.github.io/flask-mailman/>`_.
+`Flask-Mail documentation <https://flask-mail.readthedocs.io/en/latest/>`_.
 
 .. _proxy-configuration:
 

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -38,7 +38,7 @@ possible using SQLAlchemy:
     from flask_sqlalchemy import SQLAlchemy
     from flask_security import Security, SQLAlchemyUserDatastore, \
         UserMixin, RoleMixin, auth_required
-    from flask_mailman import Mail
+    from flask_mail import Mail
 
     # Create app
     app = Flask(__name__)

--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -4,10 +4,10 @@ flask_security.mail_util
 
 Utility class providing methods for validating, normalizing and sending emails.
 
-:copyright: (c) 2020-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2020-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
-While this default implementation uses Flask-Mailman - we want to make sure that
+While this default implementation uses Flask-Mail - we want to make sure that
 Flask-Mailman isn't REQUIRED (if this implementation isn't used).
 """
 
@@ -79,7 +79,7 @@ class MailUtil:
         so we cast to str() here to force localization.
         """
 
-        if current_app.extensions.get("mailman", None):
+        if current_app.extensions.get("mailman", None):  # pragma: no cover
             from flask_mailman import EmailMultiAlternatives, Mail
 
             # Flask-Mailman doesn't appear to take a tuple - a bug has been filed
@@ -104,7 +104,7 @@ class MailUtil:
                     msg.attach_alternative(html, "text/html")
                 msg.send()
 
-        elif current_app.extensions.get("mail", None):  # pragma: no cover
+        elif current_app.extensions.get("mail", None):
             from flask_mail import Message
 
             # In Flask-Mail, sender can be a two element tuple -- (name, address)

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,7 +25,7 @@ ignore_errors = True
 
 [mypy-quart.*]
 ignore_missing_imports = True
-[mypy-flask_mail.*]
+[mypy-flask_mailman.*]
 ignore_missing_imports = True
 [mypy-twilio.*]
 ignore_missing_imports = True

--- a/pyproject-too.toml
+++ b/pyproject-too.toml
@@ -50,7 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
 fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18", "sqlalchemy-utils>=0.41.1"]
-common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mailman>=0.3.0", "bleach>=6.0.0"]
+common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
 low = [
     # Lowest supported versions
@@ -58,7 +58,7 @@ low = [
     "Flask-SQLAlchemy==3.1.0",
     "Flask-SQLAlchemy-Lite==0.1.0;python_version>='3.10'",
     "Flask-Babel==4.0.0",
-    "Flask-Mailman==0.3.0",
+    "Flask-Mail==0.10.0",
     "Flask-Login==0.6.3",
     "Flask-WTF==1.1.2",
     "peewee==3.17.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
 fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18", "sqlalchemy-utils>=0.41.1"]
-common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mailman>=0.3.0", "bleach>=6.0.0"]
+common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
 low = [
     # Lowest supported versions
@@ -58,7 +58,7 @@ low = [
     "Flask-SQLAlchemy==3.1.0",
     "Flask-SQLAlchemy-Lite==0.1.0;python_version>='3.10'",
     "Flask-Babel==4.0.0",
-    "Flask-Mailman==0.3.0",
+    "Flask-Mail==0.10.0",
     "Flask-Login==0.6.3",
     "Flask-WTF==1.1.2",
     "peewee==3.17.9",

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,6 @@
 Flask-Babel
 Babel
-Flask-Mailman
+Flask-Mail
 Flask-SQLAlchemy
 Flask-SQLAlchemy-Lite
 argon2-cffi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from passlib.registry import register_crypt_handler
 import pytest
 from flask import Flask, Response, jsonify, render_template
 from flask import request as flask_request
-from flask_mailman import Mail
+from flask_mail import Mail
 from flask_wtf import CSRFProtect
 
 try:
@@ -379,6 +379,12 @@ def app(request):
     # help find tests that don't clean up - note that pony leaves a connection so
     # we can't use this in 'production'...
     # assert not find_sqlite_connections()
+
+
+@pytest.fixture()
+def outbox(app):
+    with app.mail.record_messages() as outbox:
+        yield outbox
 
 
 @pytest.fixture()

--- a/tests/test_change_email.py
+++ b/tests/test_change_email.py
@@ -4,7 +4,7 @@ test_change_email
 
 Change email functionality tests
 
-:copyright: (c) 2024-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2024-2025 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -47,7 +47,7 @@ def capture_change_email_requests():
 
 
 @pytest.mark.settings(change_email_error_view="/change-email")
-def test_ce(app, clients, get_message):
+def test_ce(app, clients, get_message, outbox):
     client = clients
 
     @change_email_confirmed.connect_via(app)
@@ -60,15 +60,15 @@ def test_ce(app, clients, get_message):
     with capture_change_email_requests() as ce_requests:
         response = client.post("/change-email", data={"email": "<EMAIL>"})
         assert get_message("INVALID_EMAIL_ADDRESS") in response.data
-        assert not app.mail.outbox
+        assert len(outbox) == 0
 
         response = client.post("/change-email", data=dict(email="matt2@lp.com"))
         msg = get_message("CHANGE_EMAIL_SENT", email="matt2@lp.com")
         assert msg in response.data
         assert "matt2@lp.com" == ce_requests[0]["new_email"]
         token = ce_requests[0]["token"]
-    assert len(app.mail.outbox) == 1
-    assert app.config["SECURITY_CHANGE_EMAIL_WITHIN"] in app.mail.outbox[0].body
+    assert len(outbox) == 1
+    assert app.config["SECURITY_CHANGE_EMAIL_WITHIN"] in outbox[0].body
 
     response = client.get("/change-email/" + token, follow_redirects=True)
     assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
@@ -84,7 +84,7 @@ def test_ce(app, clients, get_message):
     assert flashes[0]["message"].encode("utf-8") == get_message("API_ERROR")
 
 
-def test_ce_json(app, client, get_message):
+def test_ce_json(app, client, get_message, outbox):
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
     @change_email_confirmed.connect_via(app)
@@ -99,14 +99,14 @@ def test_ce_json(app, client, get_message):
         assert response.json["response"]["errors"][0].encode("utf=8") == get_message(
             "INVALID_EMAIL_ADDRESS"
         )
-        assert not app.mail.outbox
+        assert len(outbox) == 0
 
         response = client.post("/change-email", json=dict(email="matt2@lp.com"))
         assert response.status_code == 200
         assert response.json["response"]["current_email"] == "matt@lp.com"
         assert "matt2@lp.com" == ce_requests[0]["new_email"]
         token = ce_requests[0]["token"]
-    assert len(app.mail.outbox) == 1
+    assert len(outbox) == 1
 
     response = client.get(
         "/change-email/" + token, headers=headers, follow_redirects=True
@@ -137,7 +137,7 @@ def test_expired_token(client, get_message):
     assert msg in response.data
 
 
-def test_template(app, client, get_message):
+def test_template(app, client, get_message, outbox):
     # Check contents of email template - this uses a test template
     # in order to check all context vars since the default template
     # doesn't have all of them.
@@ -146,8 +146,7 @@ def test_template(app, client, get_message):
     with capture_change_email_requests() as ce_requests:
         client.post("/change-email", data=dict(email="matt2@lp.com"))
         # check email
-        outbox = app.mail.outbox
-        assert outbox[0].to[0] == "matt2@lp.com"
+        assert outbox[0].recipients[0] == "matt2@lp.com"
         matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)
         # should be 4 - link, email, token, config item
         assert matcher[1].split(":")[1] == "matt@lp.com"
@@ -162,7 +161,7 @@ def test_template(app, client, get_message):
 
 
 @pytest.mark.settings(return_generic_responses=True)
-def test_generic_response(app, client, get_message):
+def test_generic_response(app, client, get_message, outbox):
     authenticate(client, email="matt@lp.com")
     with capture_change_email_requests():
         # first try bad formatted email - should get detailed error
@@ -176,7 +175,7 @@ def test_generic_response(app, client, get_message):
         msg = get_message("CHANGE_EMAIL_SENT", email="gal@lp.com")
         assert msg in response.data
         # but no email was actually sent
-        assert not app.mail.outbox
+        assert len(outbox) == 0
 
 
 @pytest.mark.settings(

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -32,7 +32,7 @@ from tests.test_utils import (
 pytestmark = pytest.mark.changeable()
 
 
-def test_changeable_flag(app, clients, get_message):
+def test_changeable_flag(app, clients, get_message, outbox):
     tcl = clients
     recorded = []
 
@@ -120,7 +120,6 @@ def test_changeable_flag(app, clients, get_message):
         },
         follow_redirects=True,
     )
-    outbox = app.mail.outbox
 
     assert get_message("PASSWORD_CHANGE") in response.data
     assert b"Home Page" in response.data
@@ -323,7 +322,7 @@ def test_auth_uniquifier(app):
 
 @pytest.mark.app_settings(babel_default_locale="fr_FR")
 @pytest.mark.babel()
-def test_xlation(app, client, get_message_local):
+def test_xlation(app, client, get_message_local, outbox):
     # Test form and email translation
     assert check_xlation(app, "fr_FR"), "You must run python setup.py compile_catalog"
 
@@ -347,7 +346,6 @@ def test_xlation(app, client, get_message_local):
         },
         follow_redirects=True,
     )
-    outbox = app.mail.outbox
 
     with app.test_request_context():
         assert get_message_local("PASSWORD_CHANGE").encode("utf-8") in response.data
@@ -361,7 +359,7 @@ def test_xlation(app, client, get_message_local):
         )
         assert (
             str(markupsafe.escape(localize_callback("Your password has been changed.")))
-            in outbox[0].alternatives[0][0]
+            in outbox[0].alts["html"]
         )
         assert localize_callback("Your password has been changed") in outbox[0].body
 
@@ -381,7 +379,7 @@ def test_custom_change_template(client):
 
 
 @pytest.mark.settings(send_password_change_email=False)
-def test_disable_change_emails(app, client):
+def test_disable_change_emails(app, client, outbox):
     client.post(
         "/change",
         data={
@@ -391,7 +389,7 @@ def test_disable_change_emails(app, client):
         },
         follow_redirects=True,
     )
-    assert not app.mail.outbox
+    assert len(outbox) == 0
 
 
 @pytest.mark.settings(post_change_view="/profile")

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -139,7 +139,7 @@ def test_confirmable_flag(app, clients, get_message):
 
 
 @pytest.mark.registerable()
-def test_confirmation_template(app, client, get_message):
+def test_confirmation_template(app, client, get_message, outbox):
     # Check contents of email template - this uses a test template
     # in order to check all context vars since the default template
     # doesn't have all of them.
@@ -162,7 +162,6 @@ def test_confirmation_template(app, client, get_message):
         # Explicitly ask for confirmation -
         # this will use the confirmation_instructions template
         client.post("/confirm", data=dict(email="mary@lp.com"))
-        outbox = app.mail.outbox
         assert len(outbox) == 2
         # check registration email
         matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -31,7 +31,7 @@ from tests.test_utils import authenticate, capture_reset_password_requests, logo
     username_recovery_template="custom_security/recover_username.html",
     change_username_template="custom_security/change_username.html",
 )
-def test_context_processors(client, app):
+def test_context_processors(client, app, outbox):
     @app.security.context_processor
     def default_ctx_processor():
         return {"global": "global"}
@@ -110,7 +110,7 @@ def test_context_processors(client, app):
 
     client.post("/reset", data=dict(email="matt@lp.com"))
 
-    email = app.mail.outbox[1]
+    email = outbox[1]
     assert "global" in email.body
     assert "bar-mail" in email.body
 

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -24,7 +24,7 @@ from flask_security import Security, UserMixin, login_instructions_sent
 pytestmark = pytest.mark.passwordless()
 
 
-def test_passwordless_flag(app, client, get_message):
+def test_passwordless_flag(app, client, get_message, outbox):
     recorded = []
 
     @login_instructions_sent.connect_via(app)
@@ -47,7 +47,7 @@ def test_passwordless_flag(app, client, get_message):
     )
     assert response.status_code == 200
     assert len(recorded) == 1
-    assert len(app.mail.outbox) == 1
+    assert len(outbox) == 1
 
     # Test login with json and invalid email
     data = dict(email="nobody@lp.com")
@@ -64,7 +64,7 @@ def test_passwordless_flag(app, client, get_message):
 
     assert len(recorded) == 2
     assert len(requests) == 1
-    assert len(app.mail.outbox) == 2
+    assert len(outbox) == 2
     assert "user" in requests[0]
     assert "login_token" in requests[0]
 
@@ -90,13 +90,12 @@ def test_passwordless_flag(app, client, get_message):
     assert get_message("USER_DOES_NOT_EXIST") in response.data
 
 
-def test_passwordless_template(app, client, get_message):
+def test_passwordless_template(app, client, get_message, outbox):
     # Check contents of email template - this uses a test template
     # in order to check all context vars since the default template
     # doesn't have all of them.
     with capture_passwordless_login_requests() as requests:
         client.post("/login", data=dict(email="joe@lp.com"), follow_redirects=True)
-        outbox = app.mail.outbox
         assert len(outbox) == 1
         matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)
         # should be 4 - link, email, token, config item


### PR DESCRIPTION
Flask-Mail is again supported and part of Pallets-Eco. Flask-Mailman is still supported as before.