### PR TITLE
Update Catalan and Spanish translations.

### DIFF
--- a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 3.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2026-04-14 15:32-0700\n"
-"PO-Revision-Date: 2026-03-24 09:50+0100\n"
+"POT-Creation-Date: 2026-05-04 13:44+0200\n"
+"PO-Revision-Date: 2026-05-02 11:51+0200\n"
 "Last-Translator: Ariel von Barnekow <avbarnekow@gmail.com>\n"
 "Language: ca_ES\n"
 "Language-Team: \n"
@@ -18,72 +18,72 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.18.0\n"
+"Generated-By: Babel 2.17.0\n"
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Confirm your new email address"
 msgstr "Confirma la teva nova adreça de correu electrònic"
 
-#: flask_security/core.py:302
+#: flask_security/core.py:310
 msgid "Login Required"
 msgstr "Per poder veure la pàgina sol·licitada és necessari iniciar la sessió"
 
-#: flask_security/core.py:303
+#: flask_security/core.py:311
 msgid "Welcome"
 msgstr "Benvingut/da"
 
-#: flask_security/core.py:304
+#: flask_security/core.py:312
 msgid "Please confirm your email"
 msgstr "Si us plau, confirmeu el vostre correu electrònic"
 
-#: flask_security/core.py:305
+#: flask_security/core.py:313
 msgid "Login instructions"
 msgstr "Instruccions d'inici de la sessió"
 
-#: flask_security/core.py:306
+#: flask_security/core.py:314
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "S'ha restablit la teva contrasenya"
 
-#: flask_security/core.py:307
+#: flask_security/core.py:315
 msgid "Your password has been changed"
 msgstr "S'ha canviat la teva contrasenya"
 
-#: flask_security/core.py:308
+#: flask_security/core.py:316
 msgid "Password reset instructions"
 msgstr "Instruccions de recuperació de la contrasenya"
 
-#: flask_security/core.py:309
+#: flask_security/core.py:317
 #: flask_security/templates/security/email/change_username_notice.txt:1
 msgid "Your username has been changed"
 msgstr "El teu nom d'usuari ha estat canviat"
 
-#: flask_security/core.py:310
+#: flask_security/core.py:318
 msgid "Your requested username"
 msgstr "El nom d'usuari que has sol·licitat"
 
-#: flask_security/core.py:313
+#: flask_security/core.py:321
 msgid "Two-Factor Login"
 msgstr "Inici de sessió amb doble factor d'autenticació"
 
-#: flask_security/core.py:314
+#: flask_security/core.py:322
 msgid "Two-Factor Rescue"
 msgstr "Recuperació de doble factor"
 
-#: flask_security/core.py:356
+#: flask_security/core.py:364
 msgid "Verification Code"
 msgstr "Codi de verificació"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:410
 msgid "Input not appropriate for requested API"
 msgstr "Dades d'entrada no apropiades per l'API demanada"
 
-#: flask_security/core.py:404
+#: flask_security/core.py:412
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Autenticació fallida - identitat o contrasenya/codi d'accés invàlid"
 
-#: flask_security/core.py:409
+#: flask_security/core.py:417
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -91,23 +91,23 @@ msgstr ""
 "Si aquesta adreça de correu electrònic és al nostre sistema, rebràs un "
 "correu electrònic que descriu com restablir la teva contrasenya."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:423
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Si aquesta identitat és al nostre sistema, se t'ha enviat un codi."
 
-#: flask_security/core.py:418
+#: flask_security/core.py:426
 msgid "You do not have permission to view this resource."
 msgstr "No tens permís d'accés per a consultar aquest recurs."
 
-#: flask_security/core.py:420
+#: flask_security/core.py:428
 msgid "You must sign in to view this resource."
 msgstr "Has d'iniciar sessió per veure aquest recurs."
 
-#: flask_security/core.py:424
+#: flask_security/core.py:432
 msgid "You must reauthenticate to access this endpoint"
 msgstr "Has de tornar a autenticar-te per accedir a aquest punt final"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:437
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
@@ -116,24 +116,24 @@ msgstr ""
 "Gràcies. Per confirmar la teva adreça de correu electrònic %(email)s, fes"
 " clic al enllaç del correu electrònic que acabem d'enviar-te."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:443
 msgid "Thank you. Your email has been confirmed."
 msgstr "Moltes gràcies. S'ha confirmat el teu correu electrònic."
 
-#: flask_security/core.py:436
+#: flask_security/core.py:444
 msgid "Your email has already been confirmed."
 msgstr "El teu correu electrònic ja s'havia confirmat."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:445
 msgid "Invalid confirmation token."
 msgstr "Token de confirmació no vàlid."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:447
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ja es associat amb un compte."
 
-#: flask_security/core.py:444
+#: flask_security/core.py:452
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -142,12 +142,12 @@ msgstr ""
 "L'atribut d'identitat '%(attr)s' amb valor '%(value)s' ja està associat a"
 " un compte."
 
-#: flask_security/core.py:450
+#: flask_security/core.py:458
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "Identitat %(id)s no registrada"
 
-#: flask_security/core.py:455
+#: flask_security/core.py:463
 #, python-format
 msgid ""
 "An error occurred while communicating with the OAuth provider: "
@@ -156,57 +156,57 @@ msgstr ""
 "S'ha produït un error en comunicar-se amb el proveïdor OAuth: "
 "(%(exerror)s - %(exdesc)s). Si us plau, torneu-ho a provar."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:469
 msgid "Password does not match"
 msgstr "La contrasenya no coincideix"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:470
 msgid "Passwords do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: flask_security/core.py:463
+#: flask_security/core.py:471
 msgid "Redirections outside the domain are forbidden"
 msgstr "Les redireccions a llocs web externes s'han prohibit"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:472
 msgid "Recovery code invalid"
 msgstr "Codi de recuperació invàlid"
 
-#: flask_security/core.py:465
+#: flask_security/core.py:473
 msgid "No recovery codes generated yet"
 msgstr "Encara no s'han generat codis de recuperació"
 
-#: flask_security/core.py:467
+#: flask_security/core.py:475
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Les instruccions per restablir la teva contrasenya s'han enviat a "
 "%(email)s."
 
-#: flask_security/core.py:471
+#: flask_security/core.py:479
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr "No has restablert la teva contrasenya dins de %(within)s. "
 
-#: flask_security/core.py:474
+#: flask_security/core.py:482
 msgid "Invalid reset password token."
 msgstr "El token per restablir la contrasenya no és vàlid."
 
-#: flask_security/core.py:475
+#: flask_security/core.py:483
 msgid "Email requires confirmation."
 msgstr "El correu electrònic requereix d'una confirmació."
 
-#: flask_security/core.py:477
+#: flask_security/core.py:485
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Les instruccions de confirmació s'han enviat a %(email)s."
 
-#: flask_security/core.py:481
+#: flask_security/core.py:489
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr "No has confirmat el teu correu electrònic dins de %(within)s. "
 
-#: flask_security/core.py:486
+#: flask_security/core.py:494
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -215,78 +215,78 @@ msgstr ""
 "No vas iniciar la sessió abans de %(within)s. S'han enviat noves "
 "instruccions a %(email)s."
 
-#: flask_security/core.py:492
+#: flask_security/core.py:500
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "S'han enviat instruccions per l'inici de sessió a %(email)s."
 
-#: flask_security/core.py:495
+#: flask_security/core.py:503
 msgid "Invalid login token."
 msgstr "Token de d'inici de sessió no vàlid."
 
-#: flask_security/core.py:496
+#: flask_security/core.py:504
 msgid "Account is disabled."
 msgstr "El compte està desactivat."
 
-#: flask_security/core.py:497
+#: flask_security/core.py:505
 msgid "Email not provided"
 msgstr "No s'ha inclòs el correu electrònic"
 
-#: flask_security/core.py:498
+#: flask_security/core.py:506
 msgid "Invalid email address"
 msgstr "Adreça de correu electrònic no vàlida"
 
-#: flask_security/core.py:499 flask_security/core.py:545
+#: flask_security/core.py:507 flask_security/core.py:554
 msgid "Invalid code"
 msgstr "Codi invàlid"
 
-#: flask_security/core.py:500
+#: flask_security/core.py:508
 msgid "Password not provided"
 msgstr "No s'ha inclòs la contrasenya"
 
