### PR TITLE
Chore for 5.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
           - {python: '3.12', tox: 'py312-release' }
           - {python: '3.12', tox: 'py312-low' }
           - {python: '3.13', tox: 'py313-release' }
+          - {python: '3.13', tox: 'py313-low' }
+          - {python: '3.14', tox: 'py314-release' }
           - {python: 'pypy-3.10', tox: 'pypy310-release'}
           - {python: 'pypy-3.10', tox: 'pypy310-low'}
 
@@ -57,7 +59,7 @@ jobs:
         - uses: actions/checkout@v6
         - uses: actions/setup-python@v6
           with:
-            python-version: "3.12"
+            python-version: "3.13"
         - name: update pip
           run: |
             python -m pip install -U pip
@@ -72,7 +74,7 @@ jobs:
         - uses: actions/checkout@v6
         - uses: actions/setup-python@v6
           with:
-            python-version: "3.12"
+            python-version: "3.13"
         - name: update pip
           run: |
             python -m pip install -U pip
@@ -86,7 +88,7 @@ jobs:
         - uses: actions/checkout@v6
         - uses: actions/setup-python@v6
           with:
-            python-version: "3.12"
+            python-version: "3.13"
         - name: update pip
           run: |
             python -m pip install -U pip
@@ -121,7 +123,7 @@ jobs:
         - uses: actions/checkout@v6
         - uses: actions/setup-python@v6
           with:
-            python-version: "3.12"
+            python-version: "3.13"
         - name: update pip
           run: |
             python -m pip install -U pip

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -145,4 +145,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "5.7.1"
+__version__ = "5.8.0"

