### PR TITLE
Change track_failed_authn to not take endpoint name.

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1147,12 +1147,10 @@ class UserMixin(BaseUserMixin):
         """
         return cv("TWO_FACTOR_REQUIRED")
 
-    def track_failed_authn(
-        self, endpoint: str | None, auth_type: str, tfa: bool = False
-    ) -> None:
+    def track_failed_authn(self, auth_type: str, tfa: bool = False) -> None:
         """Called when a user fails to authenticate.
 
-        endpoint - blueprint endpoint name:
+        The following flask-Security endpoints call this:
 
             - security.login
             - security.verify
@@ -1174,6 +1172,9 @@ class UserMixin(BaseUserMixin):
         This is called any time a credential is presented but is not verifiable.
         It is NOT called on API errors or missing data.
 
+        Use Flask's request proxy to get information such as endpoint. Note that
+        it is possible there isn't a Flask Request if this is called from the cli.
+
         The default implementation sends the user_failed_authn signal.
 
         .. versionadded:: 5.8.0
@@ -1181,7 +1182,6 @@ class UserMixin(BaseUserMixin):
         user_failed_authn.send(
             current_app._get_current_object(),  # type: ignore[attr-defined]
             _async_wrapper=current_app.ensure_sync,
-            endpoint=endpoint,
             user=self,
             auth_type=auth_type,
             tfa=tfa,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -600,14 +600,14 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
             return False
         if not self.user.password:
             # This is result of PASSWORD_REQUIRED=False and UNIFIED_SIGNIN
-            self.user.track_failed_authn(request.endpoint, "password")
+            self.user.track_failed_authn("password")
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             # Reduce timing variation between existing and non-existing users
             hash_password(self.password.data)
             return False
         self.password.data = _security.password_util.normalize(self.password.data)
         if not self.user.verify_and_update_password(self.password.data):
-            self.user.track_failed_authn(request.endpoint, "password")
+            self.user.track_failed_authn("password")
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             return False
 
@@ -669,7 +669,7 @@ class VerifyForm(Form, PasswordFormMixin):
         self.password.data = _security.password_util.normalize(self.password.data)
         assert isinstance(self.password.errors, list)
         if not self.user.verify_and_update_password(self.password.data):
-            self.user.track_failed_authn(request.endpoint, "password")
+            self.user.track_failed_authn("password")
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             return False
         return True
@@ -1049,7 +1049,7 @@ class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
             window=self.window,
         ):
             if not self.is_setup:
-                self.user.track_failed_authn(request.endpoint, "code", True)
+                self.user.track_failed_authn("code", True)
             self.code.errors.append(get_message("TWO_FACTOR_INVALID_TOKEN")[0])
             return False
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -216,7 +216,7 @@ class _UnifiedPassCodeForm(Form):
                         ok = True
                         break
             if not ok:
-                self.user.track_failed_authn(request.endpoint, "passcode")
+                self.user.track_failed_authn("passcode")
                 self.passcode.errors.append(get_message("INVALID_PASSWORD_CODE")[0])
                 return False
 
@@ -715,7 +715,7 @@ def us_verify_link() -> ResponseValue:
         window=cv("US_TOKEN_VALIDITY"),
     ):
         m, c = generic_message("INVALID_CODE", "GENERIC_AUTHN_FAILED")
-        user.track_failed_authn(request.endpoint, "passcode")
+        user.track_failed_authn("passcode")
 
         if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -359,7 +359,7 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
                 self.credential.errors.append(
                     get_message("WEBAUTHN_NO_VERIFY", cause=str(exc))[0]
                 )
-                self.user.track_failed_authn(request.endpoint, "passkey")
+                self.user.track_failed_authn("passkey")
                 return False
         return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ conftest
 Test fixtures and what not
 
 :copyright: (c) 2017 by CERN.
-:copyright: (c) 2019-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -1006,6 +1006,9 @@ def signals():
 
         def _on(app, _sc=sc, **kwargs):
             assert isinstance(app, Flask)