-#: flask_security/core.py:502
+#: flask_security/core.py:510
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "La contrasenya ha de tenir al menys %(length)s caràcters"
 
-#: flask_security/core.py:505
+#: flask_security/core.py:513
 msgid "Password not complex enough"
 msgstr "La contrasenya no és prou complexa"
 
-#: flask_security/core.py:506
+#: flask_security/core.py:514
 msgid "Password on breached list"
 msgstr "La contrasenya està a la llista de contrasenyes compromeses"
 
-#: flask_security/core.py:508
+#: flask_security/core.py:516
 msgid "Failed to contact breached passwords site"
 msgstr "No s'ha pogut contactar amb la web de filtracions de contrasenyes"
 
-#: flask_security/core.py:511
+#: flask_security/core.py:519
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Número de telèfon no vàlid, per exemple, falta el codi de país"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:520
 msgid "Specified user does not exist"
 msgstr "L'usuari no existeix"
 
-#: flask_security/core.py:513
+#: flask_security/core.py:521
 msgid "Invalid password"
 msgstr "Contrasenya no vàlida"
 
-#: flask_security/core.py:514
+#: flask_security/core.py:522
 msgid "Password or code submitted is not valid"
 msgstr "La contrasenya o el codi enviat no és vàlid"
 
-#: flask_security/core.py:515
+#: flask_security/core.py:523
 msgid "You have successfully logged in."
 msgstr "La sessió s'ha iniciat amb èxit."
 
-#: flask_security/core.py:516 flask_security/templates/security/_menu.html:19
+#: flask_security/core.py:524 flask_security/templates/security/_menu.html:19
 #: flask_security/templates/security/_menu.html:65
 msgid "Forgot password?"
 msgstr "Has oblidat la teva contrasenya?"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:527
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -294,7 +294,7 @@ msgstr ""
 "Has restablert la teva contrasenya amb èxit i s'ha iniciat la sessió "
 "automàticament."
 
-#: flask_security/core.py:526
+#: flask_security/core.py:534
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -302,92 +302,97 @@ msgstr ""
 "Has restablert la teva contrasenya amb èxit. Si us plau, autentica't amb "
 "la teva nova contrasenya."
 
-#: flask_security/core.py:532
+#: flask_security/core.py:540
 msgid "Your new password must be different than your previous password."
 msgstr "La nova contrasenya ha de ser diferent de l'anterior."
 
-#: flask_security/core.py:535
+#: flask_security/core.py:543
 msgid "You successfully changed your password."
 msgstr "La teva contrasenya s'ha modificat amb èxit."
 
-#: flask_security/core.py:536
+#: flask_security/core.py:544
 msgid "Please log in to access this page."
 msgstr "Has d'iniciar sessió per tal d'accedir a aquesta pàgina."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:545
 msgid "Please reauthenticate to access this page."
 msgstr "Has d'iniciar una nova sessió per tal d'accedir a aquesta pàgina."
 
-#: flask_security/core.py:538
+#: flask_security/core.py:546
+#, python-format
+msgid "Refresh token is invalid (%(reason)s)"
+msgstr "El token de refresc és invàlid (%(reason)s)"
+
+#: flask_security/core.py:547
 msgid "Reauthentication successful"
 msgstr "Reautenticació exitosa"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:549
 msgid "You can only access this endpoint when not logged in."
 msgstr "Només pots accedir a aquest punt final quan no estàs connectat."
 
-#: flask_security/core.py:543
+#: flask_security/core.py:552
 msgid "Code has been sent."
 msgstr "S'ha enviat el codi."
 
-#: flask_security/core.py:544
+#: flask_security/core.py:553
 msgid "Failed to send code. Please try again later"
 msgstr "No s'ha pogut enviar el codi. Si us plau, torna a intentar-ho més tard"
 
-#: flask_security/core.py:546
+#: flask_security/core.py:555
 msgid "Your code has been confirmed"
 msgstr "El teu codi ha estat confirmat"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:557
 msgid "You successfully changed your two-factor method."
 msgstr "Has canviat el teu mètode de doble factor amb èxit."
 
-#: flask_security/core.py:552
+#: flask_security/core.py:561
 msgid "You currently do not have permissions to access this page"
 msgstr "Actualment no tens permisos per accedir a aquesta pàgina"
 
-#: flask_security/core.py:555
+#: flask_security/core.py:564
 msgid "Marked method is not valid"
 msgstr "El mètode marcat no és vàlid"
 
-#: flask_security/core.py:557
+#: flask_security/core.py:566
 msgid "You successfully disabled two-factor authorization."
 msgstr "Has desactivat l'autenticació de doble factor amb èxit."
 
-#: flask_security/core.py:561 flask_security/core.py:570
+#: flask_security/core.py:570 flask_security/core.py:579
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "La configuració s'ha de completar dins de %(within)s. Si us plau, torna a"
 " començar."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:574
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr "Opcions d'inici de sessió actualment actives: %(method_list)s."
 
-#: flask_security/core.py:568
+#: flask_security/core.py:577
 msgid "Requested method is not valid"
 msgstr "El mètode sol·licitat no és vàlid"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:582
 msgid "Unified sign in setup successful"
 msgstr "Configuració d'inici de sessió unificat exitosa"
 
-#: flask_security/core.py:574
+#: flask_security/core.py:583
 msgid "You must specify a valid identity to sign in"
 msgstr "Heu de especificar una identitat vàlida per iniciar sessió"
 
-#: flask_security/core.py:575
+#: flask_security/core.py:584
 #, python-format
 msgid "Use this code to sign in: %(code)s"
 msgstr "Utilitza aquest codi per iniciar sessió: %(code)s"
 
-#: flask_security/core.py:576
+#: flask_security/core.py:585
 msgid "You successfully changed your username"
 msgstr "Has canviat el teu nom d'usuari amb èxit"
 
-#: flask_security/core.py:579
+#: flask_security/core.py:588
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -396,91 +401,91 @@ msgstr ""
 "El nom d'usuari ha de tenir almenys %(min)d caràcters i menys de %(max)d "
 "caràcters"
 
-#: flask_security/core.py:585
+#: flask_security/core.py:594
 msgid "Username contains illegal characters"
 msgstr "El nom d'usuari conté caràcters il·legals"
 
-#: flask_security/core.py:589
+#: flask_security/core.py:598
 msgid "Username can contain only letters and numbers"
 msgstr "El nom d'usuari només pot contenir lletres i números"
 
-#: flask_security/core.py:592
+#: flask_security/core.py:601
 msgid "Username not provided"
 msgstr "Nom d'usuari no proporcionat"
 
-#: flask_security/core.py:594
+#: flask_security/core.py:603
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s ja està associat amb un compte."
 
-#: flask_security/core.py:598
+#: flask_security/core.py:607
 #, python-format
 msgid "Passkey operations must be completed within %(within)s. Please start over."
 msgstr ""
 "Les operacions de la clau d'accés s'han de completar dins de %(within)s. "
 "Si us plau, torna a començar."
 
-#: flask_security/core.py:602
+#: flask_security/core.py:611
 msgid "Nickname for new passkey is required."
 msgstr "Es requereix un sobrenom per a la nova clau d'accés."
 
-#: flask_security/core.py:606
+#: flask_security/core.py:615
 #, python-format
 msgid "%(name)s is already associated with a passkey."
 msgstr "%(name)s ja està associat amb una clau d'accés."
 
-#: flask_security/core.py:610
+#: flask_security/core.py:619
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s no està registrat amb l'usuari actual."
 
-#: flask_security/core.py:614
+#: flask_security/core.py:623
 #, python-format
 msgid "Successfully deleted the passkey with name: %(name)s"
 msgstr "S'ha eliminat la clau d'accés amb nom: %(name)s"
 
-#: flask_security/core.py:618
+#: flask_security/core.py:627
 #, python-format
 msgid "Successfully added the passkey with name: %(name)s"
 msgstr "S'ha afegit la clau d'accés amb nom: %(name)s"
 
-#: flask_security/core.py:622
+#: flask_security/core.py:631
 msgid "Passkey already registered."
 msgstr "Clau d'accés ja registrada."
 
-#: flask_security/core.py:626
+#: flask_security/core.py:635
 msgid "Unregistered passkey."
 msgstr "Clau d'accés no registrada."
 
