### PR TITLE
Ensure username recovery endpoint is consistent with others.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Features & Improvements
 Fixes
 +++++
 - (:issue:`1179`) Fix verify_password for bcrypt 5.0 (mephi42)
+- (:issue:`1200`) Fix username_recovery w.r.t. inactive and non-confirmed users
 
 Docs and Chores
 +++++++++++++++
@@ -28,6 +29,7 @@ Docs and Chores
 - (:pr:`1151`) Update ca_ES translations (arielvb)
 - (:pr:`1152`) Update es_ES translations (arielvb)
 - (:pr:`1196`) Update arabic translations (samialfattani)
+- (:pr:`1199`) Update it_IT translations (gissimo)
 
 Version 5.7.1
 -------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1952,7 +1952,7 @@ Social Login (OAuth)
 
 .. py:data:: SECURITY_OAUTH_ENABLE
 
-    To enable using external Oauth providers - set this to ``True``.
+    To enable using external OAuth providers - set this to ``True``.
 
 .. py:data:: SECURITY_OAUTH_BUILTIN_PROVIDERS
 
@@ -1962,13 +1962,13 @@ Social Login (OAuth)
 
 .. py:data:: SECURITY_OAUTH_START_URL
 
-    Endpoint for starting an Oauth authentication operation.
+    Endpoint for starting an OAuth authentication operation.
 
     Default: ``"/login/oauthstart"``
 
 .. py:data:: SECURITY_OAUTH_RESPONSE_URL
 
-    Endpoint used as Oauth redirect.
+    Endpoint used as OAuth redirect.
 
     Default: ``"/login/oauthresponse"``
 
@@ -1985,7 +1985,7 @@ Social Login (OAuth)
 
 .. py:data:: SECURITY_OAUTH_VERIFY_START_URL
 
-    Endpoint for starting an Oauth reauthentication/verify operation.
+    Endpoint for starting an OAuth reauthentication/verify operation.
 
     Default: ``"/login/oauth-verify-start"``
 
@@ -1993,7 +1993,7 @@ Social Login (OAuth)
 
 .. py:data:: SECURITY_OAUTH_VERIFY_RESPONSE_URL
 
-    Endpoint used as the Oauth verify redirect.
+    Endpoint used as the OAuth verify redirect.
 
     Default: ``"/login/oauth-verify-response"``
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1176,6 +1176,7 @@ class UserMixin(BaseUserMixin):
 
         The default implementation sends the user_failed_authn signal.
 
+        .. versionadded:: 5.8.0
         """
         user_failed_authn.send(
             current_app._get_current_object(),  # type: ignore[attr-defined]

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -1069,7 +1069,7 @@ class TwoFactorRescueForm(Form):
     submit = SubmitField(get_form_field_label("submit"), id="rescue")
 
 
-class UsernameRecoveryForm(Form, UserEmailFormMixin):
+class UsernameRecoveryForm(ForgotPasswordForm):
     """The username recovery form"""
 
     submit = SubmitField(get_form_field_label("recover_username"))

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -72,6 +72,7 @@ from .utils import (
     base_render_json,
     check_and_get_token_status,
     config_value as cv,
+    confirm_redirect,
     do_flash,
     get_identity_attributes,
     get_post_login_redirect,
@@ -486,13 +487,8 @@ def us_signin_send_code() -> ResponseValue:
         }
         return base_render_json(form, include_user=False, additional=payload)
 
-    if (
-        form.requires_confirmation
-        and cv("REQUIRES_CONFIRMATION_ERROR_VIEW")
-        and not cv("RETURN_GENERIC_RESPONSES")
-    ):
-        do_flash(*get_message("CONFIRMATION_REQUIRED"))
-        return redirect(get_url(cv("REQUIRES_CONFIRMATION_ERROR_VIEW")))
+    if rurl := confirm_redirect(form, "email"):
+        return rurl
 
     return _security.render_template(
         cv("US_SIGNIN_TEMPLATE"),
@@ -618,13 +614,8 @@ def us_signin() -> ResponseValue:
     # On error - wipe code
     form.passcode.data = None
 
-    if (
-        form.requires_confirmation
-        and cv("REQUIRES_CONFIRMATION_ERROR_VIEW")
-        and not cv("RETURN_GENERIC_RESPONSES")
-    ):
-        do_flash(*get_message("CONFIRMATION_REQUIRED"))
-        return redirect(get_url(cv("REQUIRES_CONFIRMATION_ERROR_VIEW")))
+    if rurl := confirm_redirect(form, "email"):
+        return rurl
 
     return _security.render_template(
         cv("US_SIGNIN_TEMPLATE"),

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -524,6 +524,25 @@ def suppress_form_csrf():
     return {}
 
 
+def confirm_redirect(form, identity_attribute):
+    """This is a very specific utility that all open endpoints call
+    to implement the confirm redirect feature.
+    """
+    if (
+        form.requires_confirmation
+        and config_value("REQUIRES_CONFIRMATION_ERROR_VIEW")
+        and not config_value("RETURN_GENERIC_RESPONSES")
+    ):
+        do_flash(*get_message("CONFIRMATION_REQUIRED"))
+        return redirect(
+            get_url(
+                config_value("REQUIRES_CONFIRMATION_ERROR_VIEW"),
+                qparams={identity_attribute: getattr(form.user, identity_attribute)},
+            )
+        )
+    return None
+
+
 def do_flash(message: str, category: str) -> None:
     """Flash a message depending on if the `FLASH_MESSAGES` configuration
     value is set.

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -5,7 +5,7 @@ flask_security.views
 Flask-Security views module
 
 :copyright: (c) 2012 by Matt Wright.
-:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
 CSRF is tricky. By default all our forms have CSRF protection built in via
@@ -105,6 +105,7 @@ from .utils import (
     check_and_update_authn_fresh,
     check_and_get_token_status,
     config_value as cv,
+    confirm_redirect,
     do_flash,
     get_identity_attributes,
     get_message,
@@ -217,21 +218,9 @@ def login() -> ResponseValue:
         }
         return base_render_json(form, additional=payload)
 
-    if (
-        form.requires_confirmation
-        and cv("REQUIRES_CONFIRMATION_ERROR_VIEW")
-        and not cv("RETURN_GENERIC_RESPONSES")
-    ):
-        # Validation failed BECAUSE user needs to confirm
-        assert form.user_authenticated
-        assert form.email.data  # email_required validator
-        do_flash(*get_message("CONFIRMATION_REQUIRED"))
-        return redirect(
-            get_url(
-                cv("REQUIRES_CONFIRMATION_ERROR_VIEW"),
-                qparams={"email": form.email.data},
-            )
-        )
+    if rurl := confirm_redirect(form, "email"):
+        return rurl
+
     return _security.render_template(
         cv("LOGIN_USER_TEMPLATE"),
         login_user_form=form,
@@ -552,18 +541,8 @@ def forgot_password():
         # Never include user info since this is an anonymous endpoint.
         return base_render_json(form, include_user=False)
 
-    if (
-        form.requires_confirmation
-        and cv("REQUIRES_CONFIRMATION_ERROR_VIEW")
-        and not cv("RETURN_GENERIC_RESPONSES")
-    ):
-        do_flash(*get_message("CONFIRMATION_REQUIRED"))
-        return redirect(
-            get_url(
-                cv("REQUIRES_CONFIRMATION_ERROR_VIEW"),
-                qparams={"email": form.email.data},
-            )
-        )
+    if rurl := confirm_redirect(form, "email"):
+        return rurl
 
     if is_user_authenticated(current_user):
         form.email.data = current_user.email
@@ -1197,6 +1176,9 @@ def recover_username():
 
     if _security._want_json(request):
         return base_render_json(form, include_user=False)
+
+    if rurl := confirm_redirect(form, "email"):
+        return rurl
 
     return _security.render_template(
         cv("USERNAME_RECOVERY_TEMPLATE"),

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -2,7 +2,7 @@
 test_recoverable
 ~~~~~~~~~~~~~~~~
 
-Recoverable functionality tests
+Recoverable (password, usernanme) functionality tests
 
 :copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
@@ -22,6 +22,7 @@ from tests.test_utils import (
     capture_flashes,
     capture_reset_password_requests,
     check_location,
+    check_signals,
     get_form_input_value,
     is_authenticated,
     logout,
@@ -33,7 +34,6 @@ from flask_security.forms import ForgotPasswordForm, LoginForm
 from flask_security.signals import (
     password_reset,
     reset_password_instructions_sent,
-    username_recovery_email_sent,
 )
 
 pytestmark = pytest.mark.recoverable()
@@ -133,19 +133,13 @@ def test_recoverable_flag(app, clients, get_message, outbox):
 
 
 @pytest.mark.confirmable()
-@pytest.mark.registerable()
 @pytest.mark.settings(requires_confirmation_error_view="/confirm")
 def test_requires_confirmation_error_redirect(app, clients):
-    data = dict(
-        email="jyl@lp.com", password="awesome sunset", password_confirm="awesome sunset"
-    )
-    clients.post("/register", data=data)
-
     response = clients.post(
-        "/reset", data=dict(email="jyl@lp.com"), follow_redirects=True
+        "/reset", data=dict(email="joe@lp.com"), follow_redirects=True
     )
     assert b"send_confirmation_form" in response.data
-    assert b"jyl@lp.com" in response.data
+    assert b"joe@lp.com" in response.data
 
 
 @pytest.mark.settings()
@@ -928,15 +922,7 @@ def test_recoverable_auth_json(app, client, get_message, outbox):
 
 
 @pytest.mark.username_recovery()
-def test_username_recovery_valid_email(app, clients, get_message, outbox):
-    recorded_recovery_sent = []
-
-    @username_recovery_email_sent.connect_via(app)
-    def on_email_sent(app, **kwargs):
-        assert isinstance(app, Flask)
-        assert isinstance(kwargs["user"], UserMixin)
-        recorded_recovery_sent.append(kwargs["user"])
-
+def test_username_recovery_valid_email(app, clients, get_message, outbox, signals):
     # Test the username recovery view
     response = clients.get("/recover-username")
     assert b"<h1>Username Recovery</h1>" in response.data
@@ -945,7 +931,8 @@ def test_username_recovery_valid_email(app, clients, get_message, outbox):
         "/recover-username", data=dict(email="joe@lp.com"), follow_redirects=True
     )
 
-    assert len(recorded_recovery_sent) == 1
+    check_signals(signals, "username_recovery_email_sent")
+    assert signals["username_recovery_email_sent"][0]["user_email"] == "joe@lp.com"
     assert len(outbox) == 1
     assert response.status_code == 200
 
@@ -975,8 +962,8 @@ def test_username_recovery_valid_email(app, clients, get_message, outbox):
 
 
 @pytest.mark.username_recovery()
-def test_username_recovery_invalid_email(app, clients, outbox):
-    response = clients.post(
+def test_username_recovery_invalid_email(app, client, outbox):
+    response = client.post(
         "/recover-username", data=dict(email="bogus@lp.com"), follow_redirects=True
     )
 
@@ -984,10 +971,9 @@ def test_username_recovery_invalid_email(app, clients, outbox):
     assert response.status_code == 200
 
     # Test JSON responses
-    response = clients.post(
+    response = client.post(
         "/recover-username",
         json=dict(email="bogus@lp.com"),
-        headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 400
     assert response.headers["Content-Type"] == "application/json"
@@ -1000,13 +986,9 @@ def test_username_recovery_invalid_email(app, clients, outbox):
 
 @pytest.mark.username_recovery()
 @pytest.mark.settings(return_generic_responses=True)
-def test_username_recovery_generic_responses(app, clients, get_message, outbox):
-    recorded_recovery_sent = []
-
-    @username_recovery_email_sent.connect_via(app)
-    def on_email_sent(app, **kwargs):
-        recorded_recovery_sent.append(kwargs["user"])
-
+def test_username_recovery_generic_responses(
+    app, clients, get_message, outbox, signals
+):
     # Test with valid email
     with capture_flashes() as flashes:
         response = clients.post(
@@ -1018,7 +1000,8 @@ def test_username_recovery_generic_responses(app, clients, get_message, outbox):
     assert get_message("USERNAME_RECOVERY_REQUEST") == flashes[0]["message"].encode(
         "utf-8"
     )
-    assert len(recorded_recovery_sent) == 1
+    check_signals(signals, "username_recovery_email_sent")
+    assert signals["username_recovery_email_sent"][0]["user_email"] == "joe@lp.com"
     assert len(outbox) == 1
     assert response.status_code == 200
 
@@ -1034,25 +1017,58 @@ def test_username_recovery_generic_responses(app, clients, get_message, outbox):
         "utf-8"
     )
     # Validate no email was sent (there should only be one from the previous test)
-    assert len(recorded_recovery_sent) == 1
+    check_signals(signals, "username_recovery_email_sent")
     assert len(outbox) == 1
     assert response.status_code == 200
 
     # Test JSON responses - valid email
-    response = clients.post(
-        "/recover-username",
-        json=dict(email="joe@lp.com"),
-        headers={"Content-Type": "application/json"},
-    )
+    response = clients.post("/recover-username", json=dict(email="joe@lp.com"))
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
 
     # Test JSON responses - invalid email
-    response = clients.post(
-        "/recover-username",
-        json=dict(email="bogus@lp.com"),
-        headers={"Content-Type": "application/json"},
-    )
+    response = clients.post("/recover-username", json=dict(email="bogus@lp.com"))
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
     assert not any(e in response.json["response"].keys() for e in ["error", "errors"])
+
+
+@pytest.mark.username_recovery()
+def test_ur_inactive(client, get_message):
+    response = client.post(
+        "/recover-username", data=dict(email="tiya@lp.com"), follow_redirects=True
+    )
+    assert get_message("DISABLED_ACCOUNT") in response.data
+
+
+@pytest.mark.username_recovery()
+@pytest.mark.confirmable()
+def test_ur_confirm_needed(app, client, get_message, outbox):
+    response = client.post("/recover-username", json=dict(email="joe@lp.com"))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "CONFIRMATION_REQUIRED"
+    )
+    assert len(outbox) == 0
+
+
+@pytest.mark.username_recovery()
+@pytest.mark.confirmable()
+@pytest.mark.settings(requires_confirmation_error_view="/confirm")
+def test_ur_confirmation_error_redirect(app, client):
+    response = client.post(
+        "/recover-username", data=dict(email="joe@lp.com"), follow_redirects=True
+    )
+    assert b"send_confirmation_form" in response.data
+    assert b"joe@lp.com" in response.data
+
+
+@pytest.mark.username_recovery()
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_allowed_authn=_allowed))
+def test_ur_override_user_allowed(app, client, get_message):
+    response = client.post("/recover-username", json=dict(email="gal@lp.com"))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"] == ["You are not allowed to do that"]
+    assert response.json["response"]["field_errors"]["email"] == [
+        "You are not allowed to do that"
+    ]

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1310,14 +1310,14 @@ def test_requires_confirmation_error_redirect(app, client):
         data=dict(identity="jyl@lp.com", chosen_method="email"),
         follow_redirects=False,
     )
-    assert "/confirm" in response.location
+    assert response.location == "/confirm?email=jyl%40lp.com"
 
     response = client.post(
         "/us-signin",
         data=dict(identity="jyl@lp.com", passcode="password"),
         follow_redirects=False,
     )
-    assert "/confirm" in response.location
+    assert response.location == "/confirm?email=jyl%40lp.com"
 
 
 @pytest.mark.registerable()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ test_utils
 
 Test utils
 
-:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -29,7 +29,6 @@ from flask_security.signals import (
     tf_security_token_sent,
     user_registered,
     us_security_token_sent,
-    username_recovery_email_sent,
 )
 from flask_security.utils import hash_data, hash_password
 
@@ -166,6 +165,7 @@ def get_existing_session(client):
         serializer = URLSafeTimedSerializer("secret", serializer=TaggedJSONSerializer())
         val = serializer.loads_unsafe(cookie.value)
         return val[1]
+    return None
 
 
 def reset_fresh(client, within):
@@ -381,12 +381,8 @@ def capture_registrations():
 
 
 @contextmanager
-def capture_reset_password_requests(reset_password_sent_at=None):
-    """Testing utility for capturing password reset requests.
-
-    :param reset_password_sent_at: An optional datetime object to set the
-                                   user's `reset_password_sent_at` to
-    """
+def capture_reset_password_requests():
+    """Testing utility for capturing password reset requests."""
     reset_requests = []
 
     def _on(app, **data):
@@ -398,22 +394,6 @@ def capture_reset_password_requests(reset_password_sent_at=None):
         yield reset_requests
     finally:
         reset_password_instructions_sent.disconnect(_on)
-
-
-@contextmanager
-def capture_username_recovery_requests():
-    """Testing utility for capturing username recovery requests."""
-    recovery_requests = []
-
-    def _on(app, **data):
-        recovery_requests.append(data)
-
-    username_recovery_email_sent.connect(_on)
-
-    try:
-        yield recovery_requests
-    finally:
-        username_recovery_email_sent.disconnect(_on)
 
 
 def check_signals(


### PR DESCRIPTION
- Test for user not active
- Test for user requiring confirmation
- Support the confirmation_required redirect

closes #1200