### PR TITLE
Fix TypeError when JSON login password is a non-string value

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -561,6 +561,12 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
             return False
 
         assert self.password.data is not None  # validator password_required
+        if not isinstance(self.password.data, str):
+            # e.g. a JSON body can set this to a dict/list/number - DataRequired()
+            # only checks truthiness, and passing that on crashes hash_password()/
+            # normalize() below instead of failing validation.
+            self.password.errors.append(get_message("INVALID_PASSWORD")[0])
+            return False
         # Stay clear of accessing 'username' unless we added that field.
         # Lots of applications have added their own.
         # To make subclassing easier - if self.ifield has been set we assume

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -689,6 +689,15 @@ def test_invalid_json_auth(client):
     assert b'"code": 400' in response.data
 
 
+def test_non_string_json_password_auth(client):
+    # A JSON body can set password to a non-string (e.g. a dict) - used to crash.
+    data = dict(email="matt@lp.com", password={"not": "a string"})
+    response = client.post(
+        "/login?include_auth_token", content_type="application/json", json=data
+    )
+    assert b'"code": 400' in response.data
+
+
 def test_token_auth_via_querystring_valid_token(client):
     response = json_authenticate(client)
     token = response.json["response"]["user"]["authentication_token"]


### PR DESCRIPTION
## Summary

`LoginForm.validate()` only checks if `password.data` is truthy, not its type. Flask-WTF supports JSON request bodies, so a login POST with a non-string `password` (e.g. a dict) passes this check.

That value then reaches `hash_password()` / `get_hmac()` or `password_util.normalize()` unchanged, and both crash with an unhandled `TypeError` instead of a normal validation error.

## Fix

Add an `isinstance(self.password.data, str)` check in `LoginForm.validate()`, right after the existing password-required assertion. Non-string passwords are now rejected like any other invalid login.

## Testing

- Added `test_non_string_json_password_auth` in `tests/test_basic.py`.
- Confirmed it reproduces the crash on `main` (reverted the fix locally) and passes with the fix.
- Ran the full `test_basic.py` suite locally: no new failures (a few pre-existing skips for optional deps I don't have installed: pymongo, peewee, asgiref, flask_sqlalchemy_lite).
- `flake8` and `black --check` are clean.

Found via a Sentry error recurring across several apps that all use Flask-Security-Too's default JSON login, so this likely affects any app accepting JSON logins.