### PR TITLE
Fix login form remember checkbox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,13 +26,14 @@ Fixes
 +++++
 - (:issue:`1212`) Newly introduced :py:meth:`.UserMixin.is_locked` logic is inverted.
 - (:pr:`1234`) Fix for GHSA-f66q-9rf6-8795 - WebAuthn reauthentication freshness bypass. (tonghuaroot)
+- (:issue:`1244`) Fix login form remember me checkbox.
 
 
 Docs and Chores
 +++++++++++++++
 - (:issue:`1208`) Remove support for Pony ORM
 - (:pr:`1240`) Remove deprecated get_token_status() and convert uses to check_and_get_token_status()
-- Replace ``bleach`` (deprecated/unmaintained) with ``nh3`` for username sanitization
+- (:pr:`1252`) Replace ``bleach`` (deprecated/unmaintained) with ``nh3`` for username sanitization (tkfoss)
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -533,14 +533,16 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
 
     # username is added dynamically based on USERNAME_ENABLED.
     username: t.ClassVar[Field]
-    remember = BooleanField(get_form_field_label("remember_me"))
+    remember = BooleanField(
+        get_form_field_label("remember_me"),
+        default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),
+    )
     submit = SubmitField(get_form_field_label("login"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         if request and not self.next.data:
             self.next.data = request.args.get("next", "")
-        self.remember.default = cv("DEFAULT_REMEMBER_ME")
         if _security.recoverable and not self.password.description:
             html = Markup(
                 f'<a href="{url_for_security("forgot_password")}">'

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -255,11 +255,13 @@ class UnifiedSigninForm(_UnifiedPassCodeForm, NextFormMixin):
         get_form_field_label("identity"),
         validators=[RequiredLocalize()],
     )
-    remember = BooleanField(get_form_field_label("remember_me"))
+    remember = BooleanField(
+        get_form_field_label("remember_me"),
+        default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.remember.default = cv("DEFAULT_REMEMBER_ME")
         self.requires_confirmation = False
 
     def validate(self, **kwargs: t.Any) -> bool:

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -223,7 +223,10 @@ class WebAuthnRegisterResponseForm(Form):
 
 class WebAuthnSigninForm(Form, NextFormMixin):
     identity = StringField(get_form_field_label("identity"))
-    remember = BooleanField(get_form_field_label("remember_me"))
+    remember = BooleanField(
+        get_form_field_label("remember_me"),
+        default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),
+    )
     submit = SubmitField(label=get_form_field_xlate(_("Start")), id="wan_signin")
 
     user: UserMixin | None = None
@@ -232,7 +235,6 @@ class WebAuthnSigninForm(Form, NextFormMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.remember.default = cv("DEFAULT_REMEMBER_ME")
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1019,10 +1019,12 @@ def test_session_loads_identity(app, client):
 
 
 def test_remember_token(client):
-    response = authenticate(client, follow_redirects=False)
+    response = authenticate(client, follow_redirects=False, remember=True)
     client.delete_cookie("session")
-    response = client.get("/profile")
-    assert b"profile" in response.data
+    assert not client.get_cookie("session")
+    assert client.get_cookie("remember_token")
+    response = client.get("/profile", follow_redirects=True)
+    assert b"Profile Page" in response.data
 
 
 def test_request_loader_does_not_fail_with_invalid_token(client):

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -207,7 +207,7 @@ def test_change_invalidates_session(app, client):
 
 def test_change_updates_remember(app, client):
     # Test that on change password - remember cookie updated
-    authenticate(client)
+    authenticate(client, remember=True)
 
     response = client.post(
         "/change",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1694,3 +1694,12 @@ def test_td_format_humanize_fr(app, humanizer):
     assert "1 jour, 2 heures et 40 secondes" == td_format(
         timedelta(hours=26, seconds=40)
     )
+
+
+@pytest.mark.settings(default_remember_me=True)
+def test_remember_login_form(app, client):
+    # ensure form has the checkbox set if default set.
+    response = client.get("/login")
+    assert response.status_code == 200
+    r = get_form_input(response, "remember")
+    assert "checked" in r

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -37,6 +37,7 @@ from tests.test_utils import (
     reset_fresh,
     reset_fresh_auth_token,
     setup_tf_sms,
+    get_form_input,
 )
 from tests.test_webauthn import HackWebauthnUtil, reg_2_keys
 
@@ -2482,3 +2483,12 @@ def test_override_user_locked_gr(app, client, get_message):
         "GENERIC_AUTHN_FAILED"
     )
     assert "identity" not in response.json["response"]["field_errors"]
+
+
+@pytest.mark.settings(default_remember_me=True)
+def test_remember_login_form(app, client):
+    # ensure form has the checkbox set if default set.
+    response = client.get("/us-signin")
+    assert response.status_code == 200
+    r = get_form_input(response, "remember")
+    assert "checked" in r

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,12 +44,15 @@ def authenticate(
     password="password",
     endpoint=None,
     csrf=False,
+    remember=False,
     **kwargs,
 ):
-    data = dict(email=email, password=password, remember="y")
+    data = dict(email=email, password=password)
     if csrf:
         response = client.get(endpoint or "/login")
         data["csrf_token"] = get_form_input_value(response, "csrf_token")
+    if remember:
+        data["remember"] = "y"
     return client.post(endpoint or "/login", data=data, **kwargs)
 
 

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -34,6 +34,7 @@ from tests.test_utils import (
     setup_tf_sms,
     verify_token,
     check_signals,
+    get_form_input,
 )
 
 from flask_security import (
@@ -1590,7 +1591,7 @@ def test_remember_token(client):
     assert client.get_cookie("remember_token")
     client.delete_cookie("session")
     response = client.get("/profile")
-    assert b"profile" in response.data
+    assert b"Profile Page" in response.data
 
 
 @pytest.mark.two_factor()
@@ -1869,3 +1870,12 @@ def test_csrf(app, client, get_message):
     data["csrf_token"] = csrf_token
     response = client.post(response_url, data=data)
     assert check_location(app, response.location, "/post-login")
+
+
+@pytest.mark.settings(default_remember_me=True)
+def test_remember_login_form(app, client):
+    # ensure form has the checkbox set if default set.
+    response = client.get("/wan-signin")
+    assert response.status_code == 200
+    r = get_form_input(response, "remember")
+    assert "checked" in r


### PR DESCRIPTION
The login form remember checkbox didn't correctly display a tick mark if SECURITY_DEFAULT_REMEMBER_ME was set. This was due to the default being set in the form init() which doesn't work - changed to using a lambda for the default value.

Also affected us-signin form, and wan-signin form.

closes #1244