### PR TITLE
Support for tracking failed authentication.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Features & Improvements
   require two-factor authentication.
 - (:issue:`1178`) Add Cache-Control headers.
 - (:issue:`1165`) Add support for using Social Login (OAuth) for verification.
+- (:issue:`1188`) Add tracking of failed authentication attempts via :py:meth:`.UserMixin.track_failed_authn`
+  and :py:data:`user_failed_authn`
 
 Fixes
 +++++

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -284,7 +284,7 @@ sends the following signals.
     sender), it is passed `user`, and `authn_via` arguments. The `authn_via` argument
     specifies how the user authenticated - it will be a list with possible values
     of ``password``, ``sms``, ``authenticator``, ``email``, ``confirm``, ``reset``,
-    ``register``.
+    ``register``, ``webauthn``, ``oauth``.
 
     .. versionadded:: 3.4.0
 
@@ -295,6 +295,18 @@ sends the following signals.
    It is passed the app (which is the sender).
 
     .. versionadded:: 5.4.0
+
+.. data:: user_failed_authn
+
+   Sent from :py:meth:`.UserMixin.track_failed_authn` when a user fails authentication.
+   In addition to the app (which is the sender) it is passed:
+
+    * `user` - the user that failed authentication
+    * `endpoint` - the endpoint that was accessed
+    * `auth_type` - `password`, `code`, `passkey`
+    * `tfa` - True if this was a two factor authentication attempt
+
+    .. versionadded:: 5.8.0
 
 .. data:: user_registered
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -86,6 +86,7 @@ from .signals import (
     tf_security_token_sent,
     tf_disabled,
     user_authenticated,
+    user_failed_authn,
     user_unauthenticated,
     user_confirmed,
     user_registered,

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -70,6 +70,7 @@ from .recovery_codes import (
     MfRecoveryCodesForm,
     MfRecoveryCodesUtil,
 )
+from .signals import user_failed_authn
 from .tf_plugin import TfPlugin, TwoFactorSelectForm
 from .twofactor import tf_send_security_token
 from .unified_signin import (
@@ -1145,6 +1146,45 @@ class UserMixin(BaseUserMixin):
         .. versionadded:: 5.8.0
         """
         return cv("TWO_FACTOR_REQUIRED")
+
+    def track_failed_authn(
+        self, endpoint: str | None, auth_type: str, tfa: bool = False
+    ) -> None:
+        """Called when a user fails to authenticate.
+
+        endpoint - blueprint endpoint name:
+
+            - security.login
+            - security.verify
+            - security.us_signin
+            - security.us_verify
+            - security.us_verify_link
+            - security.wan_signin_response
+            - security.wan_verify_response
+            - security.two_factor_token_validation
+
+        auth_type is what failed:
+
+            - password
+            - passcode (unified signin)
+            - passkey (webauthn
+
+        tfa - True if it was a second factor that failed
+
+        This is called any time a credential is presented but is not verifiable.
+        It is NOT called on API errors or missing data.
+
+        The default implementation sends the user_failed_authn signal.
+
+        """
+        user_failed_authn.send(
+            current_app._get_current_object(),  # type: ignore[attr-defined]
+            _async_wrapper=current_app.ensure_sync,
+            endpoint=endpoint,
+            user=self,
+            auth_type=auth_type,
+            tfa=tfa,
+        )
 
 
 class WebAuthnMixin:

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -6,7 +6,7 @@ Flask-Security forms module
 
 :copyright: (c) 2012 by Matt Wright.
 :copyright: (c) 2017 by CERN.
-:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -596,12 +596,14 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
             return False
         if not self.user.password:
             # This is result of PASSWORD_REQUIRED=False and UNIFIED_SIGNIN
+            self.user.track_failed_authn(request.endpoint, "password")
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             # Reduce timing variation between existing and non-existing users
             hash_password(self.password.data)
             return False
         self.password.data = _security.password_util.normalize(self.password.data)
         if not self.user.verify_and_update_password(self.password.data):
+            self.user.track_failed_authn(request.endpoint, "password")
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             return False
 
@@ -661,6 +663,7 @@ class VerifyForm(Form, PasswordFormMixin):
         self.password.data = _security.password_util.normalize(self.password.data)
         assert isinstance(self.password.errors, list)
         if not self.user.verify_and_update_password(self.password.data):
+            self.user.track_failed_authn(request.endpoint, "password")
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             return False
         return True
@@ -1012,6 +1015,7 @@ class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
         self.primary_method: str = ""
         self.tf_totp_secret: str = ""
         self.user: UserMixin | None = None  # set by view
+        self.is_setup: bool = False
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):  # pragma: no cover
@@ -1038,6 +1042,8 @@ class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
             user=self.user,
             window=self.window,
         ):
+            if not self.is_setup:
+                self.user.track_failed_authn(request.endpoint, "code", True)
             self.code.errors.append(get_message("TWO_FACTOR_INVALID_TOKEN")[0])
             return False
 

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -136,7 +136,7 @@ def oauthresponse(name: str) -> ResponseValue:
         if response:
             return response
         # two-factor not required - login user
-        login_user(user)
+        login_user(user, authn_via=["oauth"])
         if cv("REDIRECT_BEHAVIOR") == "spa":
             redirect_url = get_url(
                 cv("POST_OAUTH_LOGIN_VIEW"), qparams=user.get_redirect_qparams()

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -5,7 +5,7 @@ flask_security.signals
 Flask-Security signals module
 
 :copyright: (c) 2012 by Matt Wright.
-:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -16,6 +16,8 @@ signals = blinker.Namespace()
 user_authenticated = signals.signal("user-authenticated")
 
 user_unauthenticated = signals.signal("user-unauthenticated")
+
+user_failed_authn = signals.signal("user-failed-authn")
 
 user_registered = signals.signal("user-registered")
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -213,6 +213,7 @@ class _UnifiedPassCodeForm(Form):
                         ok = True
                         break
             if not ok:
+                self.user.track_failed_authn(request.endpoint, "passcode")
                 self.passcode.errors.append(get_message("INVALID_PASSWORD_CODE")[0])
                 return False
 
@@ -721,6 +722,8 @@ def us_verify_link() -> ResponseValue:
         window=cv("US_TOKEN_VALIDITY"),
     ):
         m, c = generic_message("INVALID_CODE", "GENERIC_AUTHN_FAILED")
+        user.track_failed_authn(request.endpoint, "passcode")
+
         if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(
                 get_url(

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -951,6 +951,7 @@ def two_factor_setup_validate(token: str) -> ResponseValue:
     form.tf_totp_secret = totp_secret
     form.primary_method = method
     form.user = current_user
+    form.is_setup = True
 
     if form.validate_on_submit():
         tf_clean_session()  # until we completely remove session based setup/state
@@ -1040,6 +1041,7 @@ def two_factor_token_validation():
             logout_user()
             return tf_illegal_state(form, cv("TWO_FACTOR_ERROR_VIEW"))
         form.user = current_user
+        form.is_setup = True
 
     form.primary_method = pm
     form.tf_totp_secret = totp_secret

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -4,7 +4,7 @@ flask_security.webauthn
 
 Flask-Security WebAuthn module
 
-:copyright: (c) 2021-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2021-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
 This implements support for webauthn/FIDO2 Level 2 using the py_webauthn package.
@@ -342,7 +342,7 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
             credential_public_key=self.cred.public_key,
             credential_current_sign_count=self.cred.sign_count,
         )
-        # Start by verifying requiring user_verification - if that succeeds then
+        # Start by verifying requiring user_verification - if that succeeds, then
         # this authn could be used for both primary and secondary.
         # If it fails, then try to verify with user_verification == False - unless
         # as part of signin the app required user_verification (as stored in the state)
@@ -358,6 +358,7 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
                 self.credential.errors.append(
                     get_message("WEBAUTHN_NO_VERIFY", cause=str(exc))[0]
                 )
+                self.user.track_failed_authn(request.endpoint, "passkey")
                 return False
         return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -986,6 +986,38 @@ def client_nc(request, app, sqlalchemy_datastore):
     return app.test_client(use_cookies=False)
 
 
+@pytest.fixture()
+def signals():
+    """Tracks signal calls for testing purposes.
+
+    This sets up a receiver for all signals and tracks the data
+    """
+    from flask_security import signals
+    import inspect
+    import blinker
+
+    signal_calls = dict()
+    def_signals = inspect.getmembers(
+        signals, lambda v: isinstance(v, blinker.NamedSignal)
+    )
+
+    for name, sig in def_signals:
+        sc = signal_calls[name] = []
+
+        def _on(app, _sc=sc, **kwargs):
+            assert isinstance(app, Flask)
+            # user argument is an ORM structure so may not be available in a test
+            # outside of the request - capture value(s) here
+            user = kwargs.get("user", None)
+            if user:
+                assert isinstance(kwargs["user"], UserMixin)
+                kwargs["user_email"] = user.email
+            _sc.append(kwargs)
+
+        sig.connect(_on, weak=False)
+    return signal_calls
+
+
 @pytest.fixture(
     params=[
         "cl-fsqlalchemy",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -387,9 +387,13 @@ def test_invalid_user(client, get_message):
     assert get_message("USER_DOES_NOT_EXIST") in response.data
 
 
-def test_bad_password(client, get_message):
+def test_bad_password(client, get_message, signals):
     response = authenticate(client, password="bogus")
     assert get_message("INVALID_PASSWORD") in response.data
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.login"
+    assert signals["user_failed_authn"][0]["user_email"] == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "password"
+    assert not signals["user_failed_authn"][0]["tfa"]
 
 
 def test_inactive_user(client, get_message):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -27,6 +27,7 @@ from tests.test_utils import (
     capture_flashes,
     capture_reset_password_requests,
     check_location,
+    check_signals,
     check_xlation,
     get_csrf_token,
     init_app_with_options,
@@ -1168,7 +1169,7 @@ def test_verify_fresh(app, client, get_message):
     assert b"Fresh Only" in response.data
 
 
-def test_verify_fresh_json(app, client, get_message):
+def test_verify_fresh_json(app, client, get_message, signals):
     # Hit a fresh-required endpoint and walk through verify
     authenticate(client)
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -1187,6 +1188,10 @@ def test_verify_fresh_json(app, client, get_message):
         "/verify", json=dict(password="not my password"), headers=headers
     )
     assert response.status_code == 400
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.verify"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "password"
+    assert not signals["user_failed_authn"][0]["tfa"]
 
     response = client.post("/verify", json=dict(password="password"), headers=headers)
     assert response.status_code == 200
@@ -1195,10 +1200,11 @@ def test_verify_fresh_json(app, client, get_message):
     response = client.get("/fresh", headers=headers)
     assert response.status_code == 200
     assert response.json["title"] == "Fresh Only"
+    check_signals(signals, "user_failed_authn")
 
 
 @pytest.mark.changeable()
-def test_verify_pwd_json(app, client, get_message):
+def test_verify_pwd_json(app, client, get_message, signals):
     # Make sure verify accepts a normalized and original password.
     authenticate(client)
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -1227,6 +1233,7 @@ def test_verify_pwd_json(app, client, get_message):
         headers=headers,
     )
     assert response.status_code == 200
+    check_signals(signals, "password_changed")
 
 
 @pytest.mark.settings(verify_url="/auth/")

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -37,6 +37,7 @@ from tests.test_utils import (
     is_authenticated,
     json_authenticate,
     logout,
+    check_signals,
 )
 
 pytestmark = pytest.mark.two_factor()
@@ -305,7 +306,7 @@ def test_two_factor_illegal_state(app, client, get_message):
 
 
 @pytest.mark.settings(two_factor_required=True)
-def test_two_factor_flag(app, clients, get_message, outbox):
+def test_two_factor_flag(app, clients, get_message, outbox, signals):
     # trying to verify code without going through two-factor
     # first login function
     client = clients
@@ -393,6 +394,13 @@ def test_two_factor_flag(app, clients, get_message, outbox):
     # submit bad token to two_factor_token_validation
     response = client.post("/tf-validate", data=dict(code=wrong_code))
     assert get_message("TWO_FACTOR_INVALID_TOKEN") in response.data
+    assert (
+        signals["user_failed_authn"][2]["endpoint"]
+        == "security.two_factor_token_validation"
+    )
+    assert signals["user_failed_authn"][2]["user"].email == "gal@lp.com"
+    assert signals["user_failed_authn"][2]["auth_type"] == "code"
+    assert signals["user_failed_authn"][2]["tfa"]
 
     # submit right token and show appropriate response
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
@@ -576,7 +584,7 @@ def test_setup_bad_phone(app, client, get_message):
 
 
 @pytest.mark.settings(two_factor_required=True)
-def test_json(app, client):
+def test_json(app, client, signals):
     """
     Test login/setup using JSON.
     """
@@ -594,8 +602,11 @@ def test_json(app, client):
     # Verify SMS sent
     assert sms_sender.get_count() == 1
     code = sms_sender.messages[0].split()[-1]
+    assert signals["tf_security_token_sent"][0]["token"] == code
+    assert signals["tf_security_token_sent"][0]["method"] == "sms"
     response = client.post("/tf-validate", json=dict(code=code))
     assert response.status_code == 200
+    assert signals["tf_code_confirmed"][0]["user_email"] == "gal@lp.com"
     # verify logged in
     response = client.get("/profile", follow_redirects=False)
     assert response.status_code == 200
@@ -619,6 +630,7 @@ def test_json(app, client):
     assert response.json["response"]["tf_state"] == "validating_profile"
     assert response.json["response"]["tf_primary_method"] == "sms"
     code = sms_sender.messages[0].split()[-1]
+    assert signals["tf_security_token_sent"][1]["token"] == code
     response = client.post("/tf-validate", json=dict(code=code), headers=headers)
     assert response.status_code == 200
     assert "csrf_token" in response.json["response"]
@@ -637,6 +649,13 @@ def test_json(app, client):
     assert response.status_code == 400
     assert response.json["response"]["field_errors"]["code"][0] == "Invalid code"
     assert response.json["response"]["errors"][0] == "Invalid code"
+    assert (
+        signals["user_failed_authn"][0]["endpoint"]
+        == "security.two_factor_token_validation"
+    )
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "code"
+    assert signals["user_failed_authn"][0]["tfa"]
 
     # Do a GET - should get recovery options
     response = client.get("/tf-validate", headers=headers)
@@ -660,6 +679,10 @@ def test_json(app, client):
     assert response.json["response"]["tf_primary_method"] == "sms"
     assert response.json["response"]["tf_phone_number"] == "+442083661177"
     assert not tf_in_session(get_session(response))
+    check_signals(
+        signals,
+        {"user_failed_authn": 1, "tf_security_token_sent": 3, "tf_code_confirmed": 3},
+    )
 
 
 @pytest.mark.settings(two_factor_rescue_mail="helpme@myapp.com")
@@ -870,7 +893,7 @@ def test_opt_in(app, client, get_message):
         assert signalled_identity[0] == user.fs_uniquifier
 
 
-def test_opt_in_nc(app, client_nc, get_message):
+def test_opt_in_nc(app, client_nc, get_message, signals):
     """
     Test tf-setup without cookies
     """
@@ -904,6 +927,8 @@ def test_opt_in_nc(app, client_nc, get_message):
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "TWO_FACTOR_INVALID_TOKEN"
     )
+    # setup shouldn't trigger this.
+    assert len(signals["user_failed_authn"]) == 0
 
     # Validate token - this should complete 2FA setup
     @tf_profile_changed.connect_via(app)
@@ -952,7 +977,7 @@ def test_opt_in_nc_expired(app, client_nc, get_message):
     )
 
 
-def test_opt_in_state_token(app, client, get_message):
+def test_opt_in_state_token(app, client, get_message, signals):
     """
     Test using forms and new state_token approach (rather than sessions to store
     intermediate state)
@@ -979,6 +1004,8 @@ def test_opt_in_state_token(app, client, get_message):
     response = client.post(verify_url, data=dict(code=12345), follow_redirects=True)
     assert check_location(app, response.history[0].location, "/tf-setup")
     assert get_message("TWO_FACTOR_INVALID_TOKEN") in response.data
+    # setup shouldn't trigger this.
+    assert len(signals["user_failed_authn"]) == 0
 
     # Validate token - this should complete 2FA setup
     response = client.post(verify_url, data=dict(code=code), follow_redirects=True)

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -28,6 +28,7 @@ from tests.test_utils import (
     capture_flashes,
     capture_reset_password_requests,
     check_location,
+    check_signals,
     check_xlation,
     get_form_action,
     get_session,
@@ -147,13 +148,8 @@ def set_email(app, email="matt@lp.com"):
         app.security.datastore.commit()
 
 
-def test_simple_signin(app, clients, get_message, outbox):
+def test_simple_signin(app, clients, get_message, outbox, signals):
     set_email(app)
-    auths = []
-
-    @user_authenticated.connect_via(app)
-    def authned(myapp, user, **extra_args):
-        auths.append((user.email, extra_args["authn_via"]))
 
     # Test missing choice
     data = dict(identity="matt@lp.com")
@@ -195,6 +191,10 @@ def test_simple_signin(app, clients, get_message, outbox):
         follow_redirects=True,
     )
     assert get_message("INVALID_PASSWORD_CODE") in response.data
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_signin"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
+    assert not signals["user_failed_authn"][0]["tfa"]
 
     # Correct code
     assert not clients.get_cookie("remember_token")
@@ -205,7 +205,7 @@ def test_simple_signin(app, clients, get_message, outbox):
         follow_redirects=False,
     )
     assert not clients.get_cookie("remember_token")
-    assert "email" in auths[0][1]
+    assert signals["user_authenticated"][0]["authn_via"] == ["email"]
 
     assert is_authenticated(clients, get_message)
 
@@ -231,7 +231,7 @@ def test_simple_signin(app, clients, get_message, outbox):
     )
     assert response.status_code == 200
     assert clients.get_cookie("remember_token")
-    assert "sms" in auths[1][1]
+    assert signals["user_authenticated"][1]["authn_via"] == ["sms"]
 
     assert is_authenticated(clients, get_message)
 
@@ -239,14 +239,8 @@ def test_simple_signin(app, clients, get_message, outbox):
     assert not clients.get_cookie("remember_token")
 
 
-def test_simple_signin_json(app, client_nc, get_message, outbox):
+def test_simple_signin_json(app, client_nc, get_message, outbox, signals):
     set_email(app)
-    auths = []
-
-    @user_authenticated.connect_via(app)
-    def authned(myapp, user, **extra_args):
-        auths.append((user.email, extra_args["authn_via"]))
-
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
     with capture_flashes() as flashes:
@@ -282,6 +276,10 @@ def test_simple_signin_json(app, client_nc, get_message, outbox):
         assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
             "INVALID_PASSWORD_CODE"
         )
