### PR TITLE
Add IsString and IsStringOrInt validators to reject non-string field values from JSON requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ Fixes
 - (:issue:`1212`) Newly introduced :py:meth:`.UserMixin.is_locked` logic is inverted.
 - (:pr:`1234`) Fix for GHSA-f66q-9rf6-8795 - WebAuthn reauthentication freshness bypass. (tonghuaroot)
 - (:issue:`1244`) Fix login form remember me checkbox.
+- (:pr:`1258`) A JSON request body can set a form field (email, password,
+  username, identity, name, phone, refresh token, recovery/2FA code, ...) to a
+  non-string value (e.g. a dict), which used to crash with an unhandled
+  ``TypeError`` instead of failing validation cleanly. (miettal)
 
 
 Docs and Chores

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -782,11 +782,15 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
         # For unified signin there are many other ways to authenticate
         assert isinstance(self.password.errors, list)
         if cv("PASSWORD_REQUIRED"):
-            if not self.password.data or not self.password.data.strip():
+            if (
+                not self.password.data
+                or not isinstance(self.password.data, str)
+                or not self.password.data.strip()
+            ):
                 self.password.errors.append(get_message("PASSWORD_NOT_PROVIDED")[0])
                 failed = True
 
-        if self.password.data:
+        if self.password.data and isinstance(self.password.data, str):
             # We do explicit validation here for passwords
             # (rather than write a validator class) for 2 reasons:
             # 1) We want to control which fields are passed -
