### PR TITLE
Convert _WITHIN config to timedelta

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,10 +13,11 @@ Features & Improvements
 - (:issue:`1206`) Add support for refresh tokens. See :ref:`token_topic`
 - (:pr:`1233`) Change :py:data:`SECURITY_TOKEN_MAX_AGE` from an int to a timedelta.
   Also - change default from ``never expire`` to 15 minutes.
-- (:pr:`1235`) Change default LOGOUT_METHODS to be just ``"POST"``
+- (:pr:`1235`) Change default :py:data:`SECURITY_LOGOUT_METHODS` to be just ``"POST"``
 - (:issue:`1228`) Change default ``csrf`` and ``tf_validity`` cookie config to ``secure=True``
 - (:issue:`1228`) The ``tf_validity`` cookie name is now configurable via :py:data:`SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME`
 - (:issue:`1237`) Add support for CSRF on logout
+- (:pr:`xx`) Convert all _WITHIN configuration variable to use timedelta.
 
 Fixes
 +++++
@@ -27,7 +28,7 @@ Fixes
 Docs and Chores
 +++++++++++++++
 - (:issue:`1208`) Remove support for Pony ORM
-- (:pr:`xxx`) Remove deprecated get_token_status() and converted over to check_and_get_token_status()
+- (:pr:`1240`) Remove deprecated get_token_status() and converted over to check_and_get_token_status()
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -43,6 +44,9 @@ Backwards Compatibility Concerns
   has been change to ``secure=True``.
 - The default configuration for :py:data:`SECURITY_CSRF_COOKIE` has been
   changed to ``secure=True``
+- All _WITHIN configuration variables now take a timedelta instead of the
+  home-grown <#> <period>. The old form is still accepted, with a deprecation
+  warning, and converted at flask-security app init time into a timedelta.
 
 Notes
 +++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -844,6 +844,9 @@ Login/Logout
 
     Default: ``["POST"]``.
 
+    .. versionchanged:: 5.9.0
+        Default changed to just allowing ``"POST"``.
+
 
 .. py:data:: SECURITY_POST_LOGIN_VIEW
 
@@ -1055,10 +1058,12 @@ Confirmable
     Default: ``False``.
 .. py:data:: SECURITY_CONFIRM_EMAIL_WITHIN
 
-    Specifies the amount of time a user has before their confirmation
-    link expires. Always pluralize the time unit for this value.
+    Specifies how long until the confirmation link expires.
 
-    Default: ``"5 days"``.
+    Default: ``timedelta(days=2)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 .. py:data:: SECURITY_CONFIRM_URL
 
     Specifies the email confirmation URL.
@@ -1221,10 +1226,12 @@ Recoverable
 
 .. py:data:: SECURITY_RESET_PASSWORD_WITHIN
 
-    Specifies the amount of time a user has before their password reset link expires.
-    Always pluralize the time unit for this value.
+    Specifies how long until the reset link expires.
 
-    Default: ``"1 days"``.
+    Default: ``timedelta(days=1)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
 .. py:data:: SECURITY_SEND_PASSWORD_RESET_EMAIL
 
@@ -1273,10 +1280,12 @@ Change-Email
     Default: ``"security/change_email.html"``.
 .. py:data:: SECURITY_CHANGE_EMAIL_WITHIN
 
-    Specifies the amount of time a user has before their change email
-    token expires. Always pluralize the time unit for this value.
+    Specifies how long until the change email token expires.
 
-    Default: ``"2 hours"``
+    Default: ``timedelta(hours=2)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 .. py:data:: SECURITY_POST_CHANGE_EMAIL_VIEW
 
     Specifies the view to redirect to after a user successfully confirms their new email address.
@@ -1357,10 +1366,12 @@ Configuration related to the two-factor authentication feature.
     Default: ``120``.
 .. py:data:: SECURITY_TWO_FACTOR_SETUP_WITHIN
 
-    Specifies the amount of time a user has before their two-factor setup
-    token expires. Always pluralize the time unit for this value.
+    Specifies how long until the setup token expires.
 
-    Default: ``"30 minutes"``
+    Default: ``timedelta(minutes=30)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
     .. versionadded:: 5.5.0
 .. py:data:: SECURITY_TWO_FACTOR_RESCUE_MAIL
@@ -1458,7 +1469,10 @@ Configuration related to the two-factor authentication feature.
 
     Specifies the expiration of the two-factor validity cookie and verification of the token.
 
-    Default: ``"30 Days"``.
+    Default: ``timedelta(days=30)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
 
 .. py:data:: SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME
@@ -1612,10 +1626,12 @@ Unified Signin
 
 .. py:data:: SECURITY_US_SETUP_WITHIN
 
-    Specifies the amount of time a user has before their setup
-    token expires. Always pluralize the time unit for this value.
+    Specifies how long until the setup token expires.
 
-    Default: ``"30 minutes"``
+    Default: ``timedelta(minutes=30)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
 .. py:data:: SECURITY_US_SIGNIN_REPLACES_LOGIN
 
@@ -1755,10 +1771,12 @@ This feature is DEPRECATED as of 5.0.0. Please use unified signin feature instea
 
 .. py:data:: SECURITY_LOGIN_WITHIN
 
-    Specifies the amount of time a user has before a login link expires.
-    Always pluralize the time unit for this value.
+    Specifies how long until the login link expires.
 
-    Default: ``"1 days"``.
+    Default: ``timedelta(days=1)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
 .. py:data:: SECURITY_LOGIN_ERROR_VIEW
 
@@ -1849,10 +1867,12 @@ WebAuthn
 
 .. py:data:: SECURITY_WAN_REGISTER_WITHIN
 
-    Specifies the amount of time a user has before their register
-    token expires. Always pluralize the time unit for this value.
+    Specifies how long until the passkey registration token expires.
 
-    Default: ``"30 minutes"``
+    Default: ``timedelta(minutes=30)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
 .. py:data:: SECURITY_WAN_REGISTER_TIMEOUT
 
@@ -1863,10 +1883,12 @@ WebAuthn
 
 .. py:data:: SECURITY_WAN_SIGNIN_WITHIN
 
-    Specifies the amount of time a user has before their signin
-    token expires. Always pluralize the time unit for this value.
+    Specifies how long until the passkey signin token expires.
 
-    Default: ``"1 minutes"``
+    Default: ``timedelta(minutes=1)``.
+
+    .. versionchanged:: 5.9.0
+        Accepted value changed to a timedelta
 
 .. py:data:: SECURITY_WAN_SIGNIN_TIMEOUT
 

--- a/flask_security/change_email.py
+++ b/flask_security/change_email.py
@@ -41,12 +41,12 @@ from .utils import (
     do_flash,
     get_message,
     get_url,
-    get_within_delta,
     hash_data,
     send_mail,
     url_for_security,
     verify_hash,
     view_commit,
+    td_format,
 )
 
 if t.TYPE_CHECKING:  # pragma: no cover
@@ -129,7 +129,7 @@ def change_email_confirm(token):
         if expired:
             m, c = get_message(
                 "CHANGE_EMAIL_EXPIRED",
-                within=cv("CHANGE_EMAIL_WITHIN"),
+                within=td_format(cv("CHANGE_EMAIL_WITHIN")),
             )
         else:
             m, c = get_message("API_ERROR")
@@ -187,6 +187,7 @@ def _send_instructions(user, new_email):
         user=user,
         link=link,
         token=token,
+        within=td_format(cv("CHANGE_EMAIL_WITHIN")),
     )
 
     change_email_instructions_sent.send(
@@ -204,7 +205,7 @@ def _verify_token_status(token):
     new_email is still available (and if not return 'invalid').
     """
     expired, invalid, state = check_and_get_token_status(
-        token, "change_email", get_within_delta("CHANGE_EMAIL_WITHIN")
+        token, "change_email", cv("CHANGE_EMAIL_WITHIN")
     )
     if invalid or expired:
         return expired, invalid, None, None

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -20,7 +20,6 @@ from .utils import (
     send_mail,
     url_for_security,
     check_and_get_token_status,
-    get_within_delta,
     verify_hash,
 )
 
@@ -84,7 +83,7 @@ def confirm_email_token_status(token):
     :param token: The confirmation token
     """
     expired, invalid, data = check_and_get_token_status(
-        token, "confirm", get_within_delta("CONFIRM_EMAIL_WITHIN")
+        token, "confirm", cv("CONFIRM_EMAIL_WITHIN")
     )
     if invalid or expired or not data:
         return expired, invalid, None

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -241,10 +241,10 @@ _default_config: dict[str, t.Any] = {
     "SEND_PASSWORD_CHANGE_EMAIL": True,
     "SEND_PASSWORD_RESET_EMAIL": True,
     "SEND_PASSWORD_RESET_NOTICE_EMAIL": True,
-    "LOGIN_WITHIN": "1 days",
+    "LOGIN_WITHIN": timedelta(days=1),
     "CHANGE_EMAIL": False,
     "CHANGE_EMAIL_TEMPLATE": "security/change_email.html",
-    "CHANGE_EMAIL_WITHIN": "2 hours",
+    "CHANGE_EMAIL_WITHIN": timedelta(hours=2),
     "CHANGE_EMAIL_URL": "/change-email",
     "CHANGE_EMAIL_CONFIRM_URL": "/change-email-confirm",
     "CHANGE_EMAIL_ERROR_VIEW": None,  # spa
@@ -260,7 +260,7 @@ _default_config: dict[str, t.Any] = {
     "TWO_FACTOR_MAIL_VALIDITY": 300,
     "TWO_FACTOR_SMS_VALIDITY": 120,
     "TWO_FACTOR_ALWAYS_VALIDATE": True,
-    "TWO_FACTOR_LOGIN_VALIDITY": "30 days",
+    "TWO_FACTOR_LOGIN_VALIDITY": timedelta(days=30),
     "TWO_FACTOR_VALIDITY_SALT": "tf-validity-salt",
     "TWO_FACTOR_VALIDITY_COOKIE_NAME": "tf_validity",
     "TWO_FACTOR_VALIDITY_COOKIE": {
@@ -269,7 +269,7 @@ _default_config: dict[str, t.Any] = {
         "samesite": "Strict",
     },
     "TWO_FACTOR_SETUP_SALT": "tf-setup-salt",
-    "TWO_FACTOR_SETUP_WITHIN": "30 minutes",
+    "TWO_FACTOR_SETUP_WITHIN": timedelta(minutes=30),
     "TWO_FACTOR_RESCUE_EMAIL": True,
     "MULTI_FACTOR_RECOVERY_CODES": False,
     "MULTI_FACTOR_RECOVERY_CODES_N": 5,
@@ -285,8 +285,8 @@ _default_config: dict[str, t.Any] = {
     "OAUTH_RESPONSE_URL": "/login/oauthresponse",
     "OAUTH_VERIFY_START_URL": "/login/oauth-verify-start",
     "OAUTH_VERIFY_RESPONSE_URL": "/login/oauth-verify-response",
-    "CONFIRM_EMAIL_WITHIN": "5 days",
-    "RESET_PASSWORD_WITHIN": "1 days",
+    "CONFIRM_EMAIL_WITHIN": timedelta(days=2),
+    "RESET_PASSWORD_WITHIN": timedelta(days=1),
     "LOGIN_WITHOUT_CONFIRMATION": False,
     "AUTO_LOGIN_AFTER_CONFIRM": False,
     "AUTO_LOGIN_AFTER_RESET": False,
@@ -372,7 +372,7 @@ _default_config: dict[str, t.Any] = {
     "US_MFA_REQUIRED": ["password", "email"],
     "US_TOKEN_VALIDITY": 120,
     "US_EMAIL_SUBJECT": _("Verification Code"),
-    "US_SETUP_WITHIN": "30 minutes",
+    "US_SETUP_WITHIN": timedelta(minutes=30),
     "US_SIGNIN_REPLACES_LOGIN": False,
     "CACHE_CONTROL": {"private": True, "no-store": True},
     "CSRF_PROTECT_MECHANISMS": AUTHN_MECHANISMS,
@@ -400,11 +400,11 @@ _default_config: dict[str, t.Any] = {
     "WAN_REGISTER_TIMEOUT": 60000,  # milliseconds
     "WAN_REGISTER_TEMPLATE": "security/wan_register.html",
     "WAN_REGISTER_URL": "/wan-register",
-    "WAN_REGISTER_WITHIN": "30 minutes",
+    "WAN_REGISTER_WITHIN": timedelta(minutes=30),
     "WAN_SIGNIN_TIMEOUT": 60000,  # milliseconds
     "WAN_SIGNIN_TEMPLATE": "security/wan_signin.html",
     "WAN_SIGNIN_URL": "/wan-signin",
-    "WAN_SIGNIN_WITHIN": "1 minutes",
+    "WAN_SIGNIN_WITHIN": timedelta(minutes=1),
     "WAN_DELETE_URL": "/wan-delete",
     "WAN_VERIFY_URL": "/wan-verify",
     "WAN_VERIFY_TEMPLATE": "security/wan_verify.html",
@@ -1768,6 +1768,29 @@ class Security:
             app.config["SECURITY_TOKEN_MAX_AGE"] = timedelta(
                 seconds=cv("TOKEN_MAX_AGE", app=app)
             )
+
+        within_conversion = [
+            "LOGIN_WITHIN",
+            "CHANGE_EMAIL_WITHIN",
+            "CONFIRM_EMAIL_WITHIN",
+            "RESET_PASSWORD_WITHIN",
+            "TWO_FACTOR_SETUP_WITHIN",
+            "US_SETUP_WITHIN",
+            "WAN_REGISTER_WITHIN",
+            "WAN_SIGNIN_WITHIN",
+            "TWO_FACTOR_LOGIN_VALIDITY",
+        ]
+        for key in within_conversion:
+            within_value = cv(key, app=app)
+            if not isinstance(within_value, timedelta):
+                values = within_value.split()
+                app.config[f"SECURITY_{key}"] = timedelta(**{values[1]: int(values[0])})
+                warnings.warn(
+                    f"Non timedelta values for SECURITY_{key} are"
+                    f"deprecated as of 5.9",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
         self.login_manager = _get_login_manager(app, self)
         self._phone_util = self._phone_util_cls(app)

--- a/flask_security/passwordless.py
+++ b/flask_security/passwordless.py
@@ -14,11 +14,10 @@ from flask import current_app as app
 from .proxies import _security, _datastore
 from .signals import login_instructions_sent
 from .utils import (
-    config_value,
+    config_value as cv,
     send_mail,
     url_for_security,
     check_and_get_token_status,
-    get_within_delta,
 )
 
 
@@ -31,7 +30,7 @@ def send_login_instructions(user):
     login_link = url_for_security("token_login", token=token, _external=True)
 
     send_mail(
-        config_value("EMAIL_SUBJECT_PASSWORDLESS"),
+        cv("EMAIL_SUBJECT_PASSWORDLESS"),
         user.email,
         "login_instructions",
         user=user,
@@ -64,7 +63,7 @@ def login_token_status(token):
     :param token: The login token
     """
     expired, invalid, data = check_and_get_token_status(
-        token, "login", get_within_delta("LOGIN_WITHIN")
+        token, "login", cv("LOGIN_WITHIN")
     )
     if invalid or not data:
         return expired, invalid, None

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -17,13 +17,12 @@ from .signals import (
     username_recovery_email_sent,
 )
 from .utils import (
-    config_value,
+    check_and_get_token_status,
+    config_value as cv,
     hash_data,
     hash_password,
     send_mail,
     url_for_security,
-    check_and_get_token_status,
-    get_within_delta,
 )
 
 
@@ -39,9 +38,9 @@ def send_reset_password_instructions(user):
     """
     reset_link, token = generate_reset_link(user)
 
-    if config_value("SEND_PASSWORD_RESET_EMAIL"):
+    if cv("SEND_PASSWORD_RESET_EMAIL"):
         send_mail(
-            config_value("EMAIL_SUBJECT_PASSWORD_RESET"),
+            cv("EMAIL_SUBJECT_PASSWORD_RESET"),
             user.email,
             "reset_instructions",
             user=user,
@@ -63,9 +62,9 @@ def send_password_reset_notice(user):
 
     :param user: The user to send the notice to
     """
-    if config_value("SEND_PASSWORD_RESET_NOTICE_EMAIL"):
+    if cv("SEND_PASSWORD_RESET_NOTICE_EMAIL"):
         send_mail(
-            config_value("EMAIL_SUBJECT_PASSWORD_NOTICE"),
+            cv("EMAIL_SUBJECT_PASSWORD_NOTICE"),
             user.email,
             "reset_notice",
             user=user,
@@ -92,7 +91,7 @@ def reset_password_token_status(token):
     """
     user = None
     expired, invalid, data = check_and_get_token_status(
-        token, "reset", get_within_delta("RESET_PASSWORD_WITHIN")
+        token, "reset", cv("RESET_PASSWORD_WITHIN")
     )
     if data:
         user = _datastore.find_user(fs_uniquifier=data[0])
@@ -122,9 +121,9 @@ def send_username_recovery_email(user):
     """Sends the username recovery email for the specified user.
     :param user: The user requesting username recovery
     """
-    if config_value("USERNAME_RECOVERY"):
+    if cv("USERNAME_RECOVERY"):
         send_mail(
-            config_value("EMAIL_SUBJECT_USERNAME_RECOVERY"),
+            cv("EMAIL_SUBJECT_USERNAME_RECOVERY"),
             user.email,
             "username_recovery",
             user=user,

--- a/flask_security/templates/security/email/change_email_instructions.html
+++ b/flask_security/templates/security/email/change_email_instructions.html
@@ -3,8 +3,9 @@
   token - this token is part of confirmation link - but can be used to
     construct arbitrary URLs for redirecting.
   user - the entire user model object
+  within - formatted expiration of link
   security - the Flask-Security configuration
 #}
 <p>{{ _fsdomain('Use <a href="%(link)s">this link</a> to confirm your new email address.', link=link)|safe }}</p>
-<p>{{ _fsdomain('This link will expire in %(within)s.', within=config["SECURITY_CHANGE_EMAIL_WITHIN"]) }}</p>
+<p>{{ _fsdomain('This link will expire in %(within)s.', within=within) }}</p>
 <p>{{ _fsdomain('Your currently registered email is %(email)s.', email=user.email) }}</p>

--- a/flask_security/templates/security/email/change_email_instructions.txt
+++ b/flask_security/templates/security/email/change_email_instructions.txt
@@ -3,8 +3,9 @@
   token - this token is part of confirmation link - but can be used to
     construct arbitrary URLs for redirecting.
   user - the entire user model object
+  within - formatted expiration of link
   security - the Flask-Security configuration
 #}
 {{ _fsdomain('Use %(link)s to confirm your new email address.', link=link)|safe }}
-{{ _fsdomain('This link will expire in %(within)s.', within=config["SECURITY_CHANGE_EMAIL_WITHIN"]) }}
+{{ _fsdomain('This link will expire in %(within)s.', within=within) }}
 {{ _fsdomain('Your currently registered email is %(email)s.', email=user.email) }}

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -33,7 +33,6 @@ from .utils import (
     config_value as cv,
     do_flash,
     get_message,
-    get_within_delta,
     get_url,
     login_user,
     propagate_next,
@@ -280,7 +279,7 @@ def tf_validity_token_status(token):
     :param token: The Two-Factor Validity token
     """
     return check_and_get_token_status(
-        token, "tf_validity", get_within_delta("TWO_FACTOR_LOGIN_VALIDITY")
+        token, "tf_validity", cv("TWO_FACTOR_LOGIN_VALIDITY")
     )
 
 
@@ -304,7 +303,7 @@ def tf_verify_validity_token(fs_uniquifier: str) -> bool:
 def tf_set_validity_token_cookie(response: Response, token: str) -> Response:
     """Sets the Two-Factor validity cookie"""
     cookie_kwargs = cv("TWO_FACTOR_VALIDITY_COOKIE")
-    max_age = int(get_within_delta("TWO_FACTOR_LOGIN_VALIDITY").total_seconds())
+    max_age = int(cv("TWO_FACTOR_LOGIN_VALIDITY").total_seconds())
     response.set_cookie(
         cv("TWO_FACTOR_VALIDITY_COOKIE_NAME"),
         value=token,

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -79,7 +79,6 @@ from .utils import (
     get_post_verify_redirect,
     get_message,
     get_url,
-    get_within_delta,
     handle_already_auth,
     is_user_authenticated,
     localize_callback,
@@ -90,6 +89,7 @@ from .utils import (
     url_for_security,
     view_commit,
     allowed_auth_token,
+    td_format,
 )
 from .tf_plugin import tf_verify_validity_token
 from .twofactor import tf_clean_session
@@ -976,12 +976,12 @@ def us_setup_validate(token: str) -> ResponseValue:
     )
 
     expired, invalid, state = check_and_get_token_status(
-        token, "us_setup", get_within_delta("US_SETUP_WITHIN")
+        token, "us_setup", cv("US_SETUP_WITHIN")
     )
     if invalid:
         m, c = get_message("API_ERROR")
     if expired:
-        m, c = get_message("US_SETUP_EXPIRED", within=cv("US_SETUP_WITHIN"))
+        m, c = get_message("US_SETUP_EXPIRED", within=td_format(cv("US_SETUP_WITHIN")))
     if invalid or expired:
         if _security._want_json(request):
             form.form_errors.append(m)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -890,24 +890,28 @@ def config_value(key, app=None, default=None, strict=True):
     return app.config.get(key, default)
 
 
-def get_within_delta(key, app=None):
-    """Get a timedelta object from the application configuration following
-    the internal convention of::
-
-        <Amount of Units> <Type of Units>
-
-    Examples of valid config values::
-
-        5 days
-        10 minutes
-
-    :param key: The config value key without the `SECURITY_` prefix
-    :param app: Optional application to inspect. Defaults to Flask's
-                `current_app`
+def td_format(td: timedelta) -> str:
+    """Formats a timedelta object to a string.
+    This is simplistic version of what humanize provides.
+    This is english only - use humanize for localization
     """
-    txt = config_value(key, app=app)
-    values = txt.split()
-    return timedelta(**{values[1]: int(values[0])})
+    periods = [
+        ("year", 60 * 60 * 24 * 365),
+        ("month", 60 * 60 * 24 * 30),
+        ("day", 60 * 60 * 24),
+        ("hour", 60 * 60),
+        ("minute", 60),
+        ("second", 1),
+    ]
+
+    seconds = int(td.total_seconds())
+    strings = []
+    for period_name, period_seconds in periods:
+        if seconds >= period_seconds:
+            period_value, seconds = divmod(seconds, period_seconds)
+            has_s = "s" if period_value > 1 else ""
+            strings.append(f"{period_value} {period_name}{has_s}")
+    return ", ".join(strings)
 
 
 def send_mail(subject, recipient, template, **context):

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -118,7 +118,6 @@ from .utils import (
     get_post_register_redirect,
     get_post_verify_redirect,
     get_request_attr,
-    get_within_delta,
     get_url,
     handle_already_auth,
     hash_password,
@@ -129,6 +128,7 @@ from .utils import (
     propagate_next,
     send_mail,
     slash_url_suffix,
+    td_format,
     url_for_security,
     view_commit,
     allowed_auth_token,
@@ -434,7 +434,9 @@ def token_login(token):
         return redirect(url_for_security("login"))
     if expired:
         send_login_instructions(user)
-        m, c = get_message("LOGIN_EXPIRED", email=user.email, within=cv("LOGIN_WITHIN"))
+        m, c = get_message(
+            "LOGIN_EXPIRED", email=user.email, within=td_format(cv("LOGIN_WITHIN"))
+        )
         if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(
                 get_url(
@@ -503,7 +505,7 @@ def confirm_email(token):
         if expired:
             m, c = get_message(
                 "CONFIRMATION_EXPIRED",
-                within=cv("CONFIRM_EMAIL_WITHIN"),
+                within=td_format(cv("CONFIRM_EMAIL_WITHIN")),
             )
         else:
             m, c = get_message("INVALID_CONFIRMATION_TOKEN")
@@ -640,7 +642,7 @@ def reset_password(token):
             if expired:
                 m, c = get_message(
                     "PASSWORD_RESET_EXPIRED",
-                    within=cv("RESET_PASSWORD_WITHIN"),
+                    within=td_format(cv("RESET_PASSWORD_WITHIN")),
                 )
             else:
                 m, c = get_message("INVALID_RESET_PASSWORD_TOKEN")
@@ -672,7 +674,7 @@ def reset_password(token):
     if not form.user or invalid or expired:
         if expired:
             m, c = get_message(
-                "PASSWORD_RESET_EXPIRED", within=cv("RESET_PASSWORD_WITHIN")
+                "PASSWORD_RESET_EXPIRED", within=td_format(cv("RESET_PASSWORD_WITHIN"))
             )
         else:
             m, c = get_message("INVALID_RESET_PASSWORD_TOKEN")
@@ -970,13 +972,13 @@ def two_factor_setup_validate(token: str) -> ResponseValue:
     )
 
     expired, invalid, state = check_and_get_token_status(
-        token, "tf_setup", get_within_delta("TWO_FACTOR_SETUP_WITHIN")
+        token, "tf_setup", cv("TWO_FACTOR_SETUP_WITHIN")
     )
     if invalid:
         m, c = get_message("API_ERROR")
     if expired:
         m, c = get_message(
-            "TWO_FACTOR_SETUP_EXPIRED", within=cv("TWO_FACTOR_SETUP_WITHIN")
+            "TWO_FACTOR_SETUP_EXPIRED", within=td_format(cv("TWO_FACTOR_SETUP_WITHIN"))
         )
     if invalid or expired:
         tf_clean_session()  # until we completely remove session based setup/state

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -99,7 +99,6 @@ from .utils import (
     get_post_login_redirect,
     get_post_verify_redirect,
     get_url,
-    get_within_delta,
     login_user,
     lookup_identity,
     propagate_next,
@@ -108,6 +107,7 @@ from .utils import (
     view_commit,
     localize_callback,
     allowed_auth_token,
+    td_format,
 )
 
 if t.TYPE_CHECKING:  # pragma: no cover
@@ -527,12 +527,14 @@ def webauthn_register_response(token: str) -> ResponseValue:
     )
 
     expired, invalid, state = check_and_get_token_status(
-        token, "wan", get_within_delta("WAN_REGISTER_WITHIN")
+        token, "wan", cv("WAN_REGISTER_WITHIN")
     )
     if invalid:
         m, c = get_message("API_ERROR")
     if expired:
-        m, c = get_message("WEBAUTHN_EXPIRED", within=cv("WAN_REGISTER_WITHIN"))
+        m, c = get_message(
+            "WEBAUTHN_EXPIRED", within=td_format(cv("WAN_REGISTER_WITHIN"))
+        )
     if invalid or expired:
         if _security._want_json(request):
             form.form_errors.append(m)
@@ -688,12 +690,14 @@ def webauthn_signin_response(token: str) -> ResponseValue:
     )
 
     expired, invalid, state = check_and_get_token_status(
-        token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")
+        token, "wan", cv("WAN_SIGNIN_WITHIN")
     )
     if invalid:
         m, c = get_message("API_ERROR")
     if expired:
-        m, c = get_message("WEBAUTHN_EXPIRED", within=cv("WAN_SIGNIN_WITHIN"))
+        m, c = get_message(
+            "WEBAUTHN_EXPIRED", within=td_format(cv("WAN_SIGNIN_WITHIN"))
+        )
     if invalid or expired:
         if _security._want_json(request):
             form.form_errors.append(m)
@@ -850,12 +854,14 @@ def webauthn_verify_response(token: str) -> ResponseValue:
     )
 
     expired, invalid, state = check_and_get_token_status(
-        token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")
+        token, "wan", cv("WAN_SIGNIN_WITHIN")
     )
     if invalid:
         m, c = get_message("API_ERROR")
     if expired:
-        m, c = get_message("WEBAUTHN_EXPIRED", within=cv("WAN_SIGNIN_WITHIN"))
+        m, c = get_message(
+            "WEBAUTHN_EXPIRED", within=td_format(cv("WAN_SIGNIN_WITHIN"))
+        )
     if invalid or expired:
         if _security._want_json(request):
             form.form_errors.append(m)

--- a/tests/templates/security/email/change_email_instructions.txt
+++ b/tests/templates/security/email/change_email_instructions.txt
@@ -3,10 +3,11 @@
   token - this token is part of confirmation link - but can be used to
     construct arbitrary URLs for redirecting.
   user - the entire user model object
+  within - formatted expiration of link
   security - the Flask-Security configuration
 #}
 Link:{{ link }}
 Email:{{ user.email }}
 Token:{{ token }}
 RegisterBlueprint:{{ security.register_blueprint }}
-Within:{{ config["SECURITY_CHANGE_EMAIL_WITHIN"] }}
+Within:{{ within }}

--- a/tests/test_change_email.py
+++ b/tests/test_change_email.py
@@ -46,7 +46,9 @@ def capture_change_email_requests():
         change_email_instructions_sent.disconnect(_on)
 
 
-@pytest.mark.settings(change_email_error_view="/change-email")
+@pytest.mark.settings(
+    change_email_error_view="/change-email", change_email_within=timedelta(seconds=67)
+)
 def test_ce(app, clients, get_message, outbox):
     @change_email_confirmed.connect_via(app)
     def _on(app, **kwargs):
@@ -66,7 +68,7 @@ def test_ce(app, clients, get_message, outbox):
         assert "matt2@lp.com" == ce_requests[0]["new_email"]
         token = ce_requests[0]["token"]
     assert len(outbox) == 1
-    assert app.config["SECURITY_CHANGE_EMAIL_WITHIN"] in outbox[0].body
+    assert "1 minute, 7 seconds" in outbox[0].body
 
     response = clients.get("/change-email/" + token, follow_redirects=True)
     assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
@@ -118,7 +120,7 @@ def test_ce_json(app, client, get_message, outbox):
 
 
 @pytest.mark.settings(
-    change_email_within="1 milliseconds", change_email_error_view="/change-email"
+    change_email_within=timedelta(minutes=36), change_email_error_view="/change-email"
 )
 def test_expired_token(client, get_message):
     # Note that we need relatively new-ish date since session cookies also expire.
@@ -131,7 +133,7 @@ def test_expired_token(client, get_message):
         token = ce_requests[0]["token"]
 
     response = client.get("/change-email/" + token, follow_redirects=True)
-    msg = get_message("CHANGE_EMAIL_EXPIRED", within="1 milliseconds")
+    msg = get_message("CHANGE_EMAIL_EXPIRED", within="36 minutes")
     assert msg in response.data
 
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -202,7 +202,8 @@ def test_requires_confirmation_error_redirect(app, clients):
 
 
 @pytest.mark.registerable()
-@pytest.mark.settings(confirm_email_within="1 milliseconds")
+@pytest.mark.settings(confirm_email_within="1 minutes")
+@pytest.mark.filterwarnings("ignore:.*Non timedelta")
 def test_expired_confirmation_token(client, get_message):
     # Note that we need relatively new-ish date since session cookies also expire.
     with freeze_time(date.today() + timedelta(days=-1)):
@@ -219,7 +220,7 @@ def test_expired_confirmation_token(client, get_message):
         token = registrations[0]["confirm_token"]
 
     response = client.get("/confirm/" + token, follow_redirects=True)
-    msg = get_message("CONFIRMATION_EXPIRED", within="1 milliseconds", email=email)
+    msg = get_message("CONFIRMATION_EXPIRED", within="1 minute", email=email)
     assert msg in response.data
 
 
@@ -453,7 +454,7 @@ def test_spa_get(app, client, get_message):
 
 @pytest.mark.registerable()
 @pytest.mark.settings(
-    confirm_email_within="1 milliseconds",
+    confirm_email_within=timedelta(minutes=300),
     redirect_host="localhost:8081",
     redirect_behavior="spa",
     confirm_error_view="/confirm-error",
@@ -482,7 +483,7 @@ def test_spa_get_bad_token(app, client, get_message):
         assert "email" not in qparams
         assert "identity" not in qparams
 
-        msg = get_message("CONFIRMATION_EXPIRED", within="1 milliseconds")
+        msg = get_message("CONFIRMATION_EXPIRED", within="5 hours")
         assert msg == qparams["error"].encode("utf-8")
 
         # Test mangled token

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -72,6 +72,7 @@ from flask_security.utils import (
     uia_phone_mapper,
     verify_hash,
     get_post_action_redirect,
+    td_format,
 )
 from flask_security.core import _get_serializer
 
@@ -1663,3 +1664,12 @@ def test_null_user_id(app, client, get_message):
         sess["_user_id"] = ""
         sess["user_id"] = ""
     assert not is_authenticated(client, get_message)
+
+
+def test_td_format(app):
+    # Test our internal timedelta formatter - we encourage using humanize but don't
+    # want to require that dependency.
+    assert "4 seconds" == td_format(timedelta(seconds=4))
+    assert "1 day" == td_format(timedelta(days=1))
+    assert "1 day, 30 minutes" == td_format(timedelta(days=1, minutes=30))
+    assert "1 day, 2 hours, 40 seconds" == td_format(timedelta(hours=26, seconds=40))

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -109,7 +109,7 @@ def test_passwordless_template(app, client, get_message, outbox):
         assert get_message("PASSWORDLESS_LOGIN_SUCCESSFUL") in response.data
 
 
-@pytest.mark.settings(login_within="1 milliseconds")
+@pytest.mark.settings(login_within=timedelta(days=1))
 def test_expired_login_token(client, app, get_message):
     e = "matt@lp.com"
     with capture_passwordless_login_requests() as requests:
@@ -122,8 +122,7 @@ def test_expired_login_token(client, app, get_message):
 
     response = client.get("/login/" + token, follow_redirects=True)
     assert (
-        get_message("LOGIN_EXPIRED", within="1 milliseconds", email=user.email)
-        in response.data
+        get_message("LOGIN_EXPIRED", within="1 day", email=user.email) in response.data
     )
 
 
@@ -158,7 +157,7 @@ def test_spa_get(app, client):
 
 
 @pytest.mark.settings(
-    login_within="1 milliseconds",
+    login_within=timedelta(seconds=73),
     redirect_host="localhost:8081",
     redirect_behavior="spa",
     login_error_view="/login-error",
@@ -185,7 +184,9 @@ def test_spa_get_bad_token(app, client, get_message):
         qparams = dict(parse_qsl(split.query))
         assert all(k in qparams for k in ["email", "error", "identity"])
 
-        msg = get_message("LOGIN_EXPIRED", within="1 milliseconds", email="matt@lp.com")
+        msg = get_message(
+            "LOGIN_EXPIRED", within="1 minute, 13 seconds", email="matt@lp.com"
+        )
         assert msg == qparams["error"].encode("utf-8")
 
         # Test mangled token

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -298,7 +298,7 @@ def test_login_form_description(app, sqlalchemy_datastore):
         assert login_form.password.description == expected
 
 
-@pytest.mark.settings(reset_password_within="1 milliseconds")
+@pytest.mark.settings(reset_password_within=timedelta(hours=4))
 def test_expired_reset_token(client, get_message):
     # Note that we need relatively new-ish date since session cookies also expire.
     with freeze_time(date.today() + timedelta(days=-1)):
@@ -309,9 +309,7 @@ def test_expired_reset_token(client, get_message):
     token = requests[0]["token"]
 
     with capture_flashes() as flashes:
-        msg = get_message(
-            "PASSWORD_RESET_EXPIRED", within="1 milliseconds", email=user.email
-        )
+        msg = get_message("PASSWORD_RESET_EXPIRED", within="4 hours", email=user.email)
 
         # Test getting reset form with expired token
         response = client.get("/reset/" + token, follow_redirects=True)
@@ -475,7 +473,7 @@ def test_spa_get(app, client):
 
 
 @pytest.mark.settings(
-    reset_password_within="1 milliseconds",
+    reset_password_within=timedelta(seconds=39),
     redirect_host="localhost:8081",
     redirect_behavior="spa",
     reset_error_view="/reset-error",
@@ -507,7 +505,7 @@ def test_spa_get_bad_token(app, client, get_message):
         assert "email" not in qparams
 
         msg = get_message(
-            "PASSWORD_RESET_EXPIRED", within="1 milliseconds", email="joe@lp.com"
+            "PASSWORD_RESET_EXPIRED", within="39 seconds", email="joe@lp.com"
         )
         assert msg == qparams["error"].encode("utf-8")
 

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -174,7 +174,7 @@ def test_do_not_remember_tf_validity(app, client):
 
 
 @pytest.mark.settings(
-    two_factor_always_validate=False, two_factor_login_validity="-1 minutes"
+    two_factor_always_validate=False, two_factor_login_validity=timedelta(minutes=-1)
 )
 def test_tf_expired_cookie(app, client):
     tf_authenticate(app, client, remember=True)
@@ -981,8 +981,7 @@ def test_opt_in_nc_expired(app, client_nc, get_message):
     )
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
-        "TWO_FACTOR_SETUP_EXPIRED",
-        within=app.config["SECURITY_TWO_FACTOR_SETUP_WITHIN"],
+        "TWO_FACTOR_SETUP_EXPIRED", within="30 minutes"
     )
 
 

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -947,7 +947,7 @@ def test_setup_bad_token(app, client, get_message):
     assert get_message("API_ERROR") in response.data
 
 
-@pytest.mark.settings(us_setup_within="2 seconds")
+@pytest.mark.settings(us_setup_within=timedelta(seconds=47))
 def test_setup_timeout(app, client, get_message):
     # Test setup timeout
     set_email(app)
@@ -955,7 +955,7 @@ def test_setup_timeout(app, client, get_message):
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
     sms_sender = SmsSenderFactory.createSender("test")
-    app.security.us_setup_serializer = FakeSerializer(2.0)
+    app.security.us_setup_serializer = FakeSerializer(47.0)
     response = client.post(
         "us-setup",
         json=dict(chosen_method="sms", phone="650-555-1212"),
@@ -970,7 +970,7 @@ def test_setup_timeout(app, client, get_message):
     )
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
-        "US_SETUP_EXPIRED", within=app.config["SECURITY_US_SETUP_WITHIN"]
+        "US_SETUP_EXPIRED", within="47 seconds"
     )
 
 

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -12,6 +12,7 @@ WebAuthn tests
 from base64 import urlsafe_b64encode
 import copy
 import datetime
+from datetime import timedelta
 import json
 import re
 
@@ -994,7 +995,7 @@ def test_tf_validity_window_json(app, client, get_message):
     assert response.status_code == 200
 
 
-@pytest.mark.settings(wan_register_within="1 seconds")
+@pytest.mark.settings(wan_register_within=timedelta(seconds=1))
 def test_register_timeout(app, client, get_message):
     authenticate(client)
 
@@ -1004,11 +1005,11 @@ def test_register_timeout(app, client, get_message):
     response = client.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
-        "WEBAUTHN_EXPIRED", within=app.config["SECURITY_WAN_REGISTER_WITHIN"]
+        "WEBAUTHN_EXPIRED", within="1 second"
     )
 
 
-@pytest.mark.settings(wan_signin_within="2 seconds")
+@pytest.mark.settings(wan_signin_within=timedelta(seconds=2))
 def test_signin_timeout(app, client, get_message):
     authenticate(client)
 
@@ -1025,7 +1026,7 @@ def test_signin_timeout(app, client, get_message):
     )
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
-        "WEBAUTHN_EXPIRED", within=app.config["SECURITY_WAN_SIGNIN_WITHIN"]
+        "WEBAUTHN_EXPIRED", within="2 seconds"
     )
 
 
@@ -1358,7 +1359,7 @@ def test_verify(app, client, get_message):
         assert sess["fs_paa"] > old_paa
 
 
-@pytest.mark.settings(wan_signin_within="2 seconds")
+@pytest.mark.settings(wan_signin_within=timedelta(seconds=2))
 def test_verify_timeout(app, client, get_message):
     authenticate(client)
     register_options, response_url = _register_start_json(client, name="testr3")
@@ -1371,7 +1372,7 @@ def test_verify_timeout(app, client, get_message):
     response = client.post(response_url, json=dict(credential=json.dumps(SIGNIN_DATA1)))
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
-        "WEBAUTHN_EXPIRED", within=app.config["SECURITY_WAN_SIGNIN_WITHIN"]
+        "WEBAUTHN_EXPIRED", within="2 seconds"
     )
 
 


### PR DESCRIPTION
- Change all the SECURITY_XX_WITHIN from the internal <#>,<period> (e.g. 2 days) to timedelta.
- As part of flask-security init - accept the old style and convert to timedelta and issue a deprecation warning.
- add a utility to convert a timedelta to a string - this is pretty lame - the intent is for most applications to use humanize - which we'll integrate in another PR. This will solve the localization issue (#1153)
- Pass the string - within - into the change_email_instructions template.