### PR TITLE
Change config defaults for cookies.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,9 @@ Features & Improvements
 - (:issue:`1206`) Add support for refresh tokens. See :ref:`token_topic`
 - (:pr:`1233`) Change :py:data:`SECURITY_TOKEN_MAX_AGE` from an int to a timedelta.
   Also - change default from ``never expire`` to 15 minutes.
-- (:pr:`xx`) Change default LOGOUT_METHODS to be just ``"POST"``
+- (:pr:`1235`) Change default LOGOUT_METHODS to be just ``"POST"``
+- (:issue:`1228`) Change default ``csrf`` and ``tf_validity`` cookie config to ``secure=True``
+- (:issue:`1228`) The ``tf_validity`` cookie name is now configurable via :py:data:`SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME`
 
 Fixes
 +++++
@@ -35,6 +37,10 @@ Backwards Compatibility Concerns
   feature.
 - The default for :py:data:`SECURITY_LOGOUT_METHODS` has been changed to just
   allowing ``"POST"``. This is considered modern best practice.
+- The default configuration for :py:data:`SECURITY_TWO_FACTOR_VALIDITY_COOKIE`
+  has been change to ``secure=True``.
+- The default configuration for :py:data:`SECURITY_CSRF_COOKIE` has been
+  changed to ``secure=True``
 
 Notes
 +++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -282,11 +282,14 @@ These configuration keys are used globally across all features.
     set a CSRF cookie.
     The complete set of parameters is described in Flask's `set_cookie`_ documentation.
 
-    Default: ``{"samesite": "Strict", "httponly": False, "secure": False}``
+    Default: ``{"samesite": "Strict", "httponly": False, "secure": True}``
 
     .. versionchanged:: 4.1.0
         The 'key' attribute was deprecated in favor of a separate configuration
         variable :data:`SECURITY_CSRF_COOKIE_NAME`.
+
+    .. versionchanged:: 5.9.0
+        ``secure`` default changed to ``True``
 
 .. py:data:: SECURITY_CSRF_HEADER
 
@@ -1424,7 +1427,7 @@ Configuration related to the two-factor authentication feature.
 .. py:data:: SECURITY_TWO_FACTOR_ALWAYS_VALIDATE
 
     Specifies whether the application should require a two-factor code upon every login.
-    If set to ``False`` then the 2 values below are used to determine when
+    If set to ``False`` then the values below are used to determine when
     a code is required. Note that this is cookie based - so a new browser
     session will always require a fresh two-factor code.
 
@@ -1436,12 +1439,24 @@ Configuration related to the two-factor authentication feature.
     Default: ``"30 Days"``.
 
 
+.. py:data:: SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME
+
+    Name for the two factor validity cookie.
+
+    Default: ``tf_validity``
+
+    .. versionadded:: 5.9.0
+
 .. py:data:: SECURITY_TWO_FACTOR_VALIDITY_COOKIE
 
     A dictionary containing the parameters of the two-factor validity cookie.
     The complete set of parameters is described in Flask's `set_cookie`_ documentation.
 