@@ -903,7 +907,7 @@ class RegisterFormV2(
             failed = True
 
         assert isinstance(self.password.errors, list)
-        if self.password.data:
+        if self.password.data and isinstance(self.password.data, str):
             # We do explicit validation here for passwords
             # (rather than write a validator class) for 2 reasons:
             # 1) We want to control which fields are passed -

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -148,6 +148,17 @@ class LengthLocalize(ValidatorMixin, Length):
     pass
 
 
+class IsString(ValidatorMixin):
+    def __init__(self, *args, **kwargs):
+        if "message" not in kwargs:
+            kwargs["message"] = "API_ERROR"
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, form, field):
+        if not isinstance(field.data, str):
+            raise StopValidation(get_message(self._original_message)[0])
+
+
 class EmailValidation:
     """Simple interface to email_validator.
     N.B. Side-effect - if valid email, the field.data is set to the normalized value.

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -160,7 +160,8 @@ class IsString(ValidatorMixin):
             raise StopValidation(get_message(self._original_message)[0])
 
 
-# OTP/2FA code fields accept int, so these fields should use this validator instead of IsString()
+# OTP/2FA code fields accept int,so these fields should use this validator
+# instead of IsString()
 class IsStringOrInt(ValidatorMixin):
     def __init__(self, *args, **kwargs):
         if "message" not in kwargs:
@@ -342,7 +343,12 @@ class UserEmailFormMixin:
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[IsString(), email_required, EmailValidation(verify=True), valid_user_email],
+        validators=[
+            IsString(),
+            email_required,
+            EmailValidation(verify=True),
+            valid_user_email,
+        ],
     )
 
 
@@ -350,7 +356,12 @@ class UniqueEmailFormMixin:
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[IsString(), email_required, EmailValidation(verify=True), unique_user_email],
+        validators=[
+            IsString(),
+            email_required,
+            EmailValidation(verify=True),
+            unique_user_email,
+        ],
     )
 
 
@@ -506,7 +517,12 @@ class PasswordlessLoginForm(Form):
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[IsString(), email_required, EmailValidation(verify=False), valid_user_email],
+        validators=[
+            IsString(),
+            email_required,
+            EmailValidation(verify=False),
+            valid_user_email,
+        ],
     )
 
     submit = SubmitField(get_form_field_label("send_login_link"))

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -155,7 +155,8 @@ class IsString(ValidatorMixin):
         super().__init__(*args, **kwargs)
 
     def __call__(self, form, field):
-        if not isinstance(field.data, str):
+        # Skip None so this can be combined with Optional().
+        if field.data is not None and not isinstance(field.data, str):
             raise StopValidation(get_message(self._original_message)[0])
 
 
@@ -328,7 +329,7 @@ class UserEmailFormMixin:
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[email_required, EmailValidation(verify=True), valid_user_email],
+        validators=[IsString(), email_required, EmailValidation(verify=True), valid_user_email],
     )
 
 
@@ -336,7 +337,7 @@ class UniqueEmailFormMixin:
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[email_required, EmailValidation(verify=True), unique_user_email],
+        validators=[IsString(), email_required, EmailValidation(verify=True), unique_user_email],
     )
 
 
@@ -344,7 +345,7 @@ class PasswordFormMixin:
     password = PasswordField(
         get_form_field_label("password"),
         render_kw={"autocomplete": "current-password"},
-        validators=[password_required],
+        validators=[IsString(), password_required],
     )
 
 
@@ -352,7 +353,7 @@ class NewPasswordFormMixin:
     password = PasswordField(
         get_form_field_label("password"),
         render_kw={"autocomplete": "new-password"},
-        validators=[password_required],
+        validators=[IsString(), password_required],
     )
 
 
@@ -361,6 +362,7 @@ class PasswordConfirmFormMixin:
         get_form_field_label("retype_password"),
         render_kw={"autocomplete": "new-password"},
         validators=[
+            IsString(),
             EqualToLocalize("password", message="RETYPE_PASSWORD_MISMATCH"),
             password_required,
         ],
@@ -385,13 +387,14 @@ class CodeFormMixin:
             "type": "text",
             "pattern": "[0-9]*",
         },
-        validators=[RequiredLocalize()],
+        validators=[IsString(), RequiredLocalize()],
     )
 
 
 def build_username_field(app):
     if cv("USERNAME_REQUIRED", app=app):
         validators = [
+            IsString(),
             RequiredLocalize(message="USERNAME_NOT_PROVIDED"),
             username_validator,
             unique_username,
@@ -490,7 +493,7 @@ class PasswordlessLoginForm(Form):
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[email_required, EmailValidation(verify=False), valid_user_email],
+        validators=[IsString(), email_required, EmailValidation(verify=False), valid_user_email],
     )
 
     submit = SubmitField(get_form_field_label("send_login_link"))
@@ -539,7 +542,7 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
     email = EmailField(
         get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
-        validators=[email_required, EmailValidation(verify=False)],
+        validators=[IsString(), email_required, EmailValidation(verify=False)],
     )
 
     # username is added dynamically based on USERNAME_ENABLED.
@@ -653,7 +656,7 @@ def build_login_form(app, fcls):
         fcls.username = StringField(
             get_form_field_label("username"),
             render_kw={"autocomplete": "username"},
-            validators=[username_validator],
+            validators=[IsString(), username_validator],
         )
         if hasattr(fcls, "email") and fcls.email:
             # Make field Optional()
@@ -662,7 +665,7 @@ def build_login_form(app, fcls):
             fcls.email = EmailField(
                 get_form_field_label("email"),
                 render_kw={"autocomplete": "email"},
-                validators=[Optional(), EmailValidation(verify=False)],
+                validators=[IsString(), Optional(), EmailValidation(verify=False)],
             )
 
 
@@ -676,7 +679,7 @@ class LogoutForm(Form):
 
     refresh_token = HiddenField(
         get_form_field_xlate(_("Refresh Token")),
-        validators=[Optional()],
+        validators=[IsString(), Optional()],
     )
     submit = SubmitField(label=get_form_field_label("submit"))
 
@@ -801,6 +804,7 @@ class RegisterForm(ConfirmRegisterForm, NextFormMixin):
     password_confirm = PasswordField(
         get_form_field_label("retype_password"),
         validators=[
+            IsString(),
             EqualToLocalize("password", message="RETYPE_PASSWORD_MISMATCH"),
             Optional(),
         ],
@@ -922,12 +926,13 @@ def build_register_form(app, fcls):
         fcls.password = PasswordField(
             label=get_form_field_label("password"),
             render_kw={"autocomplete": "new-password"},
-            validators=[Optional()],
+            validators=[IsString(), Optional()],
         )
         fcls.password_confirm = PasswordField(
             get_form_field_label("retype_password"),
             render_kw={"autocomplete": "new-password"},
             validators=[
+                IsString(),
                 EqualToLocalize("password", message="RETYPE_PASSWORD_MISMATCH"),
             ],
         )
@@ -969,13 +974,14 @@ class ChangePasswordForm(Form):
     new_password = PasswordField(
         get_form_field_label("new_password"),
         render_kw={"autocomplete": "new-password"},
-        validators=[password_required],
+        validators=[IsString(), password_required],
     )
 
     new_password_confirm = PasswordField(
         get_form_field_label("retype_password"),
         render_kw={"autocomplete": "new-password"},
         validators=[
+            IsString(),
             EqualToLocalize("new_password", message="RETYPE_PASSWORD_MISMATCH"),
             password_required,
         ],

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -765,6 +765,7 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
     password = PasswordField(
         get_form_field_label("password"),
         render_kw={"autocomplete": "new-password"},
+        validators=[IsString()],
     )
 
     def __init__(self, *args, **kwargs):

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -160,6 +160,19 @@ class IsString(ValidatorMixin):
             raise StopValidation(get_message(self._original_message)[0])
 
 
+# OTP/2FA code fields accept int, so these fields should use this validator instead of IsString()
+class IsStringOrInt(ValidatorMixin):
+    def __init__(self, *args, **kwargs):
+        if "message" not in kwargs:
+            kwargs["message"] = "API_ERROR"
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, form, field):
+        # Skip None so this can be combined with Optional().
+        if field.data is not None and not isinstance(field.data, (str, int)):
+            raise StopValidation(get_message(self._original_message)[0])
+
+
 class EmailValidation:
     """Simple interface to email_validator.
     N.B. Side-effect - if valid email, the field.data is set to the normalized value.
