### PR TITLE
Simple check for null user_id on load.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.12
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: debug-statements
@@ -20,7 +20,7 @@ repos:
     -   id: pyupgrade
         args: [--py310-plus]
 -   repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -693,7 +693,12 @@ class FormInfo:
 
 
 def _user_loader(user_id):
-    """Load based on fs_uniquifier (alternative_id)."""
+    """Load based on fs_uniquifier (alternative_id).
+    If the db model and db are properly configured and set there is no way we should
+    ever see a null user_id. But it is clearly wrong.
+    """
+    if not user_id:
+        return None
     user = _security.datastore.find_user(fs_uniquifier=str(user_id))
     if user and user.active:
         set_request_attr("fs_authn_via", "session")

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -769,3 +769,18 @@ def test_fsqlalite_table_name(app):
     with app.app_context():
         Model.metadata.drop_all(db.engine)
         db.engine.dispose()
+
+
+def test_null_fs_uniquifier(app, client):
+    # If a record has a null fs_uniquifier - we shouldn't find it.
+    # The only way this might happen is if an app upgrades from a 3.0 Flask-Security
+    # and doesn't properly update their DB.
+    ds = app.security.datastore
+    with app.test_request_context("/"):
+        user = ds.find_user(email="gal@lp.com")
+        user.fs_uniquifier = ""
+        ds.put(user)
+        ds.commit()
+
+        user = app.security.login_manager.user_callback("")
+        assert not user

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -35,6 +35,7 @@ from tests.test_utils import (
     populate_data,
     reset_fresh,
     get_form_input,
+    is_authenticated,
 )
 from tests.test_webauthn import HackWebauthnUtil, reg_2_keys
 
@@ -1599,3 +1600,13 @@ def test_password_required_setting(app, sqlalchemy_datastore):
     with pytest.raises(ValueError) as vex:
         Security(app=app, datastore=sqlalchemy_datastore)
     assert "SECURITY_PASSWORD_REQUIRED can only be" in str(vex.value)
+
+
+def test_null_user_id(app, client, get_message):
+    # if DB not configured correctly - make sure we catch null fs_uniquifier
+    json_authenticate(client)
+    assert is_authenticated(client, get_message)
+    with client.session_transaction() as sess:
+        sess["_user_id"] = ""
+        sess["user_id"] = ""
+    assert not is_authenticated(client, get_message)


### PR DESCRIPTION
If properly configured this should never happen - but for folks upgrading from old Flask-Security its possible. We shouldn't ever return a DB record with a null fs_uniquifier.

close #1116