+        assert signals["user_failed_authn"][0]["endpoint"] == "security.us_signin"
+        assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+        assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
+        assert not signals["user_failed_authn"][0]["tfa"]
 
         # Login successfully with code
         response = client_nc.post(
@@ -292,7 +290,7 @@ def test_simple_signin_json(app, client_nc, get_message, outbox):
         )
         assert response.status_code == 200
         assert "authentication_token" in response.json["response"]["user"]
-        assert "email" in auths[0][1]
+        assert signals["user_authenticated"][0]["authn_via"] == ["email"]
 
         logout(client_nc)
         assert not is_authenticated(client_nc, get_message)
@@ -592,13 +590,8 @@ def test_post_already_authenticated(client, get_message):
 
 
 @pytest.mark.settings(us_email_subject="Code For You")
-def test_verify_link(app, client, get_message, outbox):
+def test_verify_link(app, client, get_message, outbox, signals):
     set_email(app)
-    auths = []
-
-    @user_authenticated.connect_via(app)
-    def authned(myapp, user, **extra_args):
-        auths.append((user.email, extra_args["authn_via"]))
 
     with capture_send_code_requests() as requests:
         response = client.post(
@@ -633,14 +626,19 @@ def test_verify_link(app, client, get_message, outbox):
         follow_redirects=True,
     )
     assert get_message("INVALID_CODE") in response.data
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_verify_link"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
+    assert not signals["user_failed_authn"][0]["tfa"]
 
     # Try actual link
     response = client.get(magic_link, follow_redirects=True)
     assert get_message("PASSWORDLESS_LOGIN_SUCCESSFUL") in response.data
