### PR TITLE
Add descriptions to authentication-related signals for clarity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: pyupgrade
         args: [--py310-plus]
 -   repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -13,49 +13,87 @@ import blinker
 
 signals = blinker.Namespace()
 
-user_authenticated = signals.signal("user-authenticated", "a user has been authenticated")
+user_authenticated = signals.signal(
+    "user-authenticated", "a user has been authenticated"
+)
 
-user_unauthenticated = signals.signal("user-unauthenticated", "a user tried to access an unauthenticated resource")
+user_unauthenticated = signals.signal(
+    "user-unauthenticated", "a user tried to access an unauthenticated resource"
+)
 
-user_failed_authn = signals.signal("user-failed-authn", "a user failed authentication (bad password, etc)")
+user_failed_authn = signals.signal(
+    "user-failed-authn", "a user failed authentication (bad password, etc)"
+)
 
 user_registered = signals.signal("user-registered", "a new user has registered")
 
 # For cases of RETURN_GENERIC_RESPONSES with existing email/username
-user_not_registered = signals.signal("user-not-registered", "a user failed authentication (bad password, etc)")
+user_not_registered = signals.signal(
+    "user-not-registered", "a user failed authentication (bad password, etc)"
+)
 
 user_confirmed = signals.signal("user-confirmed", "a user has confirmed their account")
 
-confirm_instructions_sent = signals.signal("confirm-instructions-sent", "confirmation instructions have been sent to a user")
+confirm_instructions_sent = signals.signal(
+    "confirm-instructions-sent", "confirmation instructions have been sent to a user"
+)
 
-login_instructions_sent = signals.signal("login-instructions-sent", "login instructions have been sent to a user")
+login_instructions_sent = signals.signal(
+    "login-instructions-sent", "login instructions have been sent to a user"
+)
 
 password_reset = signals.signal("password-reset", "a user's password has been reset")
 
-password_changed = signals.signal("password-changed", "a user has changed their password")
+password_changed = signals.signal(
+    "password-changed", "a user has changed their password"
+)
 
-reset_password_instructions_sent = signals.signal("password-reset-instructions-sent", "password reset instructions have been sent to a user")
+reset_password_instructions_sent = signals.signal(
+    "password-reset-instructions-sent",
+    "password reset instructions have been sent to a user",
+)
 
-tf_code_confirmed = signals.signal("tf-code-confirmed", "a two-factor authentication code has been confirmed")
+tf_code_confirmed = signals.signal(
+    "tf-code-confirmed", "a two-factor authentication code has been confirmed"
+)
 
-tf_profile_changed = signals.signal("tf-profile-changed", "a two-factor authentication profile has been changed")
+tf_profile_changed = signals.signal(
+    "tf-profile-changed", "a two-factor authentication profile has been changed"
+)
 
-tf_security_token_sent = signals.signal("tf-security-token-sent", "a two-factor authentication security token has been sent")
+tf_security_token_sent = signals.signal(
+    "tf-security-token-sent", "a two-factor authentication security token has been sent"
+)
 
-tf_disabled = signals.signal("tf-disabled", "two-factor authentication has been disabled")
+tf_disabled = signals.signal(
+    "tf-disabled", "two-factor authentication has been disabled"
+)
 
-us_security_token_sent = signals.signal("us-security-token-sent", "a user Unified-Signin security token has been sent")
+us_security_token_sent = signals.signal(
+    "us-security-token-sent", "a user Unified-Signin security token has been sent"
+)
 
-us_profile_changed = signals.signal("us-profile-changed", "a user Unified-Signin profile has been changed")
+us_profile_changed = signals.signal(
+    "us-profile-changed", "a user Unified-Signin profile has been changed"
+)
 
 wan_registered = signals.signal("wan-registered", "a Passkey has been registered")
 
 wan_deleted = signals.signal("wan-deleted", "a Passkey has been deleted")
 
-change_email_instructions_sent = signals.signal("change-email-instructions-sent", "change email instructions have been sent to a user")
+change_email_instructions_sent = signals.signal(
+    "change-email-instructions-sent",
+    "change email instructions have been sent to a user",
+)
 
-change_email_confirmed = signals.signal("change-email-confirmed", "a user has confirmed their email change")
+change_email_confirmed = signals.signal(
+    "change-email-confirmed", "a user has confirmed their email change"
+)
 
