### PR TITLE
Reject WebAuthn verify assertion bound to a different user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,11 +17,12 @@ Features & Improvements
 Fixes
 +++++
 - (:issue:`1212`) Newly introduced :py:meth:`.UserMixin.is_locked` logic is inverted.
+- (:pr:`1234`) Fix for GHSA-f66q-9rf6-8795 - WebAuthn reauthentication freshness bypass. (tonghuaroot)
+
 
 Docs and Chores
 +++++++++++++++
 - (:issue:`1208`) Remove support for Pony ORM
-
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -869,10 +869,23 @@ def webauthn_verify_response(token: str) -> ResponseValue:
     form.is_verify = True
 
     if form.validate_on_submit():
-        # update last use and sign count
-        after_this_request(view_commit)
         assert form.cred
         assert form.user
+        # The assertion was cryptographically valid for `form.user`. For the
+        # reauthentication / verify flow, that user must also be the user
+        # currently logged in to this session - otherwise an attacker who
+        # owns any registered credential could satisfy a victim session's
+        # freshness gate by submitting their own credential's assertion.
+        if form.user.email != current_user.email:
+            m, c = get_message("WEBAUTHN_MISMATCH_USER_HANDLE")
+            if _security._want_json(request):
+                form.form_errors.append(m)
+                return base_render_json(form, include_user=False)
+            do_flash(m, c)
+            return redirect(url_for_security("wan_verify"))
+
+        # update last use and sign count
+        after_this_request(view_commit)
         form.cred.lastuse_datetime = _security.datetime_factory()
         form.cred.sign_count = form.authentication_verification.new_sign_count
         _datastore.put(form.cred)

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1428,6 +1428,49 @@ def test_verify_validate_error(app, client, get_message, signals):
     )
 
 
+def test_verify_rejects_cross_user_assertion(app, client, get_message):
+    # The reauthentication-freshness gate must not be satisfied by a
+    # WebAuthn assertion whose proven credential belongs to a different
+    # user than the currently authenticated session user. Sibling of the
+    # OAuth fix in `oauth_glue.oauth_verify_response`.
+    authenticate(client, email="joe@lp.com")
+    register_options, response_url = _register_start_json(
+        client, name="joekey", usage="first"
+    )
+    response = client.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
+    assert response.status_code == 200
+    logout(client)
+
+    authenticate(client, email="matt@lp.com")
+    register_options, response_url = _register_start_json(
+        client, name="mattkey", usage="first"
+    )
+    response = client.post(response_url, json=dict(credential=json.dumps(REG_DATA_UV)))
+    assert response.status_code == 200
+
+    old_paa = reset_fresh(client, app.config["SECURITY_FRESHNESS"])
+
+    response = client.post("wan-verify", json=dict())
+    response_url = f'wan-verify/{response.json["response"]["wan_state"]}'
+    # Submit joe's assertion while logged in as matt.
+    response = client.post(response_url, json=dict(credential=json.dumps(SIGNIN_DATA1)))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_MISMATCH_USER_HANDLE"
+    )
+    with client.session_transaction() as sess:
+        assert sess["fs_paa"] == old_paa
+
+    # same with forms
+    response = client.post(
+        response_url,
+        data=dict(credential=json.dumps(SIGNIN_DATA1)),
+        follow_redirects=True,
+    )
+    assert b"<title>Reauthenticate</title>" in response.data
+    assert b"Credential user handle" in response.data
+
+
 @pytest.mark.settings(wan_allow_as_verify=None)
 def test_no_verify(app, client):
     authenticate(client)


### PR DESCRIPTION
Fix GHSA-f66q-9rf6-8795 - webauthn /verify could be satisfied by any user on the system that had an registered webauthn credential.