### PR TITLE
Make tests work with latest wtforms.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,12 +23,12 @@ markers =
 
 filterwarnings =
     error
+    ignore:.*Passing SelectField choices as tuples.*:DeprecationWarning:wtforms:0
     ignore::DeprecationWarning:mongoengine:
     ignore::DeprecationWarning:flask_login:0
     # next for py 3.12
     ignore::DeprecationWarning:dateutil:0
     ignore:.*passwordless feature.*:DeprecationWarning:flask_security:0
-    ignore:.*'crypt' is deprecated.*:DeprecationWarning:passlib:0
     ignore::DeprecationWarning:pony:0
     ignore:.*'sms' was enabled in SECURITY_US_ENABLED_METHODS;.*:UserWarning:flask_security:0
     ignore:.*'get_token_status' is deprecated.*:DeprecationWarning:flask_security:0


### PR DESCRIPTION
They are deprecating how select choices are set - we can't upgrade until 3.3 actually comes out - so for now just add an ignore deprecation line in pytest.ini.