-username_recovery_email_sent = signals.signal("username-recovery-email-sent", "username recovery email has been sent to a user")
+username_recovery_email_sent = signals.signal(
+    "username-recovery-email-sent", "username recovery email has been sent to a user"
+)
 
-username_changed = signals.signal("username-changed", "a user has changed their username")
+username_changed = signals.signal(
+    "username-changed", "a user has changed their username"
+)

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -13,49 +13,49 @@ import blinker
 
 signals = blinker.Namespace()
 
-user_authenticated = signals.signal("user-authenticated")
+user_authenticated = signals.signal("user-authenticated", "a user has been authenticated")
 
-user_unauthenticated = signals.signal("user-unauthenticated")
+user_unauthenticated = signals.signal("user-unauthenticated", "a user tried to access an unauthenticated resource")
 
-user_failed_authn = signals.signal("user-failed-authn")
+user_failed_authn = signals.signal("user-failed-authn", "a user failed authentication (bad password, etc)")
 
-user_registered = signals.signal("user-registered")
+user_registered = signals.signal("user-registered", "a new user has registered")
 
 # For cases of RETURN_GENERIC_RESPONSES with existing email/username
-user_not_registered = signals.signal("user-not-registered")
+user_not_registered = signals.signal("user-not-registered", "a user failed authentication (bad password, etc)")
 
-user_confirmed = signals.signal("user-confirmed")
+user_confirmed = signals.signal("user-confirmed", "a user has confirmed their account")
 
-confirm_instructions_sent = signals.signal("confirm-instructions-sent")
+confirm_instructions_sent = signals.signal("confirm-instructions-sent", "confirmation instructions have been sent to a user")
 
-login_instructions_sent = signals.signal("login-instructions-sent")
+login_instructions_sent = signals.signal("login-instructions-sent", "login instructions have been sent to a user")
 
-password_reset = signals.signal("password-reset")
+password_reset = signals.signal("password-reset", "a user's password has been reset")
 
-password_changed = signals.signal("password-changed")
+password_changed = signals.signal("password-changed", "a user has changed their password")
 
-reset_password_instructions_sent = signals.signal("password-reset-instructions-sent")
+reset_password_instructions_sent = signals.signal("password-reset-instructions-sent", "password reset instructions have been sent to a user")
 
-tf_code_confirmed = signals.signal("tf-code-confirmed")
+tf_code_confirmed = signals.signal("tf-code-confirmed", "a two-factor authentication code has been confirmed")
 
-tf_profile_changed = signals.signal("tf-profile-changed")
+tf_profile_changed = signals.signal("tf-profile-changed", "a two-factor authentication profile has been changed")
 
-tf_security_token_sent = signals.signal("tf-security-token-sent")
+tf_security_token_sent = signals.signal("tf-security-token-sent", "a two-factor authentication security token has been sent")
 
-tf_disabled = signals.signal("tf-disabled")
+tf_disabled = signals.signal("tf-disabled", "two-factor authentication has been disabled")
 
-us_security_token_sent = signals.signal("us-security-token-sent")
+us_security_token_sent = signals.signal("us-security-token-sent", "a user Unified-Signin security token has been sent")
 
-us_profile_changed = signals.signal("us-profile-changed")
+us_profile_changed = signals.signal("us-profile-changed", "a user Unified-Signin profile has been changed")
 
-wan_registered = signals.signal("wan-registered")
+wan_registered = signals.signal("wan-registered", "a Passkey has been registered")
 
-wan_deleted = signals.signal("wan-deleted")
+wan_deleted = signals.signal("wan-deleted", "a Passkey has been deleted")
 
-change_email_instructions_sent = signals.signal("change-email-instructions-sent")
+change_email_instructions_sent = signals.signal("change-email-instructions-sent", "change email instructions have been sent to a user")
 
-change_email_confirmed = signals.signal("change-email")
+change_email_confirmed = signals.signal("change-email-confirmed", "a user has confirmed their email change")
 
-username_recovery_email_sent = signals.signal("username-recovery-email-sent")
+username_recovery_email_sent = signals.signal("username-recovery-email-sent", "username recovery email has been sent to a user")
 
-username_changed = signals.signal("username-changed")
+username_changed = signals.signal("username-changed", "a user has changed their username")


### PR DESCRIPTION
Add descriptions to authentication-related signals for clarity.

this doc parameter can be used in different parts such as logging.