-    assert "email" in auths[0][1]
+    assert signals["user_authenticated"][0]["authn_via"] == ["email"]
 
     # verify logged in
     assert is_authenticated(client, get_message)
+    check_signals(signals, {"user_failed_authn": 1, "us_security_token_sent": 1})
 
 
 @pytest.mark.settings(
@@ -649,7 +647,7 @@ def test_verify_link(app, client, get_message, outbox):
     login_error_view="/login-error",
     post_login_view="/post-login",
 )
-def test_verify_link_spa(app, client, get_message, outbox):
+def test_verify_link_spa(app, client, get_message, outbox, signals):
     # N.B. we use client here since this only works/ is supported if using
     # sessions.
     set_email(app)
@@ -697,6 +695,10 @@ def test_verify_link_spa(app, client, get_message, outbox):
     assert "/login-error" == split.path
     qparams = dict(parse_qsl(split.query))
     assert get_message("INVALID_CODE") == qparams["error"].encode("utf-8")
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_verify_link"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
+    assert not signals["user_failed_authn"][0]["tfa"]
 
     # Try actual link
     response = client.get(magic_link, follow_redirects=False)
@@ -706,11 +708,12 @@ def test_verify_link_spa(app, client, get_message, outbox):
     assert "/post-login" == split.path
     qparams = dict(parse_qsl(split.query))
     assert qparams["email"] == "matt@lp.com"