+            kwargs["request_endpoint"] = (
+                flask_request.endpoint if flask_request else None
+            )
             # user argument is an ORM structure so may not be available in a test
             # outside of the request - capture value(s) here
             user = kwargs.get("user", None)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -390,7 +390,7 @@ def test_invalid_user(client, get_message):
 def test_bad_password(client, get_message, signals):
     response = authenticate(client, password="bogus")
     assert get_message("INVALID_PASSWORD") in response.data
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.login"
+    assert signals["user_failed_authn"][0]["request_endpoint"] == "security.login"
     assert signals["user_failed_authn"][0]["user_email"] == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "password"
     assert not signals["user_failed_authn"][0]["tfa"]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1188,7 +1188,7 @@ def test_verify_fresh_json(app, client, get_message, signals):
         "/verify", json=dict(password="not my password"), headers=headers
     )
     assert response.status_code == 400
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.verify"
+    assert signals["user_failed_authn"][0]["request_endpoint"] == "security.verify"
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "password"
     assert not signals["user_failed_authn"][0]["tfa"]

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -395,7 +395,7 @@ def test_two_factor_flag(app, clients, get_message, outbox, signals):
     response = client.post("/tf-validate", data=dict(code=wrong_code))
     assert get_message("TWO_FACTOR_INVALID_TOKEN") in response.data
     assert (
-        signals["user_failed_authn"][2]["endpoint"]
+        signals["user_failed_authn"][2]["request_endpoint"]
         == "security.two_factor_token_validation"
     )
     assert signals["user_failed_authn"][2]["user"].email == "gal@lp.com"
@@ -650,7 +650,7 @@ def test_json(app, client, signals):
     assert response.json["response"]["field_errors"]["code"][0] == "Invalid code"
     assert response.json["response"]["errors"][0] == "Invalid code"
     assert (
-        signals["user_failed_authn"][0]["endpoint"]
+        signals["user_failed_authn"][0]["request_endpoint"]
         == "security.two_factor_token_validation"
     )
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -191,7 +191,7 @@ def test_simple_signin(app, clients, get_message, outbox, signals):
         follow_redirects=True,
     )
     assert get_message("INVALID_PASSWORD_CODE") in response.data
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_signin"
+    assert signals["user_failed_authn"][0]["request_endpoint"] == "security.us_signin"
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
     assert not signals["user_failed_authn"][0]["tfa"]
@@ -276,7 +276,9 @@ def test_simple_signin_json(app, client_nc, get_message, outbox, signals):
         assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
             "INVALID_PASSWORD_CODE"
         )
-        assert signals["user_failed_authn"][0]["endpoint"] == "security.us_signin"
+        assert (
+            signals["user_failed_authn"][0]["request_endpoint"] == "security.us_signin"
+        )
         assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
         assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
         assert not signals["user_failed_authn"][0]["tfa"]
@@ -626,7 +628,9 @@ def test_verify_link(app, client, get_message, outbox, signals):
         follow_redirects=True,
     )
     assert get_message("INVALID_CODE") in response.data
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_verify_link"
+    assert (
+        signals["user_failed_authn"][0]["request_endpoint"] == "security.us_verify_link"
+    )
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
     assert not signals["user_failed_authn"][0]["tfa"]
@@ -695,7 +699,9 @@ def test_verify_link_spa(app, client, get_message, outbox, signals):
     assert "/login-error" == split.path
     qparams = dict(parse_qsl(split.query))
     assert get_message("INVALID_CODE") == qparams["error"].encode("utf-8")
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_verify_link"
+    assert (
+        signals["user_failed_authn"][0]["request_endpoint"] == "security.us_verify_link"
+    )
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
     assert not signals["user_failed_authn"][0]["tfa"]
@@ -1102,7 +1108,7 @@ def test_verify_json(app, client, get_message, signals):
     assert response.json["response"]["field_errors"]["passcode"][0].encode(
         "utf-8"
     ) == get_message("INVALID_PASSWORD_CODE")
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.us_verify"
+    assert signals["user_failed_authn"][0]["request_endpoint"] == "security.us_verify"
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "passcode"
     assert not signals["user_failed_authn"][0]["tfa"]

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -616,7 +616,10 @@ def test_bad_data_signin(app, client, get_message, signals):
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_NO_VERIFY", cause="Could not verify authentication signature"
     )
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.wan_signin_response"
+    assert (
+        signals["user_failed_authn"][0]["request_endpoint"]
+        == "security.wan_signin_response"
+    )
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "passkey"
     assert not signals["user_failed_authn"][0]["tfa"]
@@ -1413,7 +1416,10 @@ def test_verify_validate_error(app, client, get_message, signals):
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_NO_VERIFY", cause="Could not verify authentication signature"
     )
-    assert signals["user_failed_authn"][0]["endpoint"] == "security.wan_verify_response"
+    assert (
+        signals["user_failed_authn"][0]["request_endpoint"]
+        == "security.wan_verify_response"
+    )
     assert signals["user_failed_authn"][0]["user"].email == "matt@lp.com"
     assert signals["user_failed_authn"][0]["auth_type"] == "passkey"
     assert not signals["user_failed_authn"][0]["tfa"]


### PR DESCRIPTION
There are lots of things an application might want to log or look at - they can access the flask.request as well as we can.