### PR TITLE
Fix verify_password() with bcrypt 5.0

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -395,6 +395,8 @@ def verify_password(password: str | bytes, password_hash: str | bytes) -> bool:
     """
     if use_double_hash(password_hash):
         password = get_hmac(password)
+        if _pwd_context.identify(password_hash) == "bcrypt":
+            password = password[:72]
 
     return _pwd_context.verify(password, password_hash)
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -24,7 +24,7 @@ from flask_security.utils import (
 )
 
 
-def test_verify_password_double_hash(app, sqlalchemy_datastore):
+def test_verify_password_double_hash_argon2(app, sqlalchemy_datastore):
     init_app_with_options(
         app,
         sqlalchemy_datastore,
@@ -42,6 +42,22 @@ def test_verify_password_double_hash(app, sqlalchemy_datastore):
 
         # Verify double hash
         assert verify_password("pass", argon2.hash(get_hmac("pass")))
+
+
+def test_verify_password_double_hash_bcrypt(app, sqlalchemy_datastore):
+    init_app_with_options(
+        app,
+        sqlalchemy_datastore,
+        **{
+            "SECURITY_PASSWORD_HASH": "bcrypt",
+            "SECURITY_PASSWORD_SALT": "salty",
+            "SECURITY_PASSWORD_SINGLE_HASH": False,
+        },
+    )
+    with app.app_context():
+        hashed_pwd = hash_password("pass")
+        assert verify_password("pass", hashed_pwd)
+        assert hashed_pwd.startswith("$2")
 
 
 def test_verify_password_single_hash(app, sqlalchemy_datastore):


### PR DESCRIPTION
verify_password() fails with "password cannot be longer than 72 bytes" when bcrypt 5.0 is installed.

Fix this similar to how commit 29946778afe4 ("Move to libpass and support bcrypt 5.0 (#1143)") did it in other places.

Add a test. Extracting salt for comparing the result with bcrypt.hashpw() is too brittle; just skip this step.