+    check_signals(signals, {"user_failed_authn": 1, "us_security_token_sent": 1})
 
     assert is_authenticated(client, get_message)
 
 
-def test_setup(app, clients, get_message):
+def test_setup(app, clients, get_message, signals):
     tcl = clients
     set_email(app)
     us_authenticate(tcl)
@@ -751,6 +754,8 @@ def test_setup(app, clients, get_message):
     # Try invalid code
     response = tcl.post(verify_url, data=dict(passcode=12345), follow_redirects=True)
     assert get_message("INVALID_PASSWORD_CODE") in response.data
+    # a bad code during setup shouldn't trigger the signal
+    assert len(signals["user_failed_authn"]) == 0
 
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = tcl.post(verify_url, data=dict(passcode=code), follow_redirects=True)
@@ -999,10 +1004,10 @@ def test_unique_phone(app, client, get_message):
 
 
 @pytest.mark.settings(freshness=timedelta(minutes=0))
-def test_verify(app, clients, get_message):
+def test_verify(app, clients, get_message, signals):
     client = clients
     # Test setup when re-authenticate required
-    # With  freshness set to 0 - the first call should require reauth (by
+    # With freshness set to 0 - the first call should require reauth (by
     # redirecting); but the second should work due to grace period.
     set_email(app)
     us_authenticate(client)
