### PR TITLE
Fix realpostgres tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,6 +551,7 @@ def sqlalchemy_setup(app, tmpdir, realdburl):
         with app.app_context():
             if realdburl:
                 db.drop_all()
+                db.engine.dispose()  # make sure Flask-SQLAlchemy connections are closed
                 _teardown_realdb(db_info)
             engine = db.engine
             engine.dispose()

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -474,6 +474,7 @@ def test_uuid(app, request, tmpdir, realdburl):
     def tear_down():
         with app.app_context():
             db.drop_all()
+            db.engine.dispose()
             _teardown_realdb(db_info)
 
     request.addfinalizer(tear_down)
@@ -677,6 +678,7 @@ def test_permissions_41(request, app, realdburl):
         if realdburl:
             with app.app_context():
                 db.drop_all()
+                db.engine.dispose()
                 _teardown_realdb(db_info)
 
     request.addfinalizer(tear_down)

--- a/tox.ini
+++ b/tox.ini
@@ -116,7 +116,7 @@ commands =
 [testenv:realpostgres]
 deps =
     -r requirements/tests.txt
-    psycopg2
+    psycopg2-binary
 commands =
     # Requires that --realdburl be set otherwise doesn't actually use DB
     tox -e compile_catalog


### PR DESCRIPTION
psycopg2 has gotten stricter about ensuring all sessions/connections are closed prior to dropping a DB.

For Flask-SQLAlchemy we need to dispose of the db engine it creates.