@@ -387,7 +400,7 @@ class CodeFormMixin:
             "type": "text",
             "pattern": "[0-9]*",
         },
-        validators=[IsString(), RequiredLocalize()],
+        validators=[IsStringOrInt(), RequiredLocalize()],
     )
 
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -808,7 +808,10 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
 
         if self.password.data:
             if not isinstance(self.password.data, str):
-                failed = True
+                # types-WTForms declares StringField.data type is str | None. But it can
+                # actually be a dict when request body is JSON. mypy therefore
+                # mis-identifies this as unreachable.
+                failed = True  # type: ignore[unreachable]
             else:
                 # We do explicit validation here for passwords
                 # (rather than write a validator class) for 2 reasons:
@@ -928,7 +931,10 @@ class RegisterFormV2(
         assert isinstance(self.password.errors, list)
         if self.password.data:
             if not isinstance(self.password.data, str):
-                failed = True
+                # types-WTForms declares StringField.data type is str | None. But it can
+                # actually be a dict when request body is JSON. mypy therefore
+                # mis-identifies this as unreachable.
+                failed = True  # type: ignore[unreachable]
             else:
                 # We do explicit validation here for passwords
                 # (rather than write a validator class) for 2 reasons:

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -1036,7 +1036,7 @@ class TwoFactorSetupForm(Form):
         ],
         validate_choice=False,
     )