--- a/pyproject-too.toml
+++ b/pyproject-too.toml
@@ -22,11 +22,6 @@ classifiers=[
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Development Status :: 5 - Production/Stable",
@@ -36,25 +31,25 @@ dynamic = [
 ]
 dependencies = [
     # flask dependencies include werkzeug, jinja2, itsdangerous, click, blinker
-    "Flask>=3.1.0",
+    "Flask>=3.1.1",
     "Flask-Login>=0.6.3",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=1.1.2",
-    "email-validator>=2.0.0",
+    "email-validator>=2.3.0",
     "markupsafe>=2.1.0",
     "libpass>=1.9.3",
     "wtforms>=3.0.0",  # for form-level errors
 ]
 
 [project.optional-dependencies]
-babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
-fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18"]
-common = ["argon2_cffi>=23.1.0", "bcrypt>=4.2.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
-mfa = ["cryptography>=42.0.4", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.5.0"]
+babel = ["babel>=2.17.0", "flask_babel>=4.0.0"]
+fsqla = ["flask_sqlalchemy>=3.1.1", "sqlalchemy>=2.0.41"]
+common = ["argon2_cffi>=25.1.0", "bcrypt>=4.2.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
+mfa = ["cryptography>=45.0.7", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.6.0"]
 low = [
     # Lowest supported versions
-    "Flask==3.1.0",
-    "Flask-SQLAlchemy==3.1.0",
+    "Flask==3.1.1",
+    "Flask-SQLAlchemy==3.1.1",
     "Flask-SQLAlchemy-Lite==0.1.0",
     "Flask-Babel==4.0.0",
     "Flask-Mail==0.10.0",
@@ -63,7 +58,7 @@ low = [
     "peewee==3.17.9",
     "argon2_cffi==21.3.0",
     "authlib==1.2.0",
-    "babel==2.12.1",
+    "babel==2.16.0",
     "bcrypt==4.0.1",
     "bleach==6.0.0",
     "freezegun",
@@ -77,10 +72,10 @@ low = [
     "qrcode==7.4.2",
     # authlib requires requests
     "requests",
-    "sqlalchemy==2.0.18",
-    "sqlalchemy-utils==0.41.1",
+    "sqlalchemy==2.0.41",
+    "sqlalchemy-utils==0.42.0",
     "webauthn==2.0.0",
-    "werkzeug==3.1.0",
+    "werkzeug==3.1.3",
     "zxcvbn==4.4.28"
 ]
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,6 @@ classifiers=[
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Development Status :: 5 - Production/Stable",
@@ -36,25 +31,25 @@ dynamic = [
 ]
 dependencies = [
     # flask dependencies include werkzeug, jinja2, itsdangerous, click, blinker
-    "Flask>=3.1.0",
+    "Flask>=3.1.1",
     "Flask-Login>=0.6.3",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=1.1.2",
-    "email-validator>=2.0.0",
+    "email-validator>=2.3.0",
     "markupsafe>=2.1.0",
     "libpass>=1.9.3",
     "wtforms>=3.0.0",  # for form-level errors
 ]
 
 [project.optional-dependencies]
-babel = ["babel>=2.12.1", "flask_babel>=4.0.0"]
-fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18"]
-common = ["argon2_cffi>=23.1.0", "bcrypt>=4.2.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
-mfa = ["cryptography>=42.0.4", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.5.0"]
+babel = ["babel>=2.17.0", "flask_babel>=4.0.0"]
+fsqla = ["flask_sqlalchemy>=3.1.1", "sqlalchemy>=2.0.41"]
+common = ["argon2_cffi>=25.1.0", "bcrypt>=4.2.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
+mfa = ["cryptography>=45.0.7", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.6.0"]
 low = [
     # Lowest supported versions
-    "Flask==3.1.0",
-    "Flask-SQLAlchemy==3.1.0",
+    "Flask==3.1.1",
+    "Flask-SQLAlchemy==3.1.1",
     "Flask-SQLAlchemy-Lite==0.1.0",
     "Flask-Babel==4.0.0",
     "Flask-Mail==0.10.0",
@@ -63,7 +58,7 @@ low = [
     "peewee==3.17.9",
     "argon2_cffi==21.3.0",
     "authlib==1.2.0",
-    "babel==2.12.1",
+    "babel==2.16.0",
     "bcrypt==4.0.1",
     "bleach==6.0.0",
     "freezegun",
@@ -77,10 +72,10 @@ low = [
     "qrcode==7.4.2",
     # authlib requires requests
     "requests",
-    "sqlalchemy==2.0.18",
-    "sqlalchemy-utils==0.41.1",
+    "sqlalchemy==2.0.41",
+    "sqlalchemy-utils==0.42.0",
     "webauthn==2.0.0",
-    "werkzeug==3.1.0",
+    "werkzeug==3.1.3",
     "zxcvbn==4.4.28"
 ]
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-basepython = python3.12
+basepython = python3.13
 envlist =
-    py{310,311,312,313,py310}-{low,release,appinstall}
+    py{310,311,312,313,314,py310}-{low,release,appinstall}
     mypy
     async
     nowebauthn
@@ -23,14 +23,14 @@ commands =
     tox -e compile_catalog
     pytest -W ignore --basetemp={envtmpdir} {posargs:tests}
 
-[testenv:py{310,311,312,313}-release]
+[testenv:py{310,311,312,313,314}-release]
 deps =
     -r requirements/tests.txt
 commands =
     tox -e compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
-[testenv:py{310,311,312,py310}-low]
+[testenv:py{310,311,312,313,314,py310}-low]
 deps =
     pytest
 extras = low
@@ -40,7 +40,7 @@ commands =
 
 # manual test to check how we're keeping up with Pallets latest
 [testenv:main]
-basepython = python3.12
+basepython = python3.14
 deps =
     -r requirements/tests.txt
     git+https://github.com/pallets/werkzeug@main#egg=werkzeug
@@ -152,7 +152,7 @@ commands =
     mypy --install-types --non-interactive flask_security tests
 
 
-[testenv:py{310,311,312,313}-appinstall]
+[testenv:py{310,311,312,313,314}-appinstall]
 commands = python -c "from flask_security import Security; s = Security()"
 
 [testenv:compile_catalog]
@@ -167,7 +167,7 @@ deps =
     jinja2
 skip_install = true
 commands =
-    pybabel extract --version 5.7.1 --keyword=_fsdomain --project=Flask-Security \
+    pybabel extract --version 5.8.0 --keyword=_fsdomain --project=Flask-Security \
         -o flask_security/translations/flask_security.pot \
         --msgid-bugs-address=jwag956@github.com --mapping-file=babel.ini \
         --add-comments=NOTE flask_security


### PR DESCRIPTION
- bump version strings
- add CI support for 3.14
- do the annual bump lowest supported versions
- change base python for tests to 3.13