### PR TITLE
Add support for using Social Login (OAuth) for reauthentication (veri…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Features & Improvements
 - (:pr:`1170`) Add API :py:meth:`.UserMixin.check_tf_required` to allow applications to control which users
   require two-factor authentication.
 - (:issue:`1178`) Add Cache-Control headers.
+- (:issue:`1165`) Add support for using Social Login (OAuth) for verification.
 
 Fixes
 +++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -181,6 +181,8 @@ These configuration keys are used globally across all features.
     When this is enabled, the following must also be defined:
 
     - :py:data:`SECURITY_POST_OAUTH_LOGIN_VIEW`  (if :py:data:`SECURITY_OAUTH_ENABLE` is True)
+    - :py:data:`SECURITY_POST_OAUTH_VERIFY_VIEW`  (if :py:data:`SECURITY_OAUTH_ENABLE` is True)
+    - :py:data:`SECURITY_VERIFY_ERROR_VIEW`  (if :py:data:`SECURITY_OAUTH_ENABLE` is True)
     - :py:data:`SECURITY_LOGIN_ERROR_VIEW`
     - :py:data:`SECURITY_CONFIRM_ERROR_VIEW`
     - :py:data:`SECURITY_POST_CHANGE_EMAIL_VIEW`
@@ -412,7 +414,7 @@ These configuration keys are used globally across all features.
 .. py:data:: SECURITY_FRESHNESS
 
     A timedelta used to protect endpoints that alter sensitive information.
-    This is used to protect the following endpoints:
+    This is used to protect the following Flask Security endpoints:
 
         - :py:data:`SECURITY_US_SETUP_URL`
         - :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
@@ -421,6 +423,8 @@ These configuration keys are used globally across all features.
         - :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES`
         - :py:data:`SECURITY_CHANGE_EMAIL_URL`
 
+    This can also be used to protect application endpoints with the :meth:`flask_security.auth_required` decorator.
+
     Setting this to a negative number will disable any freshness checking and
     the endpoints:
 
@@ -428,6 +432,8 @@ These configuration keys are used globally across all features.
         - :py:data:`SECURITY_US_VERIFY_URL`
         - :py:data:`SECURITY_US_VERIFY_SEND_CODE_URL`
         - :py:data:`SECURITY_WAN_VERIFY_URL`
+        - :py:data:`SECURITY_OAUTH_VERIFY_START_URL`
+        - :py:data:`SECURITY_OAUTH_VERIFY_RESPONSE_URL`
 
     won't be registered.
     Setting this to 0 results in undefined behavior.
@@ -1939,8 +1945,8 @@ Additional relevant configuration variables:
     * :py:data:`SECURITY_TOTP_SECRETS` - TOTP/passlib is used to generate the codes.
     * :py:data:`SECURITY_TOTP_ISSUER`
 
-Social Oauth
--------------
+Social Login (OAuth)
+--------------------
     .. versionadded:: 5.1.0
 
 .. py:data:: SECURITY_OAUTH_ENABLE
@@ -1968,7 +1974,7 @@ Social Oauth
 .. py:data:: SECURITY_POST_OAUTH_LOGIN_VIEW
 
     Specifies the view/URL to redirect to after a successful authentication (login)
-    using social oauth.
+    using social login (OAuth).
     This is only valid if :py:data:`SECURITY_REDIRECT_BEHAVIOR` == ``"spa"``.
     Query params in the redirect will contain `identity` and `email`.
 
@@ -1976,7 +1982,46 @@ Social Oauth
 
     .. versionadded:: 5.4.0
 
+.. py:data:: SECURITY_OAUTH_VERIFY_START_URL
 
+    Endpoint for starting an Oauth reauthentication/verify operation.
+
+    Default: ``"/login/oauth-verify-start"``
+
+    .. versionadded:: 5.8.0
+
+.. py:data:: SECURITY_OAUTH_VERIFY_RESPONSE_URL
+
+    Endpoint used as the Oauth verify redirect.
+
+    Default: ``"/login/oauth-verify-response"``
+
+    .. versionadded:: 5.8.0
+
+.. py:data:: SECURITY_POST_OAUTH_VERIFY_VIEW
+
+    Specifies the view/URL to redirect to after a successful reauthentication (verify)
+    using social login/oauth.
+    This is only valid if :py:data:`SECURITY_REDIRECT_BEHAVIOR` == ``"spa"``.
+    Query params in the redirect will contain `identity` and `email`.
+
+    Default: ``None``.
+
+    .. versionadded:: 5.8.0
+
+.. py:data:: SECURITY_VERIFY_ERROR_VIEW
+
+    Specifies the view/URL to redirect to after the following login/authentication errors:
+
+    * GET on oauth-verify-response where there was an OAuth protocol error.
+    * GET on oauth-verify-response where the returned identity isn't registered.
+
+    This is only valid if :py:data:`SECURITY_REDIRECT_BEHAVIOR` == ``"spa"``.
+    Query params in the redirect will contain the error type and message.
+
+    Default: ``None``.
+
+    .. versionadded:: 5.8.0
 
 Feature Flags
 -------------
@@ -2015,6 +2060,8 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_URL` ``"/mf-recovery"``
 * :py:data:`SECURITY_OAUTH_START_URL` ``"/login/oauthstart"``
 * :py:data:`SECURITY_OAUTH_RESPONSE_URL` ``"/login/oauthresponse"``
+* :py:data:`SECURITY_OAUTH_VERIFY_START_URL` ``"/login/oauth-verify-start"``
+* :py:data:`SECURITY_OAUTH_VERIFY_RESPONSE_URL` ``"/login/oauth-verify-response"``
 * :py:data:`SECURITY_TWO_FACTOR_SELECT_URL` ``"/tf-select"``
 * :py:data:`SECURITY_TWO_FACTOR_SETUP_URL` ``"/tf-setup"``
 * :py:data:`SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL` ``"/tf-validate"``
@@ -2029,6 +2076,7 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_POST_RESET_VIEW`
 * :py:data:`SECURITY_POST_CHANGE_VIEW`
 * :py:data:`SECURITY_POST_OAUTH_LOGIN_VIEW`
+* :py:data:`SECURITY_POST_OAUTH_VERIFY_VIEW`
 * :py:data:`SECURITY_UNAUTHORIZED_VIEW`
 * :py:data:`SECURITY_RESET_VIEW`
 * :py:data:`SECURITY_RESET_ERROR_VIEW`
@@ -2041,6 +2089,7 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_US_VERIFY_URL`
 * :py:data:`SECURITY_US_VERIFY_SEND_CODE_URL`
 * :py:data:`SECURITY_US_POST_SETUP_VIEW`
+* :py:data:`SECURITY_VERIFY_ERROR_VIEW`
 * :py:data:`SECURITY_WAN_REGISTER_URL`
 * :py:data:`SECURITY_WAN_SIGNIN_URL`
 * :py:data:`SECURITY_WAN_DELETE_URL`

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -91,6 +91,8 @@ The following is a list of all the available context processor decorators:
 * ``tf_token_validation_context_processor``: Two factor token validation view
 * ``us_signin_context_processor``: Unified sign in view
 * ``us_setup_context_processor``: Unified sign in setup view
+* ``us_verify_context_processor``: Unified sign in verify view
+* ``verify_context_processor``: Verify view
 * ``wan_register_context_processor``: WebAuthn registration view
 * ``wan_signin_context_processor``: WebAuthn sign in view
 * ``wan_verify_context_processor``: WebAuthn verify view

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -284,10 +284,10 @@ registered. They can be completely disabled or their names can be changed.
 Run ``flask --help`` and look for users and roles.
 
 
-Social/OAuth Authentication
-----------------------------
+Social Login (OAuth) Authentication
+------------------------------------
 Flask-Security provides a thin layer which integrates `authlib`_ with Flask-Security
-views and features (such as two-factor authentication). Flask-Security is shipped
+views and features (such as two-factor authentication and verify). Flask-Security is shipped
 with support for github and google - others can be added by the application (see `loginpass`_
 for many examples).
 
@@ -306,7 +306,7 @@ We have seen issues with some providers when `SESSION_COOKIE_SAMESITE` = "strict
 The handshake (sometimes just the first time when the user is being asked to accept your application)
 fails due to the session cookie not getting sent as part of the redirect.
 
-A very simple example of configuring social auth with Flask-Security is available
+A very simple example of configuring social login with Flask-Security is available
 in the `examples` directory.
 
 .. _Click: https://palletsprojects.com/p/click/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,8 @@ Flask application. They include:
 5. Password management (recovery and resetting) (optional)
 6. Username management (configuration, recovery, change) (optional)
 7. Two-factor authentication via email, SMS, authenticator (optional)
-8. WebAuthn Support (optional)
-9. 'social'/OAuth for authentication (e.g. google, github, ..) (optional)
+8. Passkey (Webauthn) Support (optional)
+9. Social Login (OAuth) for authentication (e.g. google, github, ..) (optional)
 10. Change email (optional)
 11. Login tracking (optional)
 12. JSON/Ajax Support

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -249,6 +249,14 @@ paths:
                     description: <
                       True if caller has a registered WebAuthn Key which has a `usage` that
                       is allowed by the SECURITY_WAN_ALLOW_AS_VERIFY configuration setting.
+                  oauth_enabled:
+                    type: boolean
+                    description: True if SECURITY_OAUTH_ENABLE is True
+                  oauth_providers:
+                    type: array
+                    items:
+                      type: string
+                      description: A list of OAuth providers that have been registered.
     post:
       summary: Verify/Reauthentication
       parameters:
@@ -998,6 +1006,14 @@ paths:
                     description: <
                       True if caller has a registered WebAuthn Key which has a `usage` that
                       is allowed by the SECURITY_WAN_ALLOW_AS_VERIFY configuration setting.
+                  oauth_enabled:
+                    type: boolean
+                    description: True if SECURITY_OAUTH_ENABLE is True
+                  oauth_providers:
+                    type: array
+                    items:
+                      type: string
+                      description: A list of OAuth providers that have been registered.
     post:
       summary: Unified sign in verify/reauthentication
       parameters:
@@ -2081,12 +2097,13 @@ paths:
           type: string
           description: provider name as registered with OAuth (e.g. 'github')
     post:
-      summary: Start a 'social'/Oauth authentication exchange.
+      summary: Start a Social Login (OAuth) authentication exchange.
       responses:
         302:
           description: >
-            Redirect to OAuth provider. The redirect URL will pass along, if provided,
-            the value of the `next` query argument. If the caller is already
+            Redirect to OAuth provider. The value of the `next` query argument will be
+            stored in the session and retrieved when the OAuth provider
+            performs a GET on the redirect URL. If the caller is already
             authenticated redirect will be to ``SECURITY_POST_LOGIN_VIEW``
         400:
           description: Caller is already authenticated
@@ -2112,13 +2129,56 @@ paths:
           headers:
             Location:
               description: |
-                On spa-success: SECURITY_POST_OAUTH_ LOGIN_VIEW?identity={identity}&email={email}
+                On spa-success: SECURITY_POST_OAUTH_LOGIN_VIEW?identity={identity}&email={email}
 
                 On spa-oauth-error: SECURITY_LOGIN_ERROR_VIEW?error={msg}
 
                 On spa-unknown-user: SECURITY_LOGIN_ERROR_VIEW?error={msg}
 
                 On form-success: `next` or SECURITY_POST_LOGIN_VIEW
+              schema:
+                type: string
+  /login/oauth-verify-start/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          description: provider name as registered with OAuth (e.g. 'github')
+    post:
+      summary: Start a Social Login (OAuth) reauthentication exchange.
+      responses:
+        302:
+          description: >
+            Redirect to OAuth provider. The value of the `next` query argument will be
+            stored in the session and retrieved when the OAuth provider
+            performs a GET on the redirect URL.
+  /login/oauth-verify-response/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          description: provider name as registered with OAuth (e.g. 'github')
+    get:
+      summary: Response from OAuth provider.
+      responses:
+        302:
+          description: >
+            Caller will be redirected based on whether successful or not and whether
+            __SECURITY_REDIRECT_BEHAVIOR__ == 'spa'.
+          headers:
+            Location:
+              description: |
+                On spa-success: SECURITY_POST_OAUTH_VERIFY_VIEW?identity={identity}&email={email}
+
+                On spa-oauth-error: SECURITY_VERIFY_ERROR_VIEW?error={msg}
+
+                On spa-unknown-user: SECURITY_VERIFY_ERROR_VIEW?error={msg}
+
+                On form-success: `next` or SECURITY_POST_VERIFY_VIEW
               schema:
                 type: string
 

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -90,7 +90,8 @@ can be protected by requiring a 'fresh' or recent authentication. Flask-Security
     - :func:`.auth_required` takes parameters that define how recent the authentication must have happened. In addition a grace
       period can be specified so that multiple step operations don't require reauthentication in the middle.
     - A default :meth:`.Security.reauthn_handler` that is called when a request fails the recent authentication check.
-    - :py:data:`SECURITY_VERIFY_URL`, :py:data:`SECURITY_US_VERIFY_URL`, :py:data:`SECURITY_WAN_VERIFY_URL` endpoints
+    - :py:data:`SECURITY_VERIFY_URL`, :py:data:`SECURITY_US_VERIFY_URL`, :py:data:`SECURITY_WAN_VERIFY_URL`,
+      :py:data:`SECURITY_OAUTH_VERIFY_START_URL` endpoints
       that request the user to reauthenticate.
     - ``VerifyForm``, ``UsVerifyForm``, ``WebAuthnVerifyForm`` forms that can be extended.
 

--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -53,6 +53,8 @@ An example configuration:
     SECURITY_RESET_ERROR_VIEW = "/reset-password-error"
     SECURITY_LOGIN_ERROR_VIEW = "/login-error"
     SECURITY_POST_OAUTH_LOGIN_VIEW = "/post-oauth-login"
+    SECURITY_POST_OAUTH_VERIFY_VIEW = "/post-oauth-verify"
+    SECURITY_VERIFY_ERROR_VIEW = "/verify-error"
     SECURITY_REDIRECT_BEHAVIOR = "spa"
 
     # CSRF protection is critical for all session-based browser UIs

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -210,4 +210,4 @@ The decision whether to require a second factor after primary authentication is 
 The default implementation returns True if :py:data:`SECURITY_TWO_FACTOR_REQUIRED` is set OR the user has a two-factor method already setup AND
 recent two-factor authentication isn't 'valid' (see above).
 
-This method can be overridden in the applications User class. A common use case might be to require two-factor for any user with the 'admin' role.
+This method can be overridden in the application's User class. A common use case might be to require two-factor for any user with the 'admin' role.

--- a/examples/oauth/server/app.py
+++ b/examples/oauth/server/app.py
@@ -1,5 +1,5 @@
 """
-Copyright 2020-2024 by J. Christopher Wagner (jwag). All rights reserved.
+Copyright 2020-2026 by J. Christopher Wagner (jwag). All rights reserved.
 :license: MIT, see LICENSE for more details.
 
 A simple example of utilizing Flask-Security's OAuth glue layer.
@@ -20,6 +20,7 @@ This example uses github as the OAuth provider. Before this example will work:
     "GITHUB_CLIENT_ID" and "GITHUB_CLIENT_SECRET".
    See: https://docs.authlib.org/en/latest/client/flask.html# for details.
    (look under profile->settings->developer settings)
+   The redirect_url should be set to https://<your app>/login
 2) Register yourself (with your github email) with this application.
 
 Note: by default this uses an in-memory DB - so everytime you restart you lose all
@@ -90,6 +91,7 @@ def create_app():
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
     }
+    app.config["SECURITY_TOTP_ISSUER"] = "me"
     # app.config["SESSION_COOKIE_SAMESITE"] = "strict"
 
     # As of Flask-SQLAlchemy 2.4.0 it is easy to pass in options directly to the
@@ -138,6 +140,13 @@ def create_app():
     @auth_required()
     def home():
         return render_template_string("Hello {{ current_user.email }}")
+
+    @app.route("/superfresh")
+    @auth_required(within=1, grace=0)
+    def superfresh():
+        return render_template_string(
+            "Hello {{ current_user.email }} you are super fresh!"
+        )
 
     @app.route("/")
     def root():

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -197,10 +197,12 @@ _default_config: dict[str, t.Any] = {
     "POST_LOGOUT_VIEW": "/",
     "LOGIN_ERROR_VIEW": None,  # spa
     "POST_OAUTH_LOGIN_VIEW": None,  # spa
+    "POST_OAUTH_VERIFY_VIEW": None,  # spa
     "CONFIRM_ERROR_VIEW": None,  # spa
     "POST_CONFIRM_VIEW": None,  # spa
     "RESET_VIEW": None,  # spa
     "RESET_ERROR_VIEW": None,  # spa
+    "VERIFY_ERROR_VIEW": None,  # spa
     "POST_RESET_VIEW": None,
     "POST_CHANGE_VIEW": None,
     "POST_VERIFY_VIEW": None,
@@ -275,6 +277,8 @@ _default_config: dict[str, t.Any] = {
     "OAUTH_BUILTIN_PROVIDERS": ["github", "google"],
     "OAUTH_START_URL": "/login/oauthstart",
     "OAUTH_RESPONSE_URL": "/login/oauthresponse",
+    "OAUTH_VERIFY_START_URL": "/login/oauth-verify-start",
+    "OAUTH_VERIFY_RESPONSE_URL": "/login/oauth-verify-response",
     "CONFIRM_EMAIL_WITHIN": "5 days",
     "RESET_PASSWORD_WITHIN": "1 days",
     "LOGIN_WITHOUT_CONFIRMATION": False,

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -5,7 +5,7 @@ flask_security.decorators
 Flask-Security decorators module
 
 :copyright: (c) 2012-2019 by Matt Wright.
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -99,6 +99,10 @@ def default_reauthn_handler(within, grace):
         payload["unified_signin_enabled"] = is_us
         payload["has_webauthn_verify_credential"] = has_webauthn(
             current_user, cv("WAN_ALLOW_AS_VERIFY")
+        )
+        payload["oauth_enabled"] = cv("OAUTH_ENABLE")
+        payload["oauth_providers"] = (
+            _security.oauthglue.provider_names if cv("OAUTH_ENABLE") else []
         )
         return _security._render_json(payload, 401, None, None)
 
@@ -197,7 +201,7 @@ def handle_csrf(method: str, json_response: bool = False) -> ResponseValue | Non
 
         #) csrfProtect already checked and accepted the token
 
-    This means in the default config - CSRF is done as part of form validation
+    This means in the default config - CSRF is done as part of form validation,
     not here. Only if the application calls CSRFProtect(app) will this method
     do anything. Furthermore - since this is called PRIOR to form instantiation
     if the request is JSON - it MUST send the csrf_token as a header.
@@ -288,7 +292,7 @@ def auth_token_required(fn: DecoratedView) -> DecoratedView:
             return current_app.ensure_sync(fn)(*args, **kwargs)
         return _security._unauthn_handler(["token"])
 
-    return t.cast(DecoratedView, decorated)
+    return decorated
 
 
 def auth_required(
@@ -625,4 +629,4 @@ def anonymous_user_required(f: DecoratedView) -> DecoratedView:
                 return redirect(get_url(cv("POST_LOGIN_VIEW")))
         return current_app.ensure_sync(f)(*args, **kwargs)
 
-    return t.cast(DecoratedView, wrapper)
+    return wrapper

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -4,13 +4,14 @@ flask_security.oauth_glue
 
 Class and methods to glue our login path with authlib for to support 'social' auth.
 
-:copyright: (c) 2022-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2022-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
 """
 
 from __future__ import annotations
 
+import time
 import typing as t
 
 try:
@@ -27,7 +28,7 @@ except ImportError:  # pragma: no cover
 from flask import abort, after_this_request, redirect, request, session
 from flask_login import current_user
 
-from .decorators import unauth_csrf
+from .decorators import auth_required, unauth_csrf
 from .oauth_provider import (
     OauthCbType,
     FsOAuthProvider,
@@ -52,6 +53,7 @@ from .utils import (
 if t.TYPE_CHECKING:  # pragma: no cover
     import flask
     from flask.typing import ResponseValue
+    from flask_security import UserMixin
 
 
 @unauth_csrf()
@@ -60,7 +62,7 @@ def oauthstart(name: str) -> ResponseValue:
     Name is a pre-registered OAuth provider.
     TODO: remember me?
     """
-    assert _security.oauthglue
+    assert _security.oauthglue is not None
     if is_user_authenticated(current_user):
         # Just redirect current_user to POST_LOGIN_VIEW.
         # For json - return an error.
@@ -81,7 +83,29 @@ def oauthstart(name: str) -> ResponseValue:
     session.pop("fs_oauth_next", None)
     if request.args.get("next"):
         session["fs_oauth_next"] = request.args.get("next")
-    return _security.oauthglue.get_redirect(name)
+    return _security.oauthglue.get_redirect(name, "oauthresponse")
+
+
+def _oauth_response_common(name: str) -> tuple[t.Any, UserMixin | None] | t.NoReturn:
+    """
+    Common code for oauth response (login or verify)
+    This can abort or raise an OAuthError or return a
+    tuple of (field_value, user)
+    """
+    assert _security.oauthglue is not None
+    authlib_provider = _security.oauthglue.authlib_provider(name)
+    oauth_provider = _security.oauthglue.providers.get(name)
+    if not authlib_provider or not oauth_provider:
+        # this should only happen with purposeful bad API call
+        abort(404)  # TODO - redirect... to where?
+    # This parses the Flask Request and can raise an OAuthError
+    token = authlib_provider.authorize_access_token()
+
+    field_name, field_value = oauth_provider.fetch_identity_cb(
+        _security.oauthglue.oauth_app, token
+    )
+    user = _security.datastore.find_user(**{field_name: field_value})
+    return field_value, user
 
 
 def oauthresponse(name: str) -> ResponseValue:
@@ -91,27 +115,18 @@ def oauthresponse(name: str) -> ResponseValue:
     We may have stored the original 'next' in the session
     N.B. all responses MUST be redirects.
     """
-    assert _security.oauthglue
-    authlib_provider = _security.oauthglue.authlib_provider(name)
+    assert _security.oauthglue is not None
     oauth_provider = _security.oauthglue.providers.get(name)
-    if not authlib_provider or not oauth_provider:
-        # this should only happen with purposeful bad API call
-        abort(404)  # TODO - redirect... to where?
-    # This parses the Flask Request
     try:
-        token = authlib_provider.authorize_access_token()
+        field_value, user = _oauth_response_common(name)
     except OAuthError as e:
         """One known way this can happen is if the session cookie 'samesite'
         is set to 'strict' and e.g. the first time the user goes to github
         and has to authorize this app and then redirect - the session
         cookie isn't sent - and by default that is where the state is kept.
         """
-        return oauth_provider.oauth_response_failure(e)
-
-    field_name, value = oauth_provider.fetch_identity_cb(
-        _security.oauthglue.oauth_app, token
-    )
-    user = _security.datastore.find_user(**{field_name: value})
+        assert oauth_provider is not None
+        return oauth_provider.oauth_response_failure("LOGIN_ERROR_VIEW", e)
     if user:
         after_this_request(view_commit)
         next_loc = session.pop("fs_oauth_next", None)
@@ -120,21 +135,20 @@ def oauthresponse(name: str) -> ResponseValue:
         )
         if response:
             return response
-        # two factor not required - login user
+        # two-factor not required - login user
         login_user(user)
         if cv("REDIRECT_BEHAVIOR") == "spa":
-            return redirect(
-                get_url(
-                    cv("POST_OAUTH_LOGIN_VIEW"), qparams=user.get_redirect_qparams()
-                )
+            redirect_url = get_url(
+                cv("POST_OAUTH_LOGIN_VIEW"), qparams=user.get_redirect_qparams()
             )
-        redirect_url = get_post_action_redirect(
-            "SECURITY_POST_LOGIN_VIEW", dict(next=next_loc)
-        )
+        else:
+            redirect_url = get_post_action_redirect(
+                "SECURITY_POST_LOGIN_VIEW", dict(next=next_loc)
+            )
         return redirect(redirect_url)
     # Seems ok to show identity - the only identity it could be is the callers
     # so seems no way this can be used to enumerate registered users.
-    m, c = get_message("IDENTITY_NOT_REGISTERED", id=value)
+    m, c = get_message("IDENTITY_NOT_REGISTERED", id=field_value)
     if cv("REDIRECT_BEHAVIOR") == "spa":
         return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
     do_flash(m, c)
@@ -142,12 +156,71 @@ def oauthresponse(name: str) -> ResponseValue:
     return redirect(url_for_security("login"))
 
 
+@auth_required(lambda: cv("API_ENABLED_METHODS"))
+def oauth_verify_start(name: str) -> ResponseValue:
+    """
+    Re-authenticate to reset freshness time.
+    With a forms-based app this is the result of a reauthn_handler redirect.
+    """
+    # we never want to return here or to the redirect location.
+    # Some providers match on entire redirect url - so we don't want to
+    # store next there. Use session.
+    assert _security.oauthglue is not None
+    session.pop("fs_oauth_next", None)
+    if request.args.get("next"):
+        session["fs_oauth_next"] = request.args.get("next")
+    return _security.oauthglue.get_redirect(name, "oauth_verify_response")
+
+
+def oauth_verify_response(name: str) -> ResponseValue:
+    """
+    Callback from oauth provider - response is provider-specific
+    Since this is a callback from oauth provider - there is no form,
+    We may have stored the original 'next' in the session
+    N.B. all responses MUST be redirects.
+    """
+    assert _security.oauthglue is not None
+    oauth_provider = _security.oauthglue.providers.get(name)
+    try:
+        field_value, user = _oauth_response_common(name)
+    except OAuthError as e:
+        """One known way this can happen is if the session cookie 'samesite'
+        is set to 'strict' and e.g. the first time the user goes to github
+        and has to authorize this app and then redirect - the session
+        cookie isn't sent - and by default that is where the state is kept.
+        """
+        assert oauth_provider is not None
+        return oauth_provider.oauth_response_failure("VERIFY_ERROR_VIEW", e)
+    next_loc = session.pop("fs_oauth_next", None)
+    if user:
+        # verified - so set freshness time.
+        session["fs_paa"] = time.time()
+        if cv("REDIRECT_BEHAVIOR") == "spa":
+            redirect_url = get_url(
+                cv("POST_OAUTH_VERIFY_VIEW"), qparams=user.get_redirect_qparams()
+            )
+        else:
+            do_flash(*get_message("REAUTHENTICATION_SUCCESSFUL"))
+            redirect_url = get_post_action_redirect(
+                "SECURITY_POST_VERIFY_VIEW", dict(next=next_loc)
+            )
+        return redirect(redirect_url)
+
+    m, c = get_message("IDENTITY_NOT_REGISTERED", id=field_value)
+    if cv("REDIRECT_BEHAVIOR") == "spa":
+        return redirect(get_url(cv("VERIFY_ERROR_VIEW"), qparams={c: m}))
+    do_flash(m, c)
+    # Go back to verify - this is the same logic as in default_reauthn_handler
+    view = "us_verify" if cv("UNIFIED_SIGNIN") else "verify"
+    return redirect(url_for_security(view, next=next_loc))
+
+
 class OAuthGlue:
     """
     Provide the necessary glue between the Flask-Security login process and
     authlib oauth client code.
 
-    There are some builtin providers which can be used or not - configured via
+    There are some builtin providers that can be used or not - configured via
     :py:data:`SECURITY_OAUTH_BUILTIN_PROVIDERS`. Any other provider can be registered
     using :py:meth:`register_provider_ext`.
 
@@ -158,6 +231,9 @@ class OAuthGlue:
     .. versionchanged:: 5.4.0
         Added register_provider_ext which allows applications more control to
         manage new providers (such as extended error handling).
+
+    .. versionchanged:: 5.8.0
+        Added endpoints for verify using OAuth.
     """
 
     def __init__(self, app: flask.Flask, oauthapp: OAuth | None = None):
@@ -187,19 +263,33 @@ class OAuthGlue:
             endpoint="oauthresponse",
         )(oauthresponse)
 
-    def get_redirect(self, name: str, **values: t.Any) -> ResponseValue:
+        if cv("FRESHNESS", app=app).total_seconds() >= 0:
+            verify_start_url = cv("OAUTH_VERIFY_START_URL", app=app)
+            bp.route(
+                verify_start_url + slash_url_suffix(verify_start_url, "<name>"),
+                methods=["POST"],
+                endpoint="oauth_verify_start",
+            )(oauth_verify_start)
+            verify_response_url = cv("OAUTH_VERIFY_RESPONSE_URL", app=app)
+            bp.route(
+                verify_response_url + slash_url_suffix(verify_response_url, "<name>"),
+                methods=["GET"],
+                endpoint="oauth_verify_response",
+            )(oauth_verify_response)
+
+    def get_redirect(
+        self, name: str, endpoint: str, **values: t.Any
+    ) -> ResponseValue | t.NoReturn:
         authlib_provider = self.authlib_provider(name)
         if not authlib_provider:
-            return abort(404)
-        start_uri = url_for_security(
-            "oauthresponse", name=name, _external=True, **values
-        )
+            abort(404)
+        start_uri = url_for_security(endpoint, name=name, _external=True, **values)
         redirect_url = authlib_provider.authorize_redirect(start_uri)
         return redirect_url
 
     @property
-    def provider_names(self):
-        return self.providers.keys()
+    def provider_names(self) -> list[str]:
+        return list(self.providers.keys())
 
     @property
     def oauth_app(self):

--- a/flask_security/oauth_provider.py
+++ b/flask_security/oauth_provider.py
@@ -81,7 +81,7 @@ class FsOAuthProvider:
             raise NotImplementedError
         return self._fetch_identity_cb(oauth, token)
 
-    def oauth_response_failure(self, e: OAuthError) -> ResponseValue:
+    def oauth_response_failure(self, error_view: str, e: OAuthError) -> ResponseValue:
         """Called if authlib authorize_access_token throws an error.
 
         N.B. flashing doesn't seem to work in some cases - if the session
@@ -91,7 +91,7 @@ class FsOAuthProvider:
             "OAUTH_HANDSHAKE_ERROR", exerror=e.error, exdesc=e.description
         )
         if cv("REDIRECT_BEHAVIOR") == "spa":
-            return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
+            return redirect(get_url(cv(error_view), qparams={c: m}))
         do_flash(m, c)
         return redirect(url_for_security("login"))
 

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -30,5 +30,19 @@
       {{ render_field(wan_verify_form.submit) }}
     </form>
   {% endif %}
+  {% if security.oauthglue %}
+    <hr class="fs-gap">
+    <h2>{{ _fsdomain("Use Social Login to Reauthenticate") }}</h2>
+    {% for provider in security.oauthglue.provider_names %}
+      <div class="fs-gap">
+        <form method="post" id="{{ provider }}_form" name="{{ provider }}_form">
+          <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Continue with %(provider)s', provider=provider) }}" formaction="{{ url_for_security('oauth_verify_start', name=provider) }}{{ prop_next() }}">
+          {% if csrf_token is defined %}
+            <input id="{{ provider }}_csrf_token" name="{{ provider }}_csrf_token" type="hidden" value="{{ csrf_token() }}">
+          {% endif %}
+        </form>
+      </div>
+    {% endfor %}
+  {% endif %}
   {% include "security/_menu.html" %}
 {% endblock content %}

--- a/flask_security/templates/security/verify.html
+++ b/flask_security/templates/security/verify.html
@@ -19,4 +19,18 @@
       {{ render_field(wan_verify_form.submit) }}
     </form>
   {% endif %}
+  {% if security.oauthglue %}
+    <hr class="fs-gap">
+    <h2>{{ _fsdomain("Use Social Login to Reauthenticate") }}</h2>
+    {% for provider in security.oauthglue.provider_names %}
+      <div class="fs-gap">
+        <form method="post" id="{{ provider }}_form" name="{{ provider }}_form">
+          <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Continue with %(provider)s', provider=provider) }}" formaction="{{ url_for_security('oauth_verify_start', name=provider) }}{{ prop_next() }}">
+          {% if csrf_token is defined %}
+            <input id="{{ provider }}_csrf_token" name="{{ provider }}_csrf_token" type="hidden" value="{{ csrf_token() }}">
+          {% endif %}
+        </form>
+      </div>
+    {% endfor %}
+  {% endif %}
 {% endblock content %}

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -664,6 +664,12 @@ def us_verify() -> ResponseValue:
             "available_methods": cv("US_ENABLED_METHODS"),
             "code_methods": code_methods,
             "has_webauthn_verify_credential": webauthn_available,
+            "oauth_enabled": cv("OAUTH_ENABLE"),
+            "oauth_providers": (
+                _security.oauthglue.provider_names  # type: ignore[union-attr]
+                if cv("OAUTH_ENABLE")
+                else []
+            ),
         }
         return base_render_json(form, additional=payload)
 
@@ -958,7 +964,7 @@ def us_setup() -> ResponseValue:
 def us_setup_validate(token: str) -> ResponseValue:
     """
     Validate new setup.
-    The token is the state variable which is signed and timed
+    The token is the state variable that is signed and timed
     and contains all the state that once confirmed will be stored in the user record.
     """
     form = t.cast(

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -261,6 +261,10 @@ def verify():
     if _security._want_json(request):
         payload = {
             "has_webauthn_verify_credential": webauthn_available,
+            "oauth_enabled": cv("OAUTH_ENABLE"),
+            "oauth_providers": (
+                _security.oauthglue.provider_names if cv("OAUTH_ENABLE") else []
+            ),
         }
         return base_render_json(form, additional=payload)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1177,6 +1177,8 @@ def test_verify_fresh_json(app, client, get_message):
     response = client.get("/fresh", headers=headers)
     assert response.status_code == 401
     assert response.json["response"]["reauth_required"]
+    assert not response.json["response"]["oauth_enabled"]
+    assert not response.json["response"]["oauth_providers"]
 
     response = client.get("/verify")
     assert b"Reauthenticate" in response.data

--- a/tests/test_oauthglue.py
+++ b/tests/test_oauthglue.py
@@ -4,7 +4,7 @@ test_oauthglue.py
 
 OAuth glue tests - oauthglue is a very thin shim between FS and authlib
 
-:copyright: (c) 2022-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2022-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -18,6 +18,7 @@ from flask_wtf import CSRFProtect
 from flask_security import FsOAuthProvider
 from tests.test_utils import (
     authenticate,
+    capture_flashes,
     check_location,
     get_csrf_token,
     get_form_action,
@@ -25,7 +26,9 @@ from tests.test_utils import (
     get_session,
     init_app_with_options,
     is_authenticated,
+    json_authenticate,
     logout,
+    reset_fresh,
     setup_tf_sms,
 )
 
@@ -337,7 +340,8 @@ def test_provider_class(app, sqlalchemy_datastore, get_message):
             profile = resp.json()
             return "email", profile["email"]
 
-        def oauth_response_failure(self, e):
+        def oauth_response_failure(self, error_view, e):
+            assert isinstance(e, MismatchingStateError)
             return redirect("/uh-oh")
 
     init_app_with_options(
@@ -367,3 +371,143 @@ def test_provider_class(app, sqlalchemy_datastore, get_message):
     assert response.status_code in [302, 303]
     assert check_location(app, response.location, "/post_login")
     assert is_authenticated(client, get_message)
+
+
+@pytest.mark.settings(oauth_enable=True, post_verify_view="/post_verify")
+def test_verify(app, sqlalchemy_datastore, get_message):
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"security_args": {"oauth": MockOAuth()}}
+    )
+    client = app.test_client()
+
+    # just authenticate using github
+    client.get("/login/oauthresponse/github", follow_redirects=False)
+    assert is_authenticated(client, get_message)
+
+    reset_fresh(client, app.config["SECURITY_FRESHNESS"])
+    # This will return the /verify form
+    response = client.get("/fresh", follow_redirects=True)
+    github_url = get_form_action(response, 1)
+    assert "oauth-verify-start" in github_url
+    response = client.post(github_url, follow_redirects=False)
+    assert "/whatever" in response.location
+    session = get_session(response)
+    assert "fs_oauth_next" in session
+
+    with capture_flashes() as flashes:
+        response = client.get(
+            "/login/oauth-verify-response/github", follow_redirects=True
+        )
+    assert flashes[0]["category"] == "info"
+    assert flashes[0]["message"].encode("utf-8") == get_message(
+        "REAUTHENTICATION_SUCCESSFUL"
+    )
+    assert b"Fresh Only" in response.data
+    session = get_session(response)
+    assert "fs_oauth_next" not in session
+
+
+@pytest.mark.settings(oauth_enable=True)
+def test_verify_unknown_user(app, sqlalchemy_datastore, get_message):
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"security_args": {"oauth": MockOAuth()}}
+    )
+    client = app.test_client()
+    authenticate(client)
+    oauth_app = app.security.oauthglue.oauth_app
+    oauth_app.github.set_identity("jwag@lp.com")  # this will cause response to fail
+
+    reset_fresh(client, app.config["SECURITY_FRESHNESS"])
+    response = client.get("/fresh", follow_redirects=True)
+    github_url = get_form_action(response, 1)
+    response = client.post(github_url, follow_redirects=False)
+
+    with capture_flashes() as flashes:
+        redirect_url = urllib.parse.urlsplit(urllib.parse.unquote(response.location))
+        local_redirect = urllib.parse.parse_qs(redirect_url.query)["redirect_uri"][0]
+        response = client.get(local_redirect, follow_redirects=True)
+    assert flashes[0]["category"] == "error"
+    assert flashes[0]["message"].encode("utf-8") == get_message(
+        "IDENTITY_NOT_REGISTERED", id="jwag@lp.com"
+    )
+    assert b"Reauthenticate" in response.data
+    session = get_session(response)
+    assert "fs_oauth_next" not in session
+
+
+@pytest.mark.settings(
+    oauth_enable=True,
+    oauth_builtin_providers=["github"],
+    post_oauth_verify_view="/post_oauth_verify",
+    redirect_host="myui.com:8090",
+    redirect_behavior="spa",
+)
+def test_verify_spa(app, sqlalchemy_datastore, get_message):
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"security_args": {"oauth": MockOAuth()}}
+    )
+    client = app.test_client()
+    json_authenticate(client)
+
+    reset_fresh(client, app.config["SECURITY_FRESHNESS"])
+    response = client.get("/fresh", headers=headers)
+    assert response.json["response"]["reauth_required"]
+    assert response.json["response"]["oauth_enabled"]
+    assert response.json["response"]["oauth_providers"] == ["github"]
+
+    response = client.post("/login/oauth-verify-start/github", follow_redirects=False)
+    assert "/whatever" in response.location
+
+    # this is what github would call
+    response = client.get("/login/oauth-verify-response/github", follow_redirects=False)
+    assert (
+        response.location == "//myui.com:8090/post_oauth_verify?"
+        "email=matt%40lp.com&identity=matt%40lp.com"
+    )
+
+
+@pytest.mark.settings(
+    oauth_enable=True, redirect_behavior="spa", verify_error_view="/verify-error"
+)
+def test_verify_unknown_user_spa(app, sqlalchemy_datastore, get_message):
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"security_args": {"oauth": MockOAuth()}}
+    )
+    client = app.test_client()
+    json_authenticate(client)
+
+    reset_fresh(client, app.config["SECURITY_FRESHNESS"])
+    oauth_app = app.security.oauthglue.oauth_app
+    oauth_app.github.set_identity("jwag@lp.com")
+
+    # what github would have called
+    response = client.get("/login/oauth-verify-response/github")
+    assert "/verify-error" in response.location
+    assert "not+registered" in response.location
+
+
+@pytest.mark.settings(
+    oauth_enable=True, redirect_behavior="spa", verify_error_view="/verify-error"
+)
+def test_verify_spa_exc(app, sqlalchemy_datastore, get_message):
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"security_args": {"oauth": MockOAuth()}}
+    )
+    client = app.test_client()
+    json_authenticate(client)
+    # try fake oauth exception
+    from authlib.integrations.base_client.errors import MismatchingStateError
+
+    oauth_app = app.security.oauthglue.oauth_app
+    oauth_app.github.set_exception(MismatchingStateError)
+    response = client.get("/login/oauth-verify-response/github", follow_redirects=False)
+    split = urlsplit(response.location)
+    assert "/verify-error" == split.path
+    qparams = dict(parse_qsl(split.query))
+    msg = get_message(
+        "OAUTH_HANDSHAKE_ERROR",
+        exerror="mismatching_state",
+        exdesc="CSRF Warning! State not equal in request and response.",
+    )
+    assert qparams["error"] == msg.decode()

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1067,6 +1067,8 @@ def test_verify_json(app, client, get_message):
     assert set(response.json["response"]["code_methods"]) == {
         "email",
     }
+    assert not response.json["response"]["oauth_enabled"]
+    assert not response.json["response"]["oauth_providers"]
 
     response = client.post(
         "us-verify/send-code",


### PR DESCRIPTION
…fy).

Also - change documentation to refer to Social Login (OAuth) which is more user-facing friendly Change the button labels to 'Continue with github' - will do the login button in another PR. Improved JSON payload for reauthentication responses, /us-verify, and /verify by adding whether OAuth feature is enabled and which providers are configured.

close #1165