-    phone = TelField(get_form_field_label("phone"))
+    phone = TelField(get_form_field_label("phone"), validators=[IsString()])
     submit = SubmitField(get_form_field_label("submit"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -806,24 +806,27 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
                 self.password.errors.append(get_message("PASSWORD_NOT_PROVIDED")[0])
                 failed = True
 
-        if self.password.data and isinstance(self.password.data, str):
-            # We do explicit validation here for passwords
-            # (rather than write a validator class) for 2 reasons:
-            # 1) We want to control which fields are passed -
-            #    sometimes that's current_user
-            #    other times it's the registration fields.
-            # 2) We want to be able to return multiple error messages.
-            rfields = {}
-            for k, v in self.data.items():
-                if hasattr(_datastore.user_model, k):
-                    rfields[k] = v
-            del rfields["password"]
-            pbad, self.password.data = _security.password_util.validate(
-                self.password.data, True, **rfields
-            )
-            if pbad:
-                self.password.errors.extend(pbad)
+        if self.password.data:
+            if not isinstance(self.password.data, str):
                 failed = True
+            else:
+                # We do explicit validation here for passwords
+                # (rather than write a validator class) for 2 reasons:
+                # 1) We want to control which fields are passed -
+                #    sometimes that's current_user
+                #    other times it's the registration fields.
+                # 2) We want to be able to return multiple error messages.
+                rfields = {}
+                for k, v in self.data.items():
+                    if hasattr(_datastore.user_model, k):
+                        rfields[k] = v
+                del rfields["password"]
+                pbad, self.password.data = _security.password_util.validate(
+                    self.password.data, True, **rfields
+                )
+                if pbad:
+                    self.password.errors.extend(pbad)
+                    failed = True
         return not failed
 
 
@@ -923,24 +926,27 @@ class RegisterFormV2(
             failed = True
 
         assert isinstance(self.password.errors, list)
-        if self.password.data and isinstance(self.password.data, str):
-            # We do explicit validation here for passwords
-            # (rather than write a validator class) for 2 reasons:
-            # 1) We want to control which fields are passed -
-            #    sometimes that's current_user
-            #    other times it's the registration fields.
-            # 2) We want to be able to return multiple error messages.
-            rfields = {}
-            for k, v in self.data.items():
-                if hasattr(_datastore.user_model, k):
-                    rfields[k] = v
-            del rfields["password"]
-            pbad, self.password.data = _security.password_util.validate(
-                self.password.data, True, **rfields
-            )
-            if pbad:
-                self.password.errors.extend(pbad)
+        if self.password.data:
+            if not isinstance(self.password.data, str):
                 failed = True
+            else:
+                # We do explicit validation here for passwords
+                # (rather than write a validator class) for 2 reasons:
+                # 1) We want to control which fields are passed -
+                #    sometimes that's current_user
+                #    other times it's the registration fields.
+                # 2) We want to be able to return multiple error messages.
+                rfields = {}
+                for k, v in self.data.items():
+                    if hasattr(_datastore.user_model, k):
+                        rfields[k] = v
+                del rfields["password"]
+                pbad, self.password.data = _security.password_util.validate(
+                    self.password.data, True, **rfields
+                )
+                if pbad:
+                    self.password.errors.extend(pbad)
+                    failed = True
         return not failed
 
     def __init__(self, *args, **kwargs):

--- a/flask_security/recovery_codes.py
+++ b/flask_security/recovery_codes.py
@@ -25,6 +25,7 @@ from .forms import (
     RequiredLocalize,
     StringField,
     SubmitField,
+    IsString,
 )
 from .proxies import _datastore, _security
 from .tf_plugin import tf_check_state, tf_illegal_state
@@ -158,7 +159,7 @@ class MfRecoveryForm(Form):
 
     code = StringField(
         get_form_field_xlate(_("Recovery Code")),
-        validators=[RequiredLocalize()],
+        validators=[IsString(), RequiredLocalize()],
     )
     submit = SubmitField(get_form_field_label("submitcode"))
 

--- a/flask_security/tokens.py
+++ b/flask_security/tokens.py
@@ -39,6 +39,7 @@ from .forms import (
     get_form_field_label,
     get_form_field_xlate,
     build_form_from_request,
+    IsString,
 )
 from .proxies import _security, _datastore
 from .signals import refresh_tracker_revoked, refresh_tracker_created
@@ -198,7 +199,7 @@ class RefreshTokenForm(Form):
 
     refresh_token = StringField(
         get_form_field_xlate(_("Refresh Token")),
-        validators=[RequiredLocalize()],
+        validators=[IsString(), RequiredLocalize()],
     )
     submit = SubmitField(label=get_form_field_label("submit"))
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -63,6 +63,7 @@ from .forms import (
     generic_message,
     get_form_field_label,
     get_form_field_xlate,
+    IsString,
 )
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
@@ -175,7 +176,7 @@ class _UnifiedPassCodeForm(Form):
             ("email", get_form_field_xlate(_("Via email"))),
             ("sms", get_form_field_xlate(_("Via SMS"))),
         ],
-        validators=[validators.Optional()],
+        validators=[IsString(), validators.Optional()],
     )
     submit_send_code = SubmitField(get_form_field_label("sendcode"))
 
@@ -253,7 +254,7 @@ class UnifiedSigninForm(_UnifiedPassCodeForm, NextFormMixin):
 
     identity = StringField(
         get_form_field_label("identity"),
-        validators=[RequiredLocalize()],
+        validators=[IsString(), RequiredLocalize()],
     )
     remember = BooleanField(
         get_form_field_label("remember_me"),
@@ -393,7 +394,7 @@ class UnifiedSigninSetupValidateForm(Form):
             "type": "text",
             "pattern": "[0-9]*",
         },
-        validators=[RequiredLocalize()],
+        validators=[IsString(), RequiredLocalize()],
     )
     submit = SubmitField(get_form_field_label("submitcode"), id="submit-code")
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -167,6 +167,7 @@ class _UnifiedPassCodeForm(Form):
             "placeholder": get_form_field_xlate(_("Code or Password")),
             "autocomplete": "off",
         },
