### PR TITLE
Change default LOGOUT method to POST.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Features & Improvements
 - (:issue:`1206`) Add support for refresh tokens. See :ref:`token_topic`
 - (:pr:`1233`) Change :py:data:`SECURITY_TOKEN_MAX_AGE` from an int to a timedelta.
   Also - change default from ``never expire`` to 15 minutes.
+- (:pr:`xx`) Change default LOGOUT_METHODS to be just ``"POST"``
 
 Fixes
 +++++
@@ -32,6 +33,8 @@ Backwards Compatibility Concerns
   'insecure-out-of-the-box' issue. Applications will have to either change the
   value if they really want a long-lasting token or use the new refresh token
   feature.
+- The default for :py:data:`SECURITY_LOGOUT_METHODS` has been changed to just
+  allowing ``"POST"``. This is considered modern best practice.
 
 Notes
 +++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -836,9 +836,10 @@ Login/Logout
 .. py:data:: SECURITY_LOGOUT_METHODS
 
     Specifies the HTTP request methods that the logout URL accepts. Specify ``None`` to disable the logout URL (and implement your own).
-    Configuring with just ``["POST"]`` is slightly more secure. The default includes ``"GET"`` for backwards compatibility.
+    Configuring with just ``["POST"]`` is slightly more secure in that it avoids a class of attacks that can force a user to be logged out
+    just by clicking on a link.
 
-    Default: ``["GET", "POST"]``.
+    Default: ``["POST"]``.
 
 
 .. py:data:: SECURITY_POST_LOGIN_VIEW

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -195,7 +195,7 @@ _default_config: dict[str, t.Any] = {
     "TWO_FACTOR_SELECT_URL": "/tf-select",
     "TWO_FACTOR_POST_SETUP_VIEW": ".two_factor_setup",  # endpoint or URL
     "TWO_FACTOR_ERROR_VIEW": ".login",
-    "LOGOUT_METHODS": ["GET", "POST"],
+    "LOGOUT_METHODS": ["POST"],
     "POST_LOGIN_VIEW": "/",
     "POST_LOGOUT_VIEW": "/",
     "LOGIN_ERROR_VIEW": None,  # spa

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,7 +4,7 @@ test_basic
 
 Test common functionality
 
-:copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
+:copyright: (c) 2019-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 """
 
@@ -531,13 +531,13 @@ def test_logout_post(client):
 
 def test_logout_with_next_invalid(client, get_message):
     authenticate(client)
-    response = client.get("/logout?next=http://google.com")
+    response = client.post("/logout?next=http://google.com")
     assert "google.com" not in response.location
 
 
 def test_logout_with_next(client):
     authenticate(client)
-    response = client.get("/logout?next=/page1", follow_redirects=True)
+    response = client.post("/logout?next=/page1", follow_redirects=True)
     assert b"Page 1" in response.data
 
 
@@ -671,7 +671,7 @@ def test_multiple_role_required(clients):
         authenticate(clients, user)
         response = clients.get("/admin_and_editor", follow_redirects=True)
         assert b"Unauthorized" in response.data
-        clients.get("/logout")
+        clients.post("/logout")
 
     authenticate(clients, "dave@lp.com")
     response = clients.get("/admin_and_editor", follow_redirects=True)

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -106,7 +106,7 @@ def test_context_processors(client, app, outbox):
     def mail():
         return {"foo": "bar-mail"}
 
-    client.get("/logout")
+    client.post("/logout")
 
     client.post("/reset", data=dict(email="matt@lp.com"))
 
@@ -127,7 +127,7 @@ def test_context_processors(client, app, outbox):
     def recover_username():
         return {"foo": "bar-recover-username"}
 
-    client.get("/logout")
+    client.post("/logout")
     response = client.get("/recover-username")
     assert b"global" in response.data
     assert b"bar-recover-username" in response.data

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1326,7 +1326,7 @@ def test_post_security_with_application_root(app, sqlalchemy_datastore):
     assert response.status_code in [302, 303]
     assert "/root" in response.location
 
-    response = client.get("/logout")
+    response = client.post("/logout")
     assert response.status_code in [302, 303]
     assert "/root" in response.location
 
@@ -1349,7 +1349,7 @@ def test_post_security_with_application_root_and_views(app, sqlalchemy_datastore
     assert response.status_code in [302, 303]
     assert "/post_login" in response.location
 
-    response = client.get("/logout")
+    response = client.post("/logout")
     assert response.status_code in [302, 303]
     assert "/post_logout" in response.location
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,7 +102,7 @@ def verify_token(client_nc, token, status=None):
 
 
 def logout(client, endpoint=None, **kwargs):
-    return client.get(endpoint or "/logout", **kwargs)
+    return client.post(endpoint or "/logout", **kwargs)
 
 
 def json_logout(client, token, endpoint=None):


### PR DESCRIPTION
This is considered modern best practice to avoid a user being logged out by simply clicking on a (possibly malware) link.