-    Default: ``{'httponly': True, 'secure': False, 'samesite': None}``.
+    Default: ``{'httponly': True, 'secure': True, 'samesite': "Strict"}``.
+
+
+    .. versionchanged:: 5.9.0
+        ``secure`` default changed to ``True``. ``samesite`` default changed to ``Strict``
 
 .. py:data:: SECURITY_TWO_FACTOR_IMPLEMENTATIONS
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -260,9 +260,10 @@ _default_config: dict[str, t.Any] = {
     "TWO_FACTOR_ALWAYS_VALIDATE": True,
     "TWO_FACTOR_LOGIN_VALIDITY": "30 days",
     "TWO_FACTOR_VALIDITY_SALT": "tf-validity-salt",
+    "TWO_FACTOR_VALIDITY_COOKIE_NAME": "tf_validity",
     "TWO_FACTOR_VALIDITY_COOKIE": {
         "httponly": True,
-        "secure": False,
+        "secure": True,
         "samesite": "Strict",
     },
     "TWO_FACTOR_SETUP_SALT": "tf-setup-salt",
@@ -378,7 +379,7 @@ _default_config: dict[str, t.Any] = {
     "CSRF_COOKIE": {
         "samesite": "Strict",
         "httponly": False,
-        "secure": False,
+        "secure": True,
     },
     "CSRF_HEADER": "X-XSRF-Token",
     "CSRF_COOKIE_REFRESH_EACH_REQUEST": False,

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -290,7 +290,7 @@ def tf_verify_validity_token(fs_uniquifier: str) -> bool:
 
     :param fs_uniquifier: The ``fs_uniquifier`` of the submitting user.
     """
-    token = request.cookies.get("tf_validity", default=None)
+    token = request.cookies.get(cv("TWO_FACTOR_VALIDITY_COOKIE_NAME"), default=None)
     if token is None:
         return False
 
@@ -302,15 +302,15 @@ def tf_verify_validity_token(fs_uniquifier: str) -> bool:
 
 
 def tf_set_validity_token_cookie(response: Response, token: str) -> Response:
-    """Sets the Two-Factor validity token for a specific user given that is
-    configured and the user selects remember me
-
-    :param response: The response with which to set the set_cookie
-    :param token: validity token
-    """
+    """Sets the Two-Factor validity cookie"""
     cookie_kwargs = cv("TWO_FACTOR_VALIDITY_COOKIE")
     max_age = int(get_within_delta("TWO_FACTOR_LOGIN_VALIDITY").total_seconds())
-    response.set_cookie("tf_validity", value=token, max_age=max_age, **cookie_kwargs)
+    response.set_cookie(
+        cv("TWO_FACTOR_VALIDITY_COOKIE_NAME"),
+        value=token,
+        max_age=max_age,
+        **cookie_kwargs,
+    )
     # This is likely overkill since so far we only return this on a POST which is
     # unlikely to be cached.
     response.vary.add("Cookie")

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -91,29 +91,35 @@ def tf_in_session(session):
     )
 
 
-@pytest.mark.settings(two_factor_always_validate=False)
-def test_always_validate(app, client, get_message):
+@pytest.mark.settings(
+    two_factor_always_validate=False, two_factor_validity_cookie_name="tfv"
+)
+def test_validity_cookie(app, client, get_message):
     tf_authenticate(app, client, remember=True)
-    assert client.get_cookie("tf_validity")
+    assert client.get_cookie("tfv")
 
+    # logout shouldn't delete cookie so we can log in again with just password
     logout(client)
 
     data = dict(email="gal@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
     assert b"Welcome gal@lp.com" in response.data
     assert response.status_code == 200
-
     logout(client)
+
+    # ensure the cookie is for a specific user
     data = dict(email="gal2@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
     assert b"Please enter your authentication code" in response.data
 
-    # make sure the cookie doesn't affect the JSON request
-    client.delete_cookie("tf_validity")
-    # Test JSON (this authenticates gal@lp.com)
+    client.delete_cookie("tfv")
+
+    # Same tests as above with JSON (this authenticates gal@lp.com)
     tf_authenticate(app, client, json=True, remember=True)
+    assert client.get_cookie("tfv")
     logout(client)
 
+    # shouldn't require tf
     data = dict(email="gal@lp.com", password="password")
     response = client.post(
         "/login",
@@ -121,7 +127,6 @@ def test_always_validate(app, client, get_message):
         follow_redirects=True,
     )
     assert response.status_code == 200
-    # verify logged in
     is_authenticated(client, get_message)
     logout(client)
 
@@ -139,7 +144,10 @@ def test_always_validate(app, client, get_message):
 
 @pytest.mark.settings(two_factor_always_validate=False)
 def test_do_not_remember_tf_validity(app, client):
+    # If 'remember' not set during login - no cookie should be sent
+    # and tf should be required every time.
     tf_authenticate(app, client)
+    assert not client.get_cookie("tf_validity")
     logout(client)
 
     data = dict(email="gal@lp.com", password="password")

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1857,10 +1857,10 @@ def test_totp_generation(app, client, get_message):
 )
 def test_us_tf_validity(app, client, get_message):
     us_tf_authenticate(app, client, remember=True)
-    assert client.get_cookie("tf_validity")
+    assert client.get_cookie(app.config["SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME"])
     logout(client)
     # logout does NOT remove this cookie
-    assert client.get_cookie("tf_validity")
+    assert client.get_cookie(app.config["SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME"])
 
     # This time shouldn't require code
     data = dict(identity="gal@lp.com", passcode="password")


### PR DESCRIPTION
Best practice these days is to set ``secure=True``. This changes CSRF_COOKIE and TF_VALIDITY_COOKIE.

Also - TF_VALIDITY_COOKIE name is now configurable.

close #1228