+        validators=[IsString()]
     )
     submit = SubmitField(get_form_field_label("submit"))
 
@@ -325,7 +326,7 @@ class UnifiedSigninSetupForm(Form):
         option_widget=CheckboxInput(),
         validate_choice=False,
     )
-    phone = TelField(get_form_field_label("phone"))
+    phone = TelField(get_form_field_label("phone"), validators=[IsString()])
     submit = SubmitField(get_form_field_label("submit"))
 
     def __init__(self, *args, **kwargs):

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -168,7 +168,7 @@ class _UnifiedPassCodeForm(Form):
             "placeholder": get_form_field_xlate(_("Code or Password")),
             "autocomplete": "off",
         },
-        validators=[IsStringOrInt()]
+        validators=[IsStringOrInt()],
     )
     submit = SubmitField(get_form_field_label("submit"))
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -64,6 +64,7 @@ from .forms import (
     get_form_field_label,
     get_form_field_xlate,
     IsString,
+    IsStringOrInt,
 )
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
@@ -167,7 +168,7 @@ class _UnifiedPassCodeForm(Form):
             "placeholder": get_form_field_xlate(_("Code or Password")),
             "autocomplete": "off",
         },
-        validators=[IsString()]
+        validators=[IsStringOrInt()]
     )
     submit = SubmitField(get_form_field_label("submit"))
 
@@ -395,7 +396,7 @@ class UnifiedSigninSetupValidateForm(Form):
             "type": "text",
             "pattern": "[0-9]*",
         },
-        validators=[IsString(), RequiredLocalize()],
+        validators=[IsStringOrInt(), RequiredLocalize()],
     )
     submit = SubmitField(get_form_field_label("submitcode"), id="submit-code")
 

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -228,7 +228,7 @@ class WebAuthnRegisterResponseForm(Form):
 
 
 class WebAuthnSigninForm(Form, NextFormMixin):