@@ -1040,9 +1045,10 @@ def test_verify(app, clients, get_message):
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client.post(verify_url, data=dict(passcode=code), follow_redirects=False)
     assert check_location(app, response.location, "/us-setup")
+    check_signals(signals, {"user_failed_authn": 0, "us_security_token_sent": 3})
 
 
-def test_verify_json(app, client, get_message):
+def test_verify_json(app, client, get_message, signals):
     # Test setup when re-authenticate required
     # N.B. with freshness=0 we never set a grace period and should never be able to
     # get to /us-setup
@@ -1096,6 +1102,10 @@ def test_verify_json(app, client, get_message):
     assert response.json["response"]["field_errors"]["passcode"][0].encode(
         "utf-8"
     ) == get_message("INVALID_PASSWORD_CODE")
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_verify"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
+    assert not signals["user_failed_authn"][0]["tfa"]
 
     response = client.post("us-verify", json=dict(passcode=None), headers=headers)
     assert response.status_code == 400
@@ -1110,6 +1120,8 @@ def test_verify_json(app, client, get_message):
     app.config["SECURITY_FRESHNESS"] = timedelta(minutes=60)
     response = client.get("us-setup", headers=headers)
     assert response.status_code == 200
+    assert len(signals["user_failed_authn"]) == 1
+    check_signals(signals, {"user_failed_authn": 1, "us_security_token_sent": 2})
 
 
 @pytest.mark.settings(freshness=timedelta(minutes=-1))