-#: flask_security/core.py:630
+#: flask_security/core.py:639
 msgid "Passkey doesn't belong to any user."
 msgstr "La clau d'accés no pertany a cap usuari."
 
-#: flask_security/core.py:634
+#: flask_security/core.py:643
 #, python-format
 msgid "Could not verify passkey: %(cause)s."
 msgstr "No s'ha pogut verificar la clau d'accés: %(cause)s."
 
-#: flask_security/core.py:638
+#: flask_security/core.py:647
 msgid "Passkey not registered for this use (first or secondary)"
 msgstr "Clau d'accés no registrada per a aquest ús (primera o secundària)"
 
-#: flask_security/core.py:642
+#: flask_security/core.py:651
 msgid "Credential user handle didn't match"
 msgstr "El controlador d'usuari de les credencials no coincideix"
 
-#: flask_security/core.py:646
+#: flask_security/core.py:655
 #, python-format
 msgid "Confirmation must be completed within %(within)s. Please start over."
 msgstr ""
 "La confirmació s'ha de completar dins de %(within)s. Si us plau, torna a "
 "començar."
 
-#: flask_security/core.py:650
+#: flask_security/core.py:659
 msgid "Change of email address confirmed"
 msgstr "Canvi d'adreça de correu electrònic confirmat"
 
-#: flask_security/core.py:655
+#: flask_security/core.py:664
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
@@ -489,7 +494,7 @@ msgstr ""
 "Les instruccions per confirmar la teva nova adreça de correu electrònic "
 "s'han enviat a %(email)s."
 
-#: flask_security/core.py:661
+#: flask_security/core.py:670
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 "Si estàs registrat, el teu nom d'usuari s'enviarà al teu correu "
@@ -651,7 +656,7 @@ msgstr "clau d'accés"
 msgid "none"
 msgstr "cap"
 
-#: flask_security/forms.py:966 flask_security/unified_signin.py:171
+#: flask_security/forms.py:966 flask_security/unified_signin.py:172
 msgid "Available Methods"
 msgstr "Mètodes disponibles"
 
@@ -687,6 +692,10 @@ msgstr "Mètodes disponibles per al doble factor d'autenticació:"
 msgid "Select"
 msgstr "Selecciona"
 
+#: flask_security/tokens.py:168
+msgid "Refresh Token"
+msgstr "Token de refresc"
+
 #: flask_security/twofactor.py:139
 msgid "Send code via email"
 msgstr "Envia el codi per correu electrònic"
@@ -695,43 +704,43 @@ msgstr "Envia el codi per correu electrònic"
 msgid "Use previously downloaded recovery code"
 msgstr "Utilitza el codi de recuperació descarregat anteriorment"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:165
 msgid "Code or Password"
 msgstr "Codi o contrasenya"
 
-#: flask_security/unified_signin.py:173
+#: flask_security/unified_signin.py:174
 msgid "Via email"
 msgstr "Via correu electrònic"
 
-#: flask_security/unified_signin.py:174
+#: flask_security/unified_signin.py:175
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:307
 msgid "Setup additional sign in option"
 msgstr "Configura una opció d'inici de sessió addicional"
 
-#: flask_security/unified_signin.py:319
+#: flask_security/unified_signin.py:320
 msgid "Delete active sign in option"
 msgstr "Elimina l'opció d'inici de sessió activa"
 
-#: flask_security/webauthn.py:124 flask_security/webauthn.py:371
+#: flask_security/webauthn.py:125 flask_security/webauthn.py:372
 msgid "Nickname"
 msgstr "Sobrenom"
 
-#: flask_security/webauthn.py:128
+#: flask_security/webauthn.py:129
 msgid "Usage"
 msgstr "Ús"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:131
 msgid "Use as a first authentication factor"
 msgstr "Utilitza com a primer factor d'autenticació"
 
-#: flask_security/webauthn.py:133
+#: flask_security/webauthn.py:134
 msgid "Use as a secondary authentication factor"
 msgstr "Utilitza com a segon factor d'autenticació"
 
-#: flask_security/webauthn.py:225
+#: flask_security/webauthn.py:226
 msgid "Start"
 msgstr "Comença"
 

--- a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
@@ -11,496 +11,493 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.6.2\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2026-04-14 15:32-0700\n"
-"PO-Revision-Date: 2026-03-24 09:48+0100\n"
+"POT-Creation-Date: 2026-05-04 13:44+0200\n"
+"PO-Revision-Date: 2026-05-04 15:40+0200\n"
 "Last-Translator: Ariel von Barnekow  <avbarnekow@gmail.com>\n"
-"Language: es_ES\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.18.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.17.0\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Confirm your new email address"
 msgstr "Confirma tu nueva dirección de correo electrónico"
 
-#: flask_security/core.py:302
+#: flask_security/core.py:310
 msgid "Login Required"
 msgstr "Inicio de sesión necesario"
 
-#: flask_security/core.py:303
+#: flask_security/core.py:311
 msgid "Welcome"
 msgstr "Bienvenido/a"
 
-#: flask_security/core.py:304
+#: flask_security/core.py:312
 msgid "Please confirm your email"
 msgstr "Por favor, confirma tu correo electrónico"
 
-#: flask_security/core.py:305
+#: flask_security/core.py:313
 msgid "Login instructions"
 msgstr "Instrucciones para iniciar sesión"
 
-#: flask_security/core.py:306
+#: flask_security/core.py:314
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Tu contraseña ha sido restablecida"
 
-#: flask_security/core.py:307
+#: flask_security/core.py:315
 msgid "Your password has been changed"
 msgstr "Tu contraseña ha sido cambiada"
 
-#: flask_security/core.py:308
+#: flask_security/core.py:316
 msgid "Password reset instructions"
 msgstr "Instrucciones de recuperación de contraseña"
 
-#: flask_security/core.py:309
+#: flask_security/core.py:317
 #: flask_security/templates/security/email/change_username_notice.txt:1
 msgid "Your username has been changed"
 msgstr "Tu nombre de usuario ha sido cambiado"
 
-#: flask_security/core.py:310
+#: flask_security/core.py:318
 msgid "Your requested username"
 msgstr "Tu nombre de usuario solicitado"
 
-#: flask_security/core.py:313
+#: flask_security/core.py:321
 msgid "Two-Factor Login"
 msgstr "Inicio de sesión de doble factor"
 
-#: flask_security/core.py:314
+#: flask_security/core.py:322
 msgid "Two-Factor Rescue"
 msgstr "Recuperación del factor de doble autenticación"
 
-#: flask_security/core.py:356
+#: flask_security/core.py:364
 msgid "Verification Code"
 msgstr "Código de verificación"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:410
 msgid "Input not appropriate for requested API"
 msgstr "Entrada no apropiada para la API solicitada"
 
-#: flask_security/core.py:404
+#: flask_security/core.py:412
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
-"Fallo de autenticación - identidad o contraseña/código de acceso no "
-"válidos"
+"Fallo de autenticación - identidad o contraseña/código de acceso no válidos"
 
-#: flask_security/core.py:409
+#: flask_security/core.py:417
 msgid ""
-"If that email address is in our system, you will receive an email "
-"describing how to reset your password."
+"If that email address is in our system, you will receive an email describing how "
+"to reset your password."
 msgstr ""
-"Si esa dirección de correo electrónico está en nuestro sistema, recibirás"
-" un correo electrónico con la descripción de como restablecer tu "
-"contraseña."
+"Si esa dirección de correo electrónico está en nuestro sistema, recibirás un "
+"correo electrónico con la descripción de como restablecer tu contraseña."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:423
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Si esa identidad está en nuestro sistema, se te envió un código."
 
-#: flask_security/core.py:418
+#: flask_security/core.py:426
 msgid "You do not have permission to view this resource."
 msgstr "No tienes permiso para consultar este recurso."
 
-#: flask_security/core.py:420
+#: flask_security/core.py:428
 msgid "You must sign in to view this resource."
 msgstr "Debes autenticarte para acceder a este recurso."
 
-#: flask_security/core.py:424
+#: flask_security/core.py:432
 msgid "You must reauthenticate to access this endpoint"
 msgstr "Debes volver a autenticarte para acceder a este recurso"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:437
 #, python-format
 msgid ""