-    identity = StringField(get_form_field_label("identity"))
+    identity = StringField(get_form_field_label("identity"), validators=[IsString()])
     remember = BooleanField(
         get_form_field_label("remember_me"),
         default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -84,6 +84,7 @@ from .forms import (
     get_form_field_label,
     get_form_field_xlate,
     _setup_methods_xlate,
+    IsString,
 )
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
@@ -124,7 +125,7 @@ else:
 class WebAuthnRegisterForm(Form):
     name = StringField(
         get_form_field_xlate(_("Nickname")),
-        validators=[RequiredLocalize(message="WEBAUTHN_NAME_REQUIRED")],
+        validators=[IsString(), RequiredLocalize(message="WEBAUTHN_NAME_REQUIRED")],
     )
     usage = RadioField(
         get_form_field_xlate(_("Usage")),
@@ -378,7 +379,7 @@ class WebAuthnDeleteForm(Form):
     # element.
     name = StringField(
         get_form_field_xlate(_("Nickname")),
-        validators=[RequiredLocalize(message="WEBAUTHN_NAME_REQUIRED")],
+        validators=[IsString(), RequiredLocalize(message="WEBAUTHN_NAME_REQUIRED")],
         id="delete-name",
     )
     submit = SubmitField(label=get_form_field_label("delete"))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -689,6 +689,13 @@ def test_invalid_json_auth(client):
     assert b'"code": 400' in response.data
 
 
+def test_isstring_non_string_email(client):
+    response = client.post(
+        "/login", json=dict(email={"not": "a string"}, password="password")
+    )
+    assert response.status_code == 400
+
+
 def test_token_auth_via_querystring_valid_token(client):
     response = json_authenticate(client)
     token = response.json["response"]["user"]["authentication_token"]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -669,6 +669,21 @@ def test_myxlation_complete(app, sqlalchemy_datastore, pytestconfig):
 
 
 @pytest.mark.babel()
+@pytest.mark.app_settings(babel_default_locale="de_DE")
+def test_isstring_xlation(app, client):
+    # Test that IsString's error message is properly localized.
+    assert check_xlation(app, "de_DE"), "You must run python setup.py compile_catalog"
+
+    response = client.post(
+        "/login", json=dict(email={"not": "a string"}, password="password")
+    )
+    assert response.status_code == 400
+    assert "Ungültige Eingabe für die angeforderte Ressource" in response.json[
+        "response"
+    ]["errors"][0]
+
+
+@pytest.mark.babel()
 @pytest.mark.app_settings(babel_default_locale="fr_FR")
 def test_form_labels(app, sqlalchemy_datastore):
     app.security = Security()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -678,9 +678,10 @@ def test_isstring_xlation(app, client):
         "/login", json=dict(email={"not": "a string"}, password="password")
     )
     assert response.status_code == 400
-    assert "Ungültige Eingabe für die angeforderte Ressource" in response.json[
-        "response"
-    ]["errors"][0]
+    assert (
+        "Ungültige Eingabe für die angeforderte Ressource"
+        in response.json["response"]["errors"][0]
+    )
 
 
 @pytest.mark.babel()

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -224,6 +224,17 @@ def test_required_password(client, get_message):
     assert get_message("CONFIRM_REGISTRATION", email="trp@lp.com") in response.data
 
 
+def test_register_non_string_password(client):
+    # ConfirmRegisterForm and RegisterFormV2 have special validation code for
+    # OWASP (user enumeration). So they should have a separate test case from
+    # general IsString tests.
+    response = client.post(
+        "/register",
+        json=dict(email="newuser@lp.com", password={"not": "a string"}),
+    )
+    assert response.status_code == 400
+
+
 @pytest.mark.settings(use_register_v2=False)
 def test_required_password_confirm(client, get_message):
     response = client.post(

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -957,6 +957,26 @@ def test_opt_in_nc(app, client_nc, get_message, signals):
     assert response.json["response"]["tf_phone_number"] == "+442083661177"
 
 
+def test_opt_in_nc_non_string_code(app, client_nc):
+    """
+    Test tf-setup with dict code.
+    It should be rejected cleanly by IsStringOrInt validator to prevent passlib crash.
+    """
+    response = json_authenticate(client_nc, "jill@lp.com")
+    token = response.json["response"]["user"]["authentication_token"]
+    headers = {"Authentication-Token": token, "Accept": "application/json"}
+
+    SmsSenderFactory.createSender("test")
+    data = dict(setup="sms", phone="+442083661177")
+    response = client_nc.post("/tf-setup", json=data, headers=headers)
+    state_token = response.json["response"]["tf_state_token"]
+
+    response = client_nc.post(
+        f"/tf-setup/{state_token}", json=dict(code={"not": "a code"}), headers=headers
+    )
+    assert response.status_code == 400
+
+
 @pytest.mark.settings(token_max_age=timedelta(days=4))
 def test_opt_in_nc_expired(app, client_nc, get_message):
     """

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -960,7 +960,8 @@ def test_opt_in_nc(app, client_nc, get_message, signals):
 def test_opt_in_nc_non_string_code(app, client_nc):
     """
     Test tf-setup with dict code.
-    It should be rejected cleanly by the IsStringOrInt validator to prevent a passlib crash.
+    It should be rejected cleanly by the IsStringOrInt validator to prevent
+    a passlib crash.
     """
     response = json_authenticate(client_nc, "jill@lp.com")
     token = response.json["response"]["user"]["authentication_token"]

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -960,7 +960,7 @@ def test_opt_in_nc(app, client_nc, get_message, signals):
 def test_opt_in_nc_non_string_code(app, client_nc):
     """
     Test tf-setup with dict code.
-    It should be rejected cleanly by IsStringOrInt validator to prevent passlib crash.
+    It should be rejected cleanly by the IsStringOrInt validator to prevent a passlib crash.
     """
     response = json_authenticate(client_nc, "jill@lp.com")
     token = response.json["response"]["user"]["authentication_token"]


### PR DESCRIPTION
Replace https://github.com/pallets-eco/flask-security/pull/1256 with a root-cause fix.

 - add IsString() validator.
 - add IsStringOrInt() validator.
 - add IsString/IsStringOrInt validation for each string-required field.
 - add a test case confirming translation works.
 - add a test case confirming the new validators work.
 - add special handling for ConfirmRegisterForm/RegisterFormV2.
 - add a test case for special handling for ConfirmRegisterForm/RegisterFormV2.