### PR TITLE
Add additional values for JSON responses when setting up an authentic…

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2486,7 +2486,13 @@ components:
                   description: The canonicalized phone number if setting up SMS
                 authr_key:
                   type: string
-                  description: TOTP key for setting up authenticator (if chosen_method == 'authenticator')
+                  description: Pretty TOTP key for setting up authenticator manually (if chosen_method == 'authenticator')
+                authr_b32key:
+                  type: string
+                  description: Base32 TOTP key for setting up authenticator (useful to create a uri) (if chosen_method == 'authenticator')
+                authr_uri:
+                  type: string
+                  description: A 'otpauth://' style URI suitable to creating a QRCode (if chosen_method == 'authenticator')
                 authr_issuer:
                   type: string
                   description: Issuer as configured with TOTP_ISSUER (same as used in QRcode) (if chosen_method == 'authenticator')
@@ -2562,7 +2568,13 @@ components:
                   example: sms
                 tf_authr_key:
                   type: string
-                  description: TOTP key for setting up authenticator (if tf_primary_method == 'authenticator')
+                  description: Pretty TOTP key for setting up authenticator manually (if tf_primary_method == 'authenticator')
+                tf_authr_b32key:
+                  type: string
+                  description: Base32 TOTP key for setting up authenticator (useful to create a uri) (if chosen_method == 'authenticator')
+                tf_authr_uri:
+                  type: string
+                  description: A 'otpauth://' style URI suitable to creating a QRCode (if chosen_method == 'authenticator')
                 tf_authr_issuer:
                   type: string
                   description: Issuer as configured with TOTP_ISSUER (same as used in QRcode) (if tf_primary_method == 'authenticator')

--- a/flask_security/totp.py
+++ b/flask_security/totp.py
@@ -111,15 +111,30 @@ class Totp:
         tp = self._totp.from_source(totp_secret)
         return tp.pretty_key()
 
+    def get_totp_b32_key(self, totp_secret: str) -> str:
+        """Generate b32 key for creating a otpauth url
+
+        :param totp_secret: a unique shared secret of the user
+
+        .. versionadded:: 5.8.0
+        """
+        tp = self._totp.from_source(totp_secret)
+        return tp.base32_key
+
     def fetch_setup_values(self, totp: str, user: UserMixin) -> dict[str, str]:
         """Generate various values user needs to setup authenticator app.
             Returns dict with keys:
                 'key': totp key
+                'b32key': totp key in base32
+                'uri': provisioning url
                 'image': image as string (useful for <img src=xx>)
                 'username: qrcode best practice
                 'issuer': qrcode best practice
 
         .. versionadded:: 4.0.0
+
+        .. versionchanged:: 5.8.0
+          Added keys b32key and uri
         """
 
         r = dict()
@@ -130,8 +145,10 @@ class Totp:
         assert self._totp.issuer
         r["username"] = username
         r["key"] = self.get_totp_pretty_key(totp)
+        r["b32key"] = self.get_totp_b32_key(totp)
         r["issuer"] = self._totp.issuer
         r["image"] = self.generate_qrcode(username, totp)
+        r["uri"] = self.get_totp_uri(username, totp)
         return r
 
     def generate_qrcode(self, username: str, totp: str) -> str:

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -904,8 +904,10 @@ def us_setup() -> ResponseValue:
 
                 # Add all the values used in qrcode to json response
                 json_response["authr_key"] = authr_setup_values["key"]
+                json_response["authr_b32key"] = authr_setup_values["b32key"]
                 json_response["authr_username"] = authr_setup_values["username"]
                 json_response["authr_issuer"] = authr_setup_values["issuer"]
+                json_response["authr_uri"] = authr_setup_values["uri"]
 
                 qrcode_values = dict(
                     authr_qrcode=authr_setup_values["image"],

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -854,8 +854,10 @@ def two_factor_setup():
             authr_setup_values = _security.totp_factory.fetch_setup_values(totp, user)
             # Add all the values used in qrcode to json response
             json_response["tf_authr_key"] = authr_setup_values["key"]
+            json_response["tf_authr_b32key"] = authr_setup_values["b32key"]
             json_response["tf_authr_username"] = authr_setup_values["username"]
             json_response["tf_authr_issuer"] = authr_setup_values["issuer"]
+            json_response["tf_authr_uri"] = authr_setup_values["uri"]
 
             qrcode_values = dict(
                 authr_qrcode=authr_setup_values["image"],

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -1265,10 +1265,18 @@ def test_authr_identity(app, client):
 
     setup_data = dict(setup="authenticator")
     response = client.post("/tf-setup", json=setup_data, headers=headers)
-    assert response.json["response"]["tf_authr_issuer"] == "tests"
-    assert response.json["response"]["tf_authr_username"] == "jill"
-    assert response.json["response"]["tf_state"] == "validating_profile"
+    jr = response.json["response"]
+    assert jr["tf_authr_issuer"] == "tests"
+    assert jr["tf_authr_username"] == "jill"
+    assert jr["tf_state"] == "validating_profile"
+    assert len(jr["tf_authr_b32key"]) % 8 == 0 and re.match(
+        r"^[A-Z2-7]+=*$", jr["tf_authr_b32key"]
+    )
     assert "tf_authr_key" in response.json["response"]
+    assert (
+        jr["tf_authr_uri"]
+        == f"otpauth://totp/tests:jill?secret={jr['tf_authr_b32key']}&issuer=tests"
+    )
 
 
 @pytest.mark.settings(

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1759,9 +1759,17 @@ def test_totp_generation(app, client, get_message):
         "us-setup", json=dict(chosen_method="authenticator"), headers=headers
     )
     assert response.status_code == 200
-    assert response.json["response"]["authr_issuer"] == "tests"
-    assert response.json["response"]["authr_username"] == "dave@lp.com"
+    jr = response.json["response"]
+    assert jr["authr_issuer"] == "tests"
+    assert jr["authr_username"] == "dave@lp.com"
     assert "authr_key" in response.json["response"]
+    assert len(jr["authr_b32key"]) % 8 == 0 and re.match(
+        r"^[A-Z2-7]+=*$", jr["authr_b32key"]
+    )
+    assert (
+        jr["authr_uri"]
+        == f"otpauth://totp/tests:dave@lp.com?secret={jr['authr_b32key']}&issuer=tests"
+    )
 
     state = response.json["response"]["state"]
 


### PR DESCRIPTION
…ater

Add the base32 key and the TOTP generated URI.
This enables JSON clients to construct a QRcode.

closes #1189