-"Thank you. To confirm your email address %(email)s, please click on the "
-"link in the email we have just sent to you."
+"Thank you. To confirm your email address %(email)s, please click on the link in "
+"the email we have just sent to you."
 msgstr ""
-"Gracias. Para confirmar tu dirección de correo electrónico %(email)s, haz"
-" clic en el enlace del mensaje que acabamos de enviarte."
+"Gracias. Para confirmar tu dirección de correo electrónico %(email)s, haz clic "
+"en el enlace del mensaje que acabamos de enviarte."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:443
 msgid "Thank you. Your email has been confirmed."
 msgstr "Gracias. Tu correo electrónico ha sido confirmado."
 
-#: flask_security/core.py:436
+#: flask_security/core.py:444
 msgid "Your email has already been confirmed."
 msgstr "Tu correo electrónico ya ha sido confirmado."
 
-#: flask_security/core.py:437
+#: flask_security/core.py:445
 msgid "Invalid confirmation token."
 msgstr "Código de confirmación inválido."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:447
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:444
+#: flask_security/core.py:452
 #, python-format
 msgid ""
-"Identity attribute '%(attr)s' with value '%(value)s' is already "
-"associated with an account."
+"Identity attribute '%(attr)s' with value '%(value)s' is already associated with "
+"an account."
 msgstr ""
-"El atributo de identidad '%(attr)s' con el valor '%(value)s' ya está "
-"asociado con una cuenta."
+"El atributo de identidad '%(attr)s' con el valor '%(value)s' ya está asociado "
+"con una cuenta."
 
-#: flask_security/core.py:450
+#: flask_security/core.py:458
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "Identidad %(id)s no registrada"
 
-#: flask_security/core.py:455
+#: flask_security/core.py:463
 #, python-format
 msgid ""
-"An error occurred while communicating with the OAuth provider: "
-"(%(exerror)s - %(exdesc)s). Please try again."
+"An error occurred while communicating with the OAuth provider: (%(exerror)s - "
+"%(exdesc)s). Please try again."
 msgstr ""
-"Ocurrió un error al comunicarse con el proveedor de OAuth: (%(exerror)s -"
-" %(exdesc)s). Por favor, inténtalo de nuevo."
+"Ocurrió un error al comunicarse con el proveedor de OAuth: (%(exerror)s - "
+"%(exdesc)s). Por favor, inténtalo de nuevo."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:469
 msgid "Password does not match"
 msgstr "La contraseña no coincide"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:470
 msgid "Passwords do not match"
 msgstr "Las contraseñas no coinciden"
 
-#: flask_security/core.py:463
+#: flask_security/core.py:471
 msgid "Redirections outside the domain are forbidden"
 msgstr "Las redirecciones a sitios web externos están prohibidas"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:472
 msgid "Recovery code invalid"
 msgstr "Código de recuperación inválido"
 
-#: flask_security/core.py:465
+#: flask_security/core.py:473
 msgid "No recovery codes generated yet"
 msgstr "Aún no se han generado códigos de recuperación"
 
-#: flask_security/core.py:467
+#: flask_security/core.py:475
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
-"Las instrucciones para restablecer tu contraseña se han enviado a "
-"%(email)s."
+"Las instrucciones para restablecer tu contraseña se han enviado a %(email)s."
 
-#: flask_security/core.py:471
+#: flask_security/core.py:479
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr "No has restablecido tu contraseña en un plazo de %(within)s. "
 
-#: flask_security/core.py:474
+#: flask_security/core.py:482
 msgid "Invalid reset password token."
 msgstr "Código de restablecimiento de contraseña inválido."
 
-#: flask_security/core.py:475
+#: flask_security/core.py:483
 msgid "Email requires confirmation."
 msgstr "El correo electrónico requiere confirmación."
 
-#: flask_security/core.py:477
+#: flask_security/core.py:485
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Las instrucciones de confirmación se han enviado a %(email)s."
 
-#: flask_security/core.py:481
+#: flask_security/core.py:489
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr "No has confirmado tu correo electrónico en un plazo de %(within)s. "
 
-#: flask_security/core.py:486
+#: flask_security/core.py:494
 #, python-format
 msgid ""
-"You did not login within %(within)s. New instructions to login have been "
-"sent to %(email)s."
+"You did not login within %(within)s. New instructions to login have been sent to "
+"%(email)s."
 msgstr ""
-"No has iniciado sesión antes de %(within)s. Nuevas instrucciones para "
-"iniciar sesión se han enviado a %(email)s."
+"No has iniciado sesión antes de %(within)s. Nuevas instrucciones para iniciar "
+"sesión se han enviado a %(email)s."
 
-#: flask_security/core.py:492
+#: flask_security/core.py:500
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Las instrucciones para iniciar sesión se han enviado a %(email)s."
 
-#: flask_security/core.py:495
+#: flask_security/core.py:503
 msgid "Invalid login token."
 msgstr "Código de inicio de sesión inválido."
 
-#: flask_security/core.py:496
+#: flask_security/core.py:504
 msgid "Account is disabled."
 msgstr "Cuenta deshabilitada."
 
-#: flask_security/core.py:497
+#: flask_security/core.py:505
 msgid "Email not provided"
 msgstr "Correo electrónico no indicado"
 
-#: flask_security/core.py:498
+#: flask_security/core.py:506
 msgid "Invalid email address"
 msgstr "Dirección de correo electrónico inválida"
 
-#: flask_security/core.py:499 flask_security/core.py:545
+#: flask_security/core.py:507 flask_security/core.py:554
 msgid "Invalid code"
 msgstr "Código inválido"
 
-#: flask_security/core.py:500
+#: flask_security/core.py:508
 msgid "Password not provided"
 msgstr "Contraseña no proporcionada"
 
-#: flask_security/core.py:502
+#: flask_security/core.py:510
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "La contraseña debe tener al menos %(length)s caracteres"
 
-#: flask_security/core.py:505
+#: flask_security/core.py:513
 msgid "Password not complex enough"
 msgstr "La contraseña no es lo suficientemente compleja"
 
-#: flask_security/core.py:506
+#: flask_security/core.py:514
 msgid "Password on breached list"
 msgstr "La contraseña aparece en la lista de contraseñas filtradas"
 
-#: flask_security/core.py:508
+#: flask_security/core.py:516
 msgid "Failed to contact breached passwords site"
 msgstr "No se ha podido contactar con el sitio de contraseñas filtradas"
 
-#: flask_security/core.py:511
+#: flask_security/core.py:519
 msgid "Phone number not valid e.g. missing country code"
 msgstr "El número de teléfono no es válido, p. ej. falta el código de país"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:520
 msgid "Specified user does not exist"
 msgstr "El usuario especificado no existe"
 
-#: flask_security/core.py:513
+#: flask_security/core.py:521
 msgid "Invalid password"
 msgstr "Contraseña inválida"
 
-#: flask_security/core.py:514
+#: flask_security/core.py:522
 msgid "Password or code submitted is not valid"
 msgstr "La contraseña o el código facilitado son inválidos"
 
-#: flask_security/core.py:515
+#: flask_security/core.py:523
 msgid "You have successfully logged in."
 msgstr "Has iniciado sesión correctamente."
 
-#: flask_security/core.py:516 flask_security/templates/security/_menu.html:19
+#: flask_security/core.py:524 flask_security/templates/security/_menu.html:19
 #: flask_security/templates/security/_menu.html:65
 msgid "Forgot password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:527
 msgid ""
-"You successfully reset your password and you have been logged in "
-"automatically."
+"You successfully reset your password and you have been logged in automatically."
 msgstr "Has restablecido tu contraseña y has iniciado sesión automáticamente."
 
-#: flask_security/core.py:526
+#: flask_security/core.py:534
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr "Has restablecido tu contraseña. Inicia sesión con tu nueva contraseña."
 
-#: flask_security/core.py:532
+#: flask_security/core.py:540
 msgid "Your new password must be different than your previous password."
 msgstr "Tu nueva contraseña debe ser diferente de la antigua."
 
-#: flask_security/core.py:535
+#: flask_security/core.py:543
 msgid "You successfully changed your password."
 msgstr "Has cambiado tu contraseña."
 
-#: flask_security/core.py:536
+#: flask_security/core.py:544
 msgid "Please log in to access this page."
 msgstr "Debes iniciar sesión para poder acceder a esta página."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:545
 msgid "Please reauthenticate to access this page."
 msgstr "Debes iniciar sesión nuevamente para poder acceder a esta página."
 
