### PR TITLE
Fix potential None password_hash issue in verify_password

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -392,7 +392,8 @@ def verify_password(password: str | bytes, password_hash: str | bytes) -> bool:
     .. note::
         Make sure that the password passed in has already been normalized.
     """
-    if use_double_hash(password_hash):
+
+    if password_hash and use_double_hash(password_hash):
         password = get_hmac(password)
         if _pwd_context.identify(password_hash) == "bcrypt":
             password = password[:72]


### PR DESCRIPTION
Added a safety check to ensure password_hash is not None before calling use_double_hash, preventing potential runtime errors.