### PR TITLE
Pin bcrypt below 5.0 since they broke everything (passlib)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
 fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18", "sqlalchemy-utils>=0.41.1"]
-common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
+common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1,<5.0", "flask_mail>=0.10.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
 low = [
     # Lowest supported versions

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,7 @@ Flask-SQLAlchemy
 Flask-SQLAlchemy-Lite
 argon2-cffi
 authlib
-bcrypt
+bcrypt<5.0.0
 bleach
 coverage
 cryptography


### PR DESCRIPTION
See discussions:
https://github.com/notypecheck/passlib/pull/20

https://github.com/pyca/bcrypt/issues/1079

libpass has released a patch (pinning bcrypt) and is working on a fix