-#: flask_security/core.py:538
+#: flask_security/core.py:546
+#, python-format
+msgid "Refresh token is invalid (%(reason)s)"
+msgstr "El token de actualización no es válido (%(reason)s)"
+
+#: flask_security/core.py:547
 msgid "Reauthentication successful"
 msgstr "Reautenticación exitosa"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:549
 msgid "You can only access this endpoint when not logged in."
 msgstr "Solo puedes acceder a este recurso si no has iniciado sesión."
 
-#: flask_security/core.py:543
+#: flask_security/core.py:552
 msgid "Code has been sent."
 msgstr "El código se ha enviado."
 
-#: flask_security/core.py:544
+#: flask_security/core.py:553
 msgid "Failed to send code. Please try again later"
 msgstr "No se pudo enviar el código. Por favor inténtalo de nuevo más tarde"
 
-#: flask_security/core.py:546
+#: flask_security/core.py:555
 msgid "Your code has been confirmed"
 msgstr "Tu código ha sido confirmado"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:557
 msgid "You successfully changed your two-factor method."
 msgstr "Has cambiado tu método de doble autenticación."
 
-#: flask_security/core.py:552
+#: flask_security/core.py:561
 msgid "You currently do not have permissions to access this page"
 msgstr "Actualmente no tienes permisos para acceder a esta página"
 
-#: flask_security/core.py:555
+#: flask_security/core.py:564
 msgid "Marked method is not valid"
 msgstr "El método marcado no es válido"
 
-#: flask_security/core.py:557
+#: flask_security/core.py:566
 msgid "You successfully disabled two-factor authorization."
 msgstr "Has deshabilitado la autenticación de doble factor."
 
-#: flask_security/core.py:561 flask_security/core.py:570
+#: flask_security/core.py:570 flask_security/core.py:579
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
-"La configuración debe completarse en el plazo de %(within)s. Por favor "
-"vuelve a empezar."
+"La configuración debe completarse en el plazo de %(within)s. Por favor vuelve a "
+"empezar."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:574
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr "Opciones de inicio de sesión activas actualmente: %(method_list)s."
 
-#: flask_security/core.py:568
+#: flask_security/core.py:577
 msgid "Requested method is not valid"
 msgstr "El método solicitado no es válido"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:582
 msgid "Unified sign in setup successful"
 msgstr "El inicio de sesión unificado se ha configurado correctamente"
 
-#: flask_security/core.py:574
+#: flask_security/core.py:583
 msgid "You must specify a valid identity to sign in"
 msgstr "Debes especificar una identidad válida para iniciar sesión"
 
-#: flask_security/core.py:575
+#: flask_security/core.py:584
 #, python-format
 msgid "Use this code to sign in: %(code)s"
 msgstr "Utiliza este código para iniciar sesión: %(code)s"
 
-#: flask_security/core.py:576
+#: flask_security/core.py:585
 msgid "You successfully changed your username"
 msgstr "Has cambiado tu nombre de usuario"
 
-#: flask_security/core.py:579
+#: flask_security/core.py:588
 #, python-format
 msgid ""
-"Username must be at least %(min)d characters and less than %(max)d "
-"characters"
+"Username must be at least %(min)d characters and less than %(max)d characters"
 msgstr ""
-"El nombre de usuario debe tener al menos %(min)d caracteres y menos de "
-"%(max)d caracteres"
+"El nombre de usuario debe tener al menos %(min)d caracteres y menos de %(max)d "
+"caracteres"
 
-#: flask_security/core.py:585
+#: flask_security/core.py:594
 msgid "Username contains illegal characters"
 msgstr "El nombre de usuario contiene caracteres no admitidos"
 
-#: flask_security/core.py:589
+#: flask_security/core.py:598
 msgid "Username can contain only letters and numbers"
 msgstr "El nombre de usuario solo puede contener letras y números"
 
-#: flask_security/core.py:592
+#: flask_security/core.py:601
 msgid "Username not provided"
 msgstr "Nombre de usuario no proporcionado"
 
-#: flask_security/core.py:594
+#: flask_security/core.py:603
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:598
+#: flask_security/core.py:607
 #, python-format
 msgid "Passkey operations must be completed within %(within)s. Please start over."
 msgstr ""
 "Las operaciones con llaves de acceso deben completarse en el plazo de "
 "%(within)s. Por favor vuelve a empezar."
 
-#: flask_security/core.py:602
+#: flask_security/core.py:611
 msgid "Nickname for new passkey is required."
 msgstr "Se requiere un nombre para la nueva llave de acceso."
 
-#: flask_security/core.py:606
+#: flask_security/core.py:615
 #, python-format
 msgid "%(name)s is already associated with a passkey."
 msgstr "%(name)s ya está asociado a una llave de acceso."
 
-#: flask_security/core.py:610
+#: flask_security/core.py:619
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s no registrado con el usuario actual."
 
-#: flask_security/core.py:614
+#: flask_security/core.py:623
 #, python-format
 msgid "Successfully deleted the passkey with name: %(name)s"
 msgstr "Se ha eliminado la llave de acceso con nombre: %(name)s"
 
-#: flask_security/core.py:618
+#: flask_security/core.py:627
 #, python-format
 msgid "Successfully added the passkey with name: %(name)s"
 msgstr "Se ha añadido la llave de acceso con nombre: %(name)s"
 
-#: flask_security/core.py:622
+#: flask_security/core.py:631
 msgid "Passkey already registered."
 msgstr "Identificador de llave de acceso ya registrado."
 
-#: flask_security/core.py:626
+#: flask_security/core.py:635
 msgid "Unregistered passkey."
 msgstr "Identificador de llave de acceso no registrado."
 
-#: flask_security/core.py:630
+#: flask_security/core.py:639
 msgid "Passkey doesn't belong to any user."
 msgstr "La llave de acceso no pertenece a ningún usuario."
 
-#: flask_security/core.py:634
+#: flask_security/core.py:643
 #, python-format
 msgid "Could not verify passkey: %(cause)s."
 msgstr "No se pudo verificar la llave de acceso: %(cause)s."
 
-#: flask_security/core.py:638
+#: flask_security/core.py:647
 msgid "Passkey not registered for this use (first or secondary)"
 msgstr "Llave de acceso no registrada para este uso (primaria o secundaria)"
 
-#: flask_security/core.py:642
+#: flask_security/core.py:651
 msgid "Credential user handle didn't match"
 msgstr "La credencial de usuario no coincide"
 
-#: flask_security/core.py:646
+#: flask_security/core.py:655
 #, python-format
 msgid "Confirmation must be completed within %(within)s. Please start over."
 msgstr ""
-"La confirmación debe completarse en el plazo de %(within)s. Por favor "
-"vuelve a empezar."
+"La confirmación debe completarse en el plazo de %(within)s. Por favor vuelve a "
+"empezar."
 
-#: flask_security/core.py:650
+#: flask_security/core.py:659
 msgid "Change of email address confirmed"
 msgstr "Cambio de dirección de correo electrónico confirmado"
 
-#: flask_security/core.py:655
+#: flask_security/core.py:664
 #, python-format
-msgid ""
-"Instructions to confirm your new email address have been sent to "
-"%(email)s."
+msgid "Instructions to confirm your new email address have been sent to %(email)s."
 msgstr ""
-"Las instrucciones para confirmar tu dirección de correo electrónico se "
-"han enviado a %(email)s."
+"Las instrucciones para confirmar tu dirección de correo electrónico se han "
+"enviado a %(email)s."
 
-#: flask_security/core.py:661
+#: flask_security/core.py:670
 msgid "If registered, your username will be sent to your email."
 msgstr ""
-"Si estas registrado, tu nombre de usuario se enviará a tu correo "
-"electrónico."
+"Si estas registrado, tu nombre de usuario se enviará a tu correo electrónico."
 
 #: flask_security/forms.py:62
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
 msgstr ""
-"Configurar con una aplicación de autenticación (p.ej. Google, LastPass, "
-"Authy)"
+"Configurar con una aplicación de autenticación (p.ej. Google, LastPass, Authy)"
 
 #: flask_security/forms.py:64
 msgid "Change Method"