@@ -1310,7 +1322,7 @@ def test_requires_confirmation_error_redirect(app, client):
 
 @pytest.mark.registerable()
 @pytest.mark.confirmable()
-def test_confirmable(app, client, get_message):
+def test_confirmable(app, client, get_message, signals):
     # Verify can't log in if need confirmation.
     data = dict(
         email="dude@lp.com", password="password", password_confirm="password", next=""
@@ -1327,6 +1339,7 @@ def test_confirmable(app, client, get_message):
     assert response.status_code == 200
 
     assert get_message("CONFIRMATION_REQUIRED") in response.data
+    check_signals(signals, "user_registered")
 
     # Verify not authenticated
     assert not is_authenticated(client, get_message)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -416,6 +416,34 @@ def capture_username_recovery_requests():
         username_recovery_email_sent.disconnect(_on)
 
 
+def check_signals(
+    signals: dict,
+    expected: str | list | dict[str, int] | None = None,
+    ignore: str | list[str] | None = None,
+) -> None:
+    # Check if test received expected # of signals.
+    # Expected can be a string (signal name), list of strings or
+    # dict of signal name to expected count.
+    # Use with the signals fixture
+    if not expected:
+        expected = dict()
+    elif isinstance(expected, str):
+        expected = {expected: 1}
+    elif isinstance(expected, list):
+        expected = {sig: 1 for sig in expected}
+    if not ignore:
+        ignore = ["user_authenticated"]  # this is too common in tests to worry about
+    elif isinstance(ignore, str):
+        ignore = [ignore]
+    for sig in signals:
+        if sig not in ignore:
+            expected_calls = expected.get(sig, 0)
+            actual_calls = len(signals[sig])
+            assert (
+                expected_calls == actual_calls
+            ), f"Expected {expected_calls} calls to {sig} but got {actual_calls}"
+
+
 @contextmanager
 def capture_flashes():
     """Testing utility for capturing flashes."""

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -32,6 +32,7 @@ from tests.test_utils import (
     reset_fresh,
     setup_tf_sms,
     verify_token,
+    check_signals,
 )
 
 from flask_security import (
@@ -577,7 +578,7 @@ def test_bad_data_register(app, client, get_message):
     )
 
 
-def test_bad_data_signin(app, client, get_message):
+def test_bad_data_signin(app, client, get_message, signals):
     authenticate(client)
     register_options, response_url = _register_start_json(client, usage="first")
     response = client.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
@@ -614,6 +615,13 @@ def test_bad_data_signin(app, client, get_message):
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_NO_VERIFY", cause="Could not verify authentication signature"
+    )
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.wan_signin_response"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "passkey"
+    assert not signals["user_failed_authn"][0]["tfa"]
+    check_signals(
+        signals, ["user_failed_authn", "wan_registered", "user_authenticated"]
     )
 
 
