### PR TITLE
Add default Cache-Control header to all responses.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,11 @@ Features & Improvements
 +++++++++++++++++++++++
 - (:pr:`1170`) Add API :py:meth:`.UserMixin.check_tf_required` to allow applications to control which users
   require two-factor authentication.
+- (:issue:`1178`) Add Cache-Control headers.
 
 Fixes
 +++++
+- (:issue:`1179`) Fix verify_password for bcrypt 5.0 (mephi42)
 
 Docs and Chores
 +++++++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -121,6 +121,30 @@ These configuration keys are used globally across all features.
 
     Default: ``lambda user: 0``
 
+
+.. py:data:: SECURITY_CACHE_CONTROL
+
+    Specifies the Cache-Control header attributes to be sent with all responses from Flask-Security endpoints.
+    Each entry in the dict is a (attribute, value) pair, where allowed attributes are
+    defined in the Flask documentation https://flask.palletsprojects.com/en/stable/api/#flask.Response.cache_control.
+
+    .. note::
+        Flask-Security does not pretend to handle the Cache-Control header for your application.
+        This default setting is to ensure that out of the box, Flask-Security responses
+        which might contain sensitive information aren't cached.
+        Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#cache_directives.
+
+    .. note::
+        Flask itself adds the 'Vary: Cookie' header to all responses that access the session (cookie).
+        This of course includes all non-anonymous Flask-Security endpoints as well as
+        any application endpoints that are decorated with a Flask-Security decorator.
+        This alone is likely enough to ensure no personal information is leaked.
+
+
+    Default: ``{"private": True, "no-store": True}``.
+
+     .. versionadded:: 5.8.0
+
 .. py:data:: SECURITY_EMAIL_VALIDATOR_ARGS
 
     Email address are validated and normalized via the ``mail_util_cls`` which

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -94,6 +94,7 @@ from .utils import _
 from .utils import config_value as cv
 from .utils import (
     FsPermNeed,
+    add_cache_control,
     csrf_cookie_handler,
     default_render_template,
     default_want_json,
@@ -350,6 +351,7 @@ _default_config: dict[str, t.Any] = {
     "US_EMAIL_SUBJECT": _("Verification Code"),
     "US_SETUP_WITHIN": "30 minutes",
     "US_SIGNIN_REPLACES_LOGIN": False,
+    "CACHE_CONTROL": {"private": True, "no-store": True},
     "CSRF_PROTECT_MECHANISMS": AUTHN_MECHANISMS,
     "CSRF_IGNORE_UNAUTH_ENDPOINTS": False,
     "CSRF_COOKIE_NAME": None,
@@ -1743,6 +1745,8 @@ class Security:
             self.two_factor_plugins.create_blueprint(app, bp, self)
             if self.oauthglue:
                 self.oauthglue._create_blueprint(app, bp)
+            if cv("CACHE_CONTROL", app=app):
+                bp.after_app_request(add_cache_control)
             app.register_blueprint(bp)
             app.context_processor(_context_processor)
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -1158,6 +1158,14 @@ def csrf_cookie_handler(response: Response) -> Response:
     return response
 
 
+def add_cache_control(resp: Response) -> Response:
+    """Add cache control header attributes to response."""
+    cc = config_value("CACHE_CONTROL") or dict()
+    for attr, v in cc.items():
+        resp.cache_control[attr] = v
+    return resp
+
+
 def base_render_json(
     form: FlaskForm,
     include_user: bool = True,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1048,6 +1048,7 @@ def test_login_info(client):
     json_authenticate(client)
     response = client.get("/login", headers={"Content-Type": "application/json"})
     assert response.status_code == 200
+    assert response.cache_control.private
     assert response.json["response"]["user"]["email"] == "matt@lp.com"
     assert "last_update" in response.json["response"]["user"]
 
@@ -1308,3 +1309,16 @@ def test_auth_token_decorator(app, client_nc):
         headers={"Content-Type": "application/json", "Authentication-Token": token},
     )
     assert response.status_code == 200
+
+
+@pytest.mark.settings(cache_control={"no-store": True})
+def test_override_cache_control(app, client_nc):
+    response = json_authenticate(client_nc)
+    assert not response.cache_control.private
+    assert response.cache_control.no_store
+
+
+@pytest.mark.settings(cache_control=None)
+def test_no_cache_control(app, client_nc):
+    response = json_authenticate(client_nc)
+    assert "Cache-Control" not in response.headers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,6 +92,8 @@ def verify_token(client_nc, token, status=None):
         "/token",
         headers={"Content-Type": "application/json", "Authentication-Token": token},
     )
+    assert response.cache_control.private
+    assert response.cache_control.no_store
     if status:
         assert response.status_code == status
     else:


### PR DESCRIPTION
As a default we use Cache-Control: private no-store private is the minimum required to ensure that no responses get cached in a shared cache. no-store goes further and requests that responses aren't cached at all - even at the browser. Note that some browsers (e.g. Chrome) have recently started, in some instances, to ignore no-store.

Flask-Security endpoints send and receive very little data - so not caching them shouldn't affect performance. As enumerated in issue #1178 - there are very few current APIs that return any sensitive information as part of a GET request that if allowed to be cached in a shared cache would enable information leaking. At least one place is in the case of using Authorization-Tokens, no sessions/session cookies. A GET /login from an authenticated user could return sensitive info that could be cached.

closes #1178