@@ -598,8 +595,7 @@ msgstr "Enviar enlace para iniciar sesión"
 msgid "Send Code"
 msgstr "Enviar código"
 
-#: flask_security/forms.py:86
-#: flask_security/templates/security/us_signin.html:1
+#: flask_security/forms.py:86 flask_security/templates/security/us_signin.html:1
 #: flask_security/templates/security/us_signin.html:7
 msgid "Sign In"
 msgstr "Iniciar sesión"
@@ -652,7 +648,7 @@ msgstr "llave de acceso"
 msgid "none"
 msgstr "ninguno"
 
-#: flask_security/forms.py:966 flask_security/unified_signin.py:171
+#: flask_security/forms.py:966 flask_security/unified_signin.py:172
 msgid "Available Methods"
 msgstr "Métodos disponibles"
 
@@ -688,6 +684,10 @@ msgstr "Métodos de doble factor disponibles:"
 msgid "Select"
 msgstr "Selecciona"
 
+#: flask_security/tokens.py:168
+msgid "Refresh Token"
+msgstr "Token de actualización"
+
 #: flask_security/twofactor.py:139
 msgid "Send code via email"
 msgstr "Enviar el código por correo electrónico"
@@ -696,43 +696,43 @@ msgstr "Enviar el código por correo electrónico"
 msgid "Use previously downloaded recovery code"
 msgstr "Usar código de recuperación descargado anteriormente"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:165
 msgid "Code or Password"
 msgstr "Código o contraseña"
 
-#: flask_security/unified_signin.py:173
+#: flask_security/unified_signin.py:174
 msgid "Via email"
 msgstr "Con correo electrónico"
 
-#: flask_security/unified_signin.py:174
+#: flask_security/unified_signin.py:175
 msgid "Via SMS"
 msgstr "Con SMS"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:307
 msgid "Setup additional sign in option"
 msgstr "Configurar una opción de inicio de sesión adicional"
 
-#: flask_security/unified_signin.py:319
+#: flask_security/unified_signin.py:320
 msgid "Delete active sign in option"
 msgstr "Eliminar la opción de inicio de sesión activa"
 
-#: flask_security/webauthn.py:124 flask_security/webauthn.py:371
+#: flask_security/webauthn.py:125 flask_security/webauthn.py:372
 msgid "Nickname"
 msgstr "Apodo"
 
-#: flask_security/webauthn.py:128
+#: flask_security/webauthn.py:129
 msgid "Usage"
 msgstr "Uso"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:131
 msgid "Use as a first authentication factor"
 msgstr "Uso como factor de autenticación primario"
 
-#: flask_security/webauthn.py:133
+#: flask_security/webauthn.py:134
 msgid "Use as a secondary authentication factor"
 msgstr "Uso como factor de autenticación secundario"
 
-#: flask_security/webauthn.py:225
+#: flask_security/webauthn.py:226
 msgid "Start"
 msgstr "Iniciar"
 
@@ -782,8 +782,7 @@ msgstr "Cambiar el correo electrónico"
 
 #: flask_security/templates/security/change_email.html:8
 msgid ""
-"Once submitted, an email confirmation will be sent to this new email "
-"address."
+"Once submitted, an email confirmation will be sent to this new email address."
 msgstr ""
 "Un mensaje de confirmación se enviará a esta nueva dirección de correo "
 "electrónico."
@@ -843,11 +842,10 @@ msgstr "Códigos de recuperación"
 
 #: flask_security/templates/security/mf_recovery_codes.html:13
 msgid ""
-"Be sure to copy these and store in a safe place. Each code can be used "
-"only once."
+"Be sure to copy these and store in a safe place. Each code can be used only once."
 msgstr ""
-"Asegúrate de copiarlos y guardarlos en un lugar seguro. Cada código sólo "
-"puede utilizarse una vez."
+"Asegúrate de copiarlos y guardarlos en un lugar seguro. Cada código sólo puede "
+"utilizarse una vez."
 
 #: flask_security/templates/security/mf_recovery_codes.html:21
 msgid "Generate new Recovery Codes"
@@ -876,8 +874,8 @@ msgstr "Selecciona un método de doble factor"
 #: flask_security/templates/security/two_factor_setup.html:28
 msgid "Two-Factor authentication adds an extra layer of security to your account"
 msgstr ""
-"La autenticación de doble factor añade una capa adicional de seguridad a "
-"tu cuenta"
+"La autenticación de doble factor añade una capa adicional de seguridad a tu "
+"cuenta"
 
 #: flask_security/templates/security/two_factor_setup.html:29
 msgid "In addition to your username and password, you'll need to use a code."
@@ -891,12 +889,12 @@ msgstr "Método de dos factores actualmente configurado: %(method)s"
 #: flask_security/templates/security/two_factor_setup.html:52
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
-"Open an authenticator app on your device and scan the following QRcode "
-"(or enter the code below manually) to start receiving codes:"
+"Open an authenticator app on your device and scan the following QRcode (or enter "
+"the code below manually) to start receiving codes:"
 msgstr ""
-"Abre una aplicación de autenticación en tu dispositivo y escanea el "
-"siguiente código QR (o ingresa manualmente el código que aparece a "
-"continuación) para comenzar a recibir códigos:"
+"Abre una aplicación de autenticación en tu dispositivo y escanea el siguiente "
+"código QR (o ingresa manualmente el código que aparece a continuación) para "
+"comenzar a recibir códigos:"
 
 #: flask_security/templates/security/two_factor_setup.html:55
 msgid "Two-Factor authentication code"
@@ -949,8 +947,7 @@ msgstr "El código de autenticación se envió a tu dirección de correo electr�
 #: flask_security/templates/security/two_factor_verify_code.html:24
 msgid "An email was sent to us in order to reset your application account"
 msgstr ""
-"Se nos envió un correo electrónico para restablecer tu cuenta de "
-"aplicación"
+"Se nos envió un correo electrónico para restablecer tu cuenta de aplicación"
 
 #: flask_security/templates/security/us_setup.html:24
 #: flask_security/templates/security/us_setup.html:30
@@ -1012,12 +1009,11 @@ msgstr "Llaves de acceso actualmente registradas:"
 #: flask_security/templates/security/wan_register.html:55
 #, python-format
 msgid ""
-"Nickname: \"%s\" Usage: \"%s\" Transports: \"%s\" Discoverable: \"%s\" "
-"Device Type: \"%s\" Backed up? \"%s\" Last used on: %s"
+"Nickname: \"%s\" Usage: \"%s\" Transports: \"%s\" Discoverable: \"%s\" Device "
+"Type: \"%s\" Backed up? \"%s\" Last used on: %s"
 msgstr ""
-"Nombre: \"%s\" Uso: \"%s\" Transportes: \"%s\" Descubrible: \"%s\" Tipo "
-"de dispositivo: \"%s\" ¿Con copia de respaldo? \"%s\" Utilizado por "
-"última vez: \"%s"
+"Nombre: \"%s\" Uso: \"%s\" Transportes: \"%s\" Descubrible: \"%s\" Tipo de "
+"dispositivo: \"%s\" ¿Con copia de respaldo? \"%s\" Utilizado por última vez: \"%s"
 
 #: flask_security/templates/security/wan_register.html:66
 msgid "Delete an Existing Passkey"
@@ -1043,8 +1039,8 @@ msgstr "Vuelve a autenticarte con una llave de acceso"
 #, python-format
 msgid "Use <a href=\"%(link)s\">this link</a> to confirm your new email address."
 msgstr ""
-"Usa <a href=\"%(link)s\">este enlace</a> para confirmar tu dirección de "
-"correo electrónico."
+"Usa <a href=\"%(link)s\">este enlace</a> para confirmar tu dirección de correo "
+"electrónico."
 
 #: flask_security/templates/security/email/change_email_instructions.html:9
 #: flask_security/templates/security/email/change_email_instructions.txt:9
@@ -1090,8 +1086,8 @@ msgstr "Tu nombre de usuario ha sido cambiado."
 #: flask_security/templates/security/email/welcome.html:10
 #, python-format
 msgid ""
-"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email"
-" address."
+"Use <a href=\"%(confirmation_link)s\">this link</a> to confirm your email "
+"address."
 msgstr ""
 "Usa <a href=\"%(confirmation_link)s\">este enlace</a> para confirmar tu "
 "dirección de correo electrónico."
@@ -1101,8 +1097,7 @@ msgstr ""
 #, python-format
 msgid "Use %(confirmation_link)s to confirm your email address."
 msgstr ""
-"Usa %(confirmation_link)s para confirmar tu dirección de correo "
-"electrónico."
+"Usa %(confirmation_link)s para confirmar tu dirección de correo electrónico."
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -1142,8 +1137,7 @@ msgstr "¡Bienvenido/a %(username)s!"
 #, python-format
 msgid "You can log into your account using the following code: %(token)s"
 msgstr ""
-"Puedes iniciar sesión en tu cuenta utilizando el siguiente código: "
-"%(token)s"
+"Puedes iniciar sesión en tu cuenta utilizando el siguiente código: %(token)s"
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
@@ -1154,8 +1148,7 @@ msgstr "no puede acceder a la cuenta de correo"
 #, python-format
 msgid "You can sign in to your account using the following code: %(token)s"
 msgstr ""
-"Puedes iniciar sesión en tu cuenta utilizando el siguiente código: "
-"%(token)s"
+"Puedes iniciar sesión en tu cuenta utilizando el siguiente código: %(token)s"
 
 #: flask_security/templates/security/email/us_instructions.html:12
 #, python-format
@@ -1166,8 +1159,7 @@ msgstr "O puedes utilizar este enlace: <a href=\"%(login_link)s\">Autenticarse</
 #, python-format
 msgid "You can sign in to your account using the following code: %(token)s."
 msgstr ""
-"Puedes iniciar sesión en tu cuenta utilizando el siguiente código: "
-"%(token)s."
+"Puedes iniciar sesión en tu cuenta utilizando el siguiente código: %(token)s."
 
 #: flask_security/templates/security/email/us_instructions.txt:12
 #, python-format
@@ -1206,29 +1198,25 @@ msgstr "¡Hola %(email)s!"
 #: flask_security/templates/security/email/welcome_existing.html:17
 #: flask_security/templates/security/email/welcome_existing.txt:18
 msgid ""
-"Someone (you?) tried to register this email - which is already in our "
-"system."
+"Someone (you?) tried to register this email - which is already in our system."
 msgstr ""
-"Alguien (¿tú?) ha intentado registrar este correo electrónico, que ya "
-"está en nuestro sistema."
+"Alguien (¿tú?) ha intentado registrar este correo electrónico, que ya está en "
+"nuestro sistema."
 
 #: flask_security/templates/security/email/welcome_existing.html:20
 #, python-format
 msgid ""
-"This account also has the following username associated with it: "
-"%(username)s."
+"This account also has the following username associated with it: %(username)s."
 msgstr ""
-"Esta cuenta también tiene asociado el siguiente nombre de usuario: "
-"%(username)s."
+"Esta cuenta también tiene asociado el siguiente nombre de usuario: %(username)s."
 
 #: flask_security/templates/security/email/welcome_existing.html:24
 #, python-format
 msgid ""
-"You can use <a href=\"%(reset_link)s\">this link</a> to reset your "
-"password."
+"You can use <a href=\"%(reset_link)s\">this link</a> to reset your password."
 msgstr ""
-"Puedes usar <a href=\"%(reset_link)s\">este enlace</a> para restablecer "
-"tu contraseña."
+"Puedes usar <a href=\"%(reset_link)s\">este enlace</a> para restablecer tu "
+"contraseña."
 
 #: flask_security/templates/security/email/welcome_existing.html:27
 #, python-format
@@ -1242,11 +1230,9 @@ msgstr ""
 #: flask_security/templates/security/email/welcome_existing.txt:21
 #, python-format
 msgid ""
-"This account also has the following username associated with it: "
-"%(username)s"
+"This account also has the following username associated with it: %(username)s"
 msgstr ""
-"Esta cuenta también tiene asociado el siguiente nombre de usuario: "
-"%(username)s"
+"Esta cuenta también tiene asociado el siguiente nombre de usuario: %(username)s"
 
 #: flask_security/templates/security/email/welcome_existing.txt:25
 #, python-format
@@ -1259,22 +1245,21 @@ msgid ""
 "You have not confirmed your email address yet - use this link: "
 "%(confirmation_link)s to do so now."
 msgstr ""
-"Aún no has confirmado tu dirección de correo electrónico - utiliza este "
-"enlace: %(confirmation_link)s para hacerlo ahora."
+"Aún no has confirmado tu dirección de correo electrónico - utiliza este enlace: "
+"%(confirmation_link)s para hacerlo ahora."
 
 #: flask_security/templates/security/email/welcome_existing_username.html:13
 #: flask_security/templates/security/email/welcome_existing_username.txt:13
 #, python-format
 msgid ""
-"You attempted to register with a username \"%(username)s\" that is "
-"already associated with another account."
+"You attempted to register with a username \"%(username)s\" that is already "
+"associated with another account."
 msgstr ""
-"Has intentado registrarte con un nombre de usuario \"%(username)s\" que "
-"ya está asociado a otra cuenta."
+"Has intentado registrarte con un nombre de usuario \"%(username)s\" que ya está "
+"asociado a otra cuenta."
 
 #: flask_security/templates/security/email/welcome_existing_username.html:15
 #: flask_security/templates/security/email/welcome_existing_username.txt:16
 msgid "Please restart the registration process with a different username."
 msgstr ""
-"Por favor reinicia el proceso de registro con un nombre de usuario "
-"diferente."
+"Por favor reinicia el proceso de registro con un nombre de usuario diferente."

--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.8.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2026-04-14 15:32-0700\n"
+"POT-Creation-Date: 2026-05-04 13:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,450 +18,455 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Confirm your new email address"
 msgstr ""
 
-#: flask_security/core.py:302
+#: flask_security/core.py:310
 msgid "Login Required"
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:311
 msgid "Welcome"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:312
 msgid "Please confirm your email"
 msgstr ""
 
-#: flask_security/core.py:305
+#: flask_security/core.py:313
 msgid "Login instructions"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:314
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr ""
 
-#: flask_security/core.py:307
+#: flask_security/core.py:315
 msgid "Your password has been changed"
 msgstr ""
 
-#: flask_security/core.py:308
+#: flask_security/core.py:316
 msgid "Password reset instructions"
 msgstr ""
 
-#: flask_security/core.py:309
+#: flask_security/core.py:317
 #: flask_security/templates/security/email/change_username_notice.txt:1
 msgid "Your username has been changed"
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:318
 msgid "Your requested username"
 msgstr ""
 
-#: flask_security/core.py:313
+#: flask_security/core.py:321
 msgid "Two-Factor Login"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:322
 msgid "Two-Factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:356
+#: flask_security/core.py:364
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:410
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:404
+#: flask_security/core.py:412
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:409
+#: flask_security/core.py:417
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:423
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:418
+#: flask_security/core.py:426
 msgid "You do not have permission to view this resource."
 msgstr ""
 
-#: flask_security/core.py:420
+#: flask_security/core.py:428
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:424
+#: flask_security/core.py:432
 msgid "You must reauthenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:437
 #, python-format
 msgid ""
 "Thank you. To confirm your email address %(email)s, please click on the "
 "link in the email we have just sent to you."
 msgstr ""
 
-#: flask_security/core.py:435
+#: flask_security/core.py:443
 msgid "Thank you. Your email has been confirmed."
 msgstr ""
 
-#: flask_security/core.py:436
+#: flask_security/core.py:444
 msgid "Your email has already been confirmed."
 msgstr ""
 
-#: flask_security/core.py:437
+#: flask_security/core.py:445
 msgid "Invalid confirmation token."
 msgstr ""
 
-#: flask_security/core.py:439
+#: flask_security/core.py:447
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:444
+#: flask_security/core.py:452
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:450
+#: flask_security/core.py:458
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:455
+#: flask_security/core.py:463
 #, python-format
 msgid ""
 "An error occurred while communicating with the OAuth provider: "
 "(%(exerror)s - %(exdesc)s). Please try again."
 msgstr ""
 
-#: flask_security/core.py:461
+#: flask_security/core.py:469
 msgid "Password does not match"
 msgstr ""
 
-#: flask_security/core.py:462
+#: flask_security/core.py:470
 msgid "Passwords do not match"
 msgstr ""
 
-#: flask_security/core.py:463
+#: flask_security/core.py:471
 msgid "Redirections outside the domain are forbidden"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:472
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:465
+#: flask_security/core.py:473
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:467
+#: flask_security/core.py:475
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:471
+#: flask_security/core.py:479
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:474
+#: flask_security/core.py:482
 msgid "Invalid reset password token."
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:483
 msgid "Email requires confirmation."
 msgstr ""
 
-#: flask_security/core.py:477
+#: flask_security/core.py:485
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:481
+#: flask_security/core.py:489
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:486
+#: flask_security/core.py:494
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:492
+#: flask_security/core.py:500
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:495
+#: flask_security/core.py:503
 msgid "Invalid login token."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:504
 msgid "Account is disabled."
 msgstr ""
 
-#: flask_security/core.py:497
+#: flask_security/core.py:505
 msgid "Email not provided"
 msgstr ""
 
-#: flask_security/core.py:498
+#: flask_security/core.py:506
 msgid "Invalid email address"
 msgstr ""
 
-#: flask_security/core.py:499 flask_security/core.py:545
+#: flask_security/core.py:507 flask_security/core.py:554
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:500
+#: flask_security/core.py:508
 msgid "Password not provided"
 msgstr ""
 
-#: flask_security/core.py:502
+#: flask_security/core.py:510
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr ""
 
-#: flask_security/core.py:505
+#: flask_security/core.py:513
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:506
+#: flask_security/core.py:514
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:516
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:511
+#: flask_security/core.py:519
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:520
 msgid "Specified user does not exist"
 msgstr ""
 
-#: flask_security/core.py:513
+#: flask_security/core.py:521
 msgid "Invalid password"
 msgstr ""
 
-#: flask_security/core.py:514
+#: flask_security/core.py:522
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:515
+#: flask_security/core.py:523
 msgid "You have successfully logged in."
 msgstr ""
 
-#: flask_security/core.py:516 flask_security/templates/security/_menu.html:19
+#: flask_security/core.py:524 flask_security/templates/security/_menu.html:19
 #: flask_security/templates/security/_menu.html:65
 msgid "Forgot password?"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:527
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:534
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:532
+#: flask_security/core.py:540
 msgid "Your new password must be different than your previous password."
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:543
 msgid "You successfully changed your password."
 msgstr ""
 
-#: flask_security/core.py:536
+#: flask_security/core.py:544
 msgid "Please log in to access this page."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:545
 msgid "Please reauthenticate to access this page."
 msgstr ""
 
-#: flask_security/core.py:538
+#: flask_security/core.py:546
+#, python-format
+msgid "Refresh token is invalid (%(reason)s)"
+msgstr ""
+
+#: flask_security/core.py:547
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:549
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:543
+#: flask_security/core.py:552
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:553
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:546
+#: flask_security/core.py:555
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:557
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:552
+#: flask_security/core.py:561
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:555
+#: flask_security/core.py:564
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:566
 msgid "You successfully disabled two-factor authorization."
 msgstr ""
 
-#: flask_security/core.py:561 flask_security/core.py:570
+#: flask_security/core.py:570 flask_security/core.py:579
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:574
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:568
+#: flask_security/core.py:577
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:582
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:574
+#: flask_security/core.py:583
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:575
+#: flask_security/core.py:584
 #, python-format
 msgid "Use this code to sign in: %(code)s"
 msgstr ""
 
-#: flask_security/core.py:576
+#: flask_security/core.py:585
 msgid "You successfully changed your username"
 msgstr ""
 
-#: flask_security/core.py:579
+#: flask_security/core.py:588
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:594
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:598
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:592
+#: flask_security/core.py:601
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:594
+#: flask_security/core.py:603
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:598
+#: flask_security/core.py:607
 #, python-format
 msgid "Passkey operations must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:602
+#: flask_security/core.py:611
 msgid "Nickname for new passkey is required."
 msgstr ""
 
-#: flask_security/core.py:606
+#: flask_security/core.py:615
 #, python-format
 msgid "%(name)s is already associated with a passkey."
 msgstr ""
 
-#: flask_security/core.py:610
+#: flask_security/core.py:619
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:614
+#: flask_security/core.py:623
 #, python-format
 msgid "Successfully deleted the passkey with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:618
+#: flask_security/core.py:627
 #, python-format
 msgid "Successfully added the passkey with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:622
+#: flask_security/core.py:631
 msgid "Passkey already registered."
 msgstr ""
 
-#: flask_security/core.py:626
+#: flask_security/core.py:635
 msgid "Unregistered passkey."
 msgstr ""
 
-#: flask_security/core.py:630
+#: flask_security/core.py:639
 msgid "Passkey doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:634
+#: flask_security/core.py:643
 #, python-format
 msgid "Could not verify passkey: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:638
+#: flask_security/core.py:647
 msgid "Passkey not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:642
+#: flask_security/core.py:651
 msgid "Credential user handle didn't match"
 msgstr ""
 
-#: flask_security/core.py:646
+#: flask_security/core.py:655
 #, python-format
 msgid "Confirmation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:650
+#: flask_security/core.py:659
 msgid "Change of email address confirmed"
 msgstr ""
 
-#: flask_security/core.py:655
+#: flask_security/core.py:664
 #, python-format
 msgid ""
 "Instructions to confirm your new email address have been sent to "
 "%(email)s."
 msgstr ""
 
-#: flask_security/core.py:661
+#: flask_security/core.py:670
 msgid "If registered, your username will be sent to your email."
 msgstr ""
 
@@ -619,7 +624,7 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:966 flask_security/unified_signin.py:171
+#: flask_security/forms.py:966 flask_security/unified_signin.py:172
 msgid "Available Methods"
 msgstr ""
 
@@ -655,6 +660,10 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: flask_security/tokens.py:168
+msgid "Refresh Token"
+msgstr ""
+
 #: flask_security/twofactor.py:139
 msgid "Send code via email"
 msgstr ""
@@ -663,43 +672,43 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:165
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:173
+#: flask_security/unified_signin.py:174
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:174
+#: flask_security/unified_signin.py:175
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:307
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:319
+#: flask_security/unified_signin.py:320
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:124 flask_security/webauthn.py:371
+#: flask_security/webauthn.py:125 flask_security/webauthn.py:372
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:128
+#: flask_security/webauthn.py:129
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:131
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:133
+#: flask_security/webauthn.py:134
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:225
+#: flask_security/webauthn.py:226
 msgid "Start"
 msgstr ""
 


### PR DESCRIPTION
Hi,

This is a minor update for Catalan and Spanish translations, to include the new messages from #1207.

```patch
diff --git a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
index e40ab59..7cc7186 100644
--- a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po

 #, python-format
 msgid "%(email)s is already associated with an account."
@@ -413,6 +413,13 @@ msgstr "Codi de recuperació invàlid"
 msgid "Redirections outside the domain are forbidden"
 msgstr "Les redireccions a llocs web externes s'han prohibit"
 
+msgid "Refresh Token"
+msgstr "Token de refresc"
+
+#, python-format
+msgid "Refresh token is invalid (%(reason)s)"
+msgstr "El token de refresc és invàlid (%(reason)s)"
+
 msgid "Register"
 msgstr "Registrar-se"
 
diff --git a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
index 0e916b0..149531f 100644
--- a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po

 
 #, python-format
 msgid "%(email)s is already associated with an account."
@@ -415,6 +415,14 @@ msgstr "Código de recuperación inválido"
 msgid "Redirections outside the domain are forbidden"
 msgstr "Las redirecciones a sitios web externos están prohibidas"
 
+msgid "Refresh Token"
+msgstr "Token de actualización"
+
+#, python-format
+msgid "Refresh token is invalid (%(reason)s)"
+msgstr "El token de actualización no es válido (%(reason)s)"
+
 msgid "Register"
 msgstr "Registrarse"
 
diff --git a/flask_security/translations/flask_security.pot b/flask_security/translations/flask_security.pot
index c070ba9..e87e0eb 100644
--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -411,6 +411,13 @@ msgstr ""
 msgid "Redirections outside the domain are forbidden"
 msgstr ""
 
+msgid "Refresh Token"
+msgstr ""
+
+#, python-format
+msgid "Refresh token is invalid (%(reason)s)"
+msgstr ""
+
 msgid "Register"
 msgstr ""
 ```