@@ -1333,7 +1341,7 @@ def test_verify_timeout(app, client, get_message):
     )
 
 
-def test_verify_validate_error(app, client, get_message):
+def test_verify_validate_error(app, client, get_message, signals):
     authenticate(client)
     register_options, response_url = _register_start_json(client, name="testr3")
     response = client.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
@@ -1362,6 +1370,24 @@ def test_verify_validate_error(app, client, get_message):
     assert flashes[0]["category"] == "error"
     assert flashes[0]["message"].encode("utf-8") == get_message(
         "WEBAUTHN_UNKNOWN_CREDENTIAL_ID"
+    )
+
+    # now muck with attestation - should get VERIFY ERROR
+    bad_signin = copy.deepcopy(SIGNIN_DATA1)
+    bad_signin["response"]["signature"] = bad_signin["response"]["signature"].replace(
+        "M", "N"
+    )
+    response = client.post(response_url, json=dict(credential=json.dumps(bad_signin)))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_NO_VERIFY", cause="Could not verify authentication signature"
+    )
+    assert signals["user_failed_authn"][0]["endpoint"] == "security.wan_verify_response"
+    assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
+    assert signals["user_failed_authn"][0]["auth_type"] == "passkey"
+    assert not signals["user_failed_authn"][0]["tfa"]
+    check_signals(
+        signals, ["user_failed_authn", "wan_registered", "user_authenticated"]
     )
 
 


### PR DESCRIPTION
This adds a new signal - user_failed_authn, and a new method to UserMixin: track_failed_authn that sends that signal. All places that accept a credential and that fails call through track_failed_authn(). API errors, and missing data don't trigger the signal.

Added a signals fixture for testing which tracks all signals during a test, and a test_util check_signals that can verify precisely which signals were received.

closes #1188