### PR TITLE
Use humanize to localize timedelta variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ Features & Improvements
 - (:issue:`1228`) Change default ``csrf`` and ``tf_validity`` cookie config to ``secure=True``
 - (:issue:`1228`) The ``tf_validity`` cookie name is now configurable via :py:data:`SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME`
 - (:issue:`1237`) Add support for CSRF on logout
-- (:pr:`xx`) Convert all _WITHIN configuration variable to use timedelta.
+- (:pr:`1241`) Convert all _WITHIN configuration variable to use timedelta
+- (:issue:`1153`) Enable localization of %(within)s variables using humanize
 
 Fixes
 +++++
@@ -28,7 +29,7 @@ Fixes
 Docs and Chores
 +++++++++++++++
 - (:issue:`1208`) Remove support for Pony ORM
-- (:pr:`1240`) Remove deprecated get_token_status() and converted over to check_and_get_token_status()
+- (:pr:`1240`) Remove deprecated get_token_status() and convert uses to check_and_get_token_status()
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -45,7 +46,7 @@ Backwards Compatibility Concerns
 - The default configuration for :py:data:`SECURITY_CSRF_COOKIE` has been
   changed to ``secure=True``
 - All _WITHIN configuration variables now take a timedelta instead of the
-  home-grown <#> <period>. The old form is still accepted, with a deprecation
+  home-grown ``<#> <period>``. The old form is still accepted, with a deprecation
   warning, and converted at flask-security app init time into a timedelta.
 
 Notes

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -356,6 +356,16 @@ Be aware that Flask-Security will validate and normalize email input using the
 `email_validator <https://pypi.org/project/email-validator/>`_ package.
 The normalized form is stored in the DB.
 
+Using Humanize
+++++++++++++++
+
+Some Flask-Security configuration variables (e.g. all the _WITHIN ones) are defined using
+timedelta. These variables are used in various error messages and email templates. In order to
+localize those portions of the message, Flask-Security uses humanize.precisedelta if
+`humanize <https://humanize.readthedocs.io/>`_ is
+installed - otherwise it uses an internal utility that always returns English.
+It is up to the application to properly configure humanize (via a call to humanize.i18n.activate(<locale>).
+
 Overriding Messages
 ++++++++++++++++++++
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -892,26 +892,33 @@ def config_value(key, app=None, default=None, strict=True):
 
 def td_format(td: timedelta) -> str:
     """Formats a timedelta object to a string.
-    This is simplistic version of what humanize provides.
-    This is english only - use humanize for localization
+    Use humanize.precisedelta if available otherwise use
+    this simplistic version of what humanize provides (English only).
     """
-    periods = [
-        ("year", 60 * 60 * 24 * 365),
-        ("month", 60 * 60 * 24 * 30),
-        ("day", 60 * 60 * 24),
-        ("hour", 60 * 60),
-        ("minute", 60),
-        ("second", 1),
-    ]
+    try:
+        import humanize
 
-    seconds = int(td.total_seconds())
-    strings = []
-    for period_name, period_seconds in periods:
-        if seconds >= period_seconds:
-            period_value, seconds = divmod(seconds, period_seconds)
-            has_s = "s" if period_value > 1 else ""
-            strings.append(f"{period_value} {period_name}{has_s}")
-    return ", ".join(strings)
+        return humanize.precisedelta(td)
+    except ImportError:
+        periods = [
+            ("year", 60 * 60 * 24 * 365),
+            ("month", 60 * 60 * 24 * 30),
+            ("day", 60 * 60 * 24),
+            ("hour", 60 * 60),
+            ("minute", 60),
+            ("second", 1),
+        ]
+
+        seconds = int(td.total_seconds())
+        strings = []
+        for period_name, period_seconds in periods:
+            if seconds >= period_seconds:
+                period_value, seconds = divmod(seconds, period_seconds)
+                has_s = "s" if period_value > 1 else ""
+                strings.append(f"{period_value} {period_name}{has_s}")
+        if len(strings) == 2:
+            return " and ".join(strings)
+        return ", ".join(strings)
 
 
 def send_mail(subject, recipient, template, **context):

--- a/pyproject-too.toml
+++ b/pyproject-too.toml
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-babel = ["babel>=2.17.0", "flask_babel>=4.0.0"]
+babel = ["babel>=2.17.0", "flask_babel>=4.0.0", "humanize>=4.12.0"]
 fsqla = ["flask_sqlalchemy>=3.1.1", "sqlalchemy>=2.0.41"]
 common = ["argon2_cffi>=25.1.0", "bcrypt>=4.2.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=45.0.7", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.6.0"]
@@ -62,6 +62,7 @@ low = [
     "bcrypt==4.0.1",
     "bleach==6.0.0",
     "freezegun",
+    "humanize",
     "jinja2==3.1.2",
     "itsdangerous==2.2.0",
     "markupsafe==2.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-babel = ["babel>=2.17.0", "flask_babel>=4.0.0"]
+babel = ["babel>=2.17.0", "flask_babel>=4.0.0", "humanize>=4.12.0"]
 fsqla = ["flask_sqlalchemy>=3.1.1", "sqlalchemy>=2.0.41"]
 common = ["argon2_cffi>=25.1.0", "bcrypt>=4.2.1", "flask_mail>=0.10.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=45.0.7", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.6.0"]
@@ -62,6 +62,7 @@ low = [
     "bcrypt==4.0.1",
     "bleach==6.0.0",
     "freezegun",
+    "humanize",
     "jinja2==3.1.2",
     "itsdangerous==2.2.0",
     "markupsafe==2.1.2",

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -12,6 +12,7 @@ coverage
 cryptography
 djlint
 freezegun
+humanize
 mongoengine
 mongomock
 msgcheck

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1207,3 +1207,16 @@ def _teardown_realdb(db_info):
     from sqlalchemy_utils import drop_database
 
     drop_database(db_info["engine"].url)
+
+
+@pytest.fixture()
+def humanizer(request):
+    pytest.importorskip("humanize")
+    import humanize
+
+    if getattr(request, "param", None):
+        humanize.i18n.activate(request.param)
+        yield 1
+        humanize.i18n.deactivate()
+    else:
+        yield 0

--- a/tests/test_change_email.py
+++ b/tests/test_change_email.py
@@ -68,7 +68,7 @@ def test_ce(app, clients, get_message, outbox):
         assert "matt2@lp.com" == ce_requests[0]["new_email"]
         token = ce_requests[0]["token"]
     assert len(outbox) == 1
-    assert "1 minute, 7 seconds" in outbox[0].body
+    assert "1 minute and 7 seconds" in outbox[0].body
 
     response = clients.get("/change-email/" + token, follow_redirects=True)
     assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
@@ -158,6 +158,18 @@ def test_template(app, client, get_message, outbox):
         _, link = matcher[0].split(":", 1)
         response = client.get(link, follow_redirects=True)
         assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
+
+
+@pytest.mark.parametrize("humanizer", ["fr_FR"], indirect=["humanizer"])
+def test_template_fr(app, client, get_message, outbox, humanizer):
+    # Check contents of email template - with humanize xlation of within
+    authenticate(client, email="matt@lp.com")
+    with capture_change_email_requests():
+        client.post("/change-email", data=dict(email="matt2@lp.com"))
+        # check email
+        assert outbox[0].recipients[0] == "matt2@lp.com"
+        matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)
+        assert matcher[4].split(":")[1] == "2 heures"
 
 
 @pytest.mark.settings(return_generic_responses=True)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1666,10 +1666,27 @@ def test_null_user_id(app, client, get_message):
     assert not is_authenticated(client, get_message)
 
 
-def test_td_format(app):
+def test_td_format(app, monkeypatch):
     # Test our internal timedelta formatter - we encourage using humanize but don't
     # want to require that dependency.
+    import sys
+
+    monkeypatch.setitem(sys.modules, "humanize", None)
     assert "4 seconds" == td_format(timedelta(seconds=4))
     assert "1 day" == td_format(timedelta(days=1))
-    assert "1 day, 30 minutes" == td_format(timedelta(days=1, minutes=30))
+    assert "1 day and 30 minutes" == td_format(timedelta(days=1, minutes=30))
     assert "1 day, 2 hours, 40 seconds" == td_format(timedelta(hours=26, seconds=40))
+
+
+def test_td_format_humanize(app):
+    pytest.importorskip("humanize")
+    assert "1 day, 2 hours and 40 seconds" == td_format(timedelta(hours=26, seconds=40))
+
+
+@pytest.mark.parametrize("humanizer", ["fr_FR"], indirect=["humanizer"])
+def test_td_format_humanize_fr(app, humanizer):
+    # humanize has built in localization
+    # app responsible for setting it up.
+    assert "1 jour, 2 heures et 40 secondes" == td_format(
+        timedelta(hours=26, seconds=40)
+    )

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -185,7 +185,7 @@ def test_spa_get_bad_token(app, client, get_message):
         assert all(k in qparams for k in ["email", "error", "identity"])
 
         msg = get_message(
-            "LOGIN_EXPIRED", within="1 minute, 13 seconds", email="matt@lp.com"
+            "LOGIN_EXPIRED", within="1 minute and 13 seconds", email="matt@lp.com"
         )
         assert msg == qparams["error"].encode("utf-8")
 


### PR DESCRIPTION
Some error messages and email templates contain substitution variables for configuration values that are defined as timedeltas. These are now localizable using humanize if installed (otherwise english is returned).

humanize has been added to the "babel" install extras. As mentioned in the docs - it is up to the application to properly configure humanize.

closes #1153