### PR TITLE
Chore - cbor2 now works again; remove pypy tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,6 @@ jobs:
           - {python: '3.13', tox: 'py313-release' }
           - {python: '3.13', tox: 'py313-low' }
           - {python: '3.14', tox: 'py314-release' }
-          - {python: 'pypy-3.11', tox: 'pypy311-release'}
 
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: pyupgrade
         args: [--py310-plus]
 -   repo: https://github.com/psf/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,8 +7,7 @@ argon2-cffi
 authlib
 bcrypt
 bleach
-# new Rust-based cbor2 doesn't handle memoryview which some (peewee) DBs return
-cbor2 < 6.0.0
+cbor2
 coverage
 cryptography
 djlint


### PR DESCRIPTION
pypy3.11 broke their JSON parsing - tired of having these tests fail - so delete from CI for now.