### PR TITLE
Match REDIRECT_BASE_DOMAIN as well as subdomains

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Features & Improvements
 - (:pr:`1249`) Add link expiration to confirmation and reset password email templates.
 - (:issue:`536` Add template path configuration variables for all email templates.
 - (:issue:`1254`) Webauthn/passkey name input value is now sanitized and normalized.
-- (:pr:`1259`) Allow redirects to exactly :py:data:`REDIRECT_BASE_DOMAIN` as well as :py:data:`REDIRECT_ALLOWED_SUBDOMAINS` of it.
+- (:pr:`1259`) Allow redirects to exactly :py:data:`SECURITY_REDIRECT_BASE_DOMAIN` by adding '.' to :py:data:`SECURITY_REDIRECT_ALLOWED_SUBDOMAINS`.
 
 Fixes
 +++++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Features & Improvements
 - (:pr:`1249`) Add link expiration to confirmation and reset password email templates.
 - (:issue:`536` Add template path configuration variables for all email templates.
 - (:issue:`1254`) Webauthn/passkey name input value is now sanitized and normalized.
-- (:pr:`tbd`) Allow redirects to exactly :py:data:`REDIRECT_BASE_DOMAIN` as well as :py:data:`REDIRECT_ALLOWED_SUBDOMAINS` of it.
+- (:pr:`1259`) Allow redirects to exactly :py:data:`REDIRECT_BASE_DOMAIN` as well as :py:data:`REDIRECT_ALLOWED_SUBDOMAINS` of it.
 
 Fixes
 +++++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Features & Improvements
 - (:pr:`1249`) Add link expiration to confirmation and reset password email templates.
 - (:issue:`536` Add template path configuration variables for all email templates.
 - (:issue:`1254`) Webauthn/passkey name input value is now sanitized and normalized.
+- (:pr:`tbd`) Allow redirects to exactly :py:data:`REDIRECT_BASE_DOMAIN` as well as :py:data:`REDIRECT_ALLOWED_SUBDOMAINS` of it.
 
 Fixes
 +++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -253,6 +253,7 @@ These configuration keys are used globally across all features.
 
     A list of subdomains. Each will be prepended to
     ``SECURITY_REDIRECT_BASE_DOMAIN`` and checked against the requested redirect.
+    If the list includes '.', the base domain itself will be checked against the redirect.
 
     Default: ``[]``
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -727,7 +727,7 @@ def validate_redirect_url(url: str) -> bool:
             return True
         base_domain = config_value("REDIRECT_BASE_DOMAIN")
         if base_domain:
-            allowable = [
+            allowable = [base_domain] + [
                 f"{sub}.{base_domain}"
                 for sub in config_value("REDIRECT_ALLOWED_SUBDOMAINS")
             ]

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -727,8 +727,8 @@ def validate_redirect_url(url: str) -> bool:
             return True
         base_domain = config_value("REDIRECT_BASE_DOMAIN")
         if base_domain:
-            allowable = [base_domain] + [
-                f"{sub}.{base_domain}"
+            allowable = [
+                base_domain if sub == "." else f"{sub}.{base_domain}"
                 for sub in config_value("REDIRECT_ALLOWED_SUBDOMAINS")
             ]
             return url_next.netloc in allowable

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -208,7 +208,7 @@ def test_redirect_allow_subdomains(app, client, get_message):
 
 
 @pytest.mark.settings(
-    redirect_base_domain="myfrontend.org", redirect_allowed_subdomains=[]
+    redirect_base_domain="myfrontend.org", redirect_allowed_subdomains=["."]
 )
 def test_redirect_allow_base_domain(app, client, get_message):
     app.config["SERVER_NAME"] = "myflaskapp.org"
@@ -220,7 +220,17 @@ def test_redirect_allow_base_domain(app, client, get_message):
 
 
 @pytest.mark.settings(
-    redirect_base_domain="myapp.org:8080", redirect_allowed_subdomains=[]
+    redirect_base_domain="myfrontend.org", redirect_allowed_subdomains=[]
+)
+def test_redirect_disallow_base_domain_without_dot(app, client, get_message):
+    app.config["SERVER_NAME"] = "myflaskapp.org"
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://myfrontend.org/imin", data=data)
+    assert get_message("INVALID_REDIRECT") in response.data
+
+
+@pytest.mark.settings(
+    redirect_base_domain="myapp.org:8080", redirect_allowed_subdomains=["."]
 )
 def test_redirect_allow_other_ports(app, client, get_message):
     app.config["SERVER_NAME"] = "myapp.org"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -208,6 +208,30 @@ def test_redirect_allow_subdomains(app, client, get_message):
 
 
 @pytest.mark.settings(
+    redirect_base_domain="myfrontend.org", redirect_allowed_subdomains=[]
+)
+def test_redirect_allow_base_domain(app, client, get_message):
+    app.config["SERVER_NAME"] = "myflaskapp.org"
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://nope.myfrontend.org", data=data)
+    assert get_message("INVALID_REDIRECT") in response.data
+    response = client.post("/login?next=http://myfrontend.org/imin", data=data)
+    assert response.location == "http://myfrontend.org/imin"
+
+
+@pytest.mark.settings(
+    redirect_base_domain="myapp.org:8080", redirect_allowed_subdomains=[]
+)
+def test_redirect_allow_other_ports(app, client, get_message):
+    app.config["SERVER_NAME"] = "myapp.org"
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://nope.myapp.org:8080", data=data)
+    assert get_message("INVALID_REDIRECT") in response.data
+    response = client.post("/login?next=http://myapp.org:8080/imin", data=data)
+    assert response.location == "http://myapp.org:8080/imin"
+
+
+@pytest.mark.settings(
     post_login_view="http://blog.bigidea.org/post_login",
     redirect_base_domain="bigidea.org",
     redirect_allowed_subdomains=["my.photo", "blog"],


### PR DESCRIPTION
Hello!

Lmk if I'm missing existing behavior that would accomplish this or if this would better be handled another way - happy to take a step back, but this _seems_ like a small change that aligns with existing documentation of this variable and the behavior of `SERVER_NAME` if this isn't set.

Thanks in advance!

## Problem and changes:

**Currently**: Setting `SECURITY_REDIRECT_BASE_DOMAIN` lets you redirect to subdomains of another host (such as redirecting to `app.myfrontend.org` when your `SERVER_NAME` is `myflask.org`). For reference, this behavior was added in #1011.

**However**: As is, it doesn't let you redirect to the `REDIRECT_BASE_DOMAIN` exactly. So if you wanted to redirect to `myfrontend.org`, or `myflask.org:8080` when your app is hosted on `myflask.org:80`, you can't.

(Both of the new tests in `test_basic.py` fail without this change)

**To fix that**: This PR adds the `REDIRECT_BASE_DOMAIN` to the list of allowable domains, so that the redirect doesn't _have_ to be a subdomain of the `REDIRECT_BASE_DOMAIN`

## Checklist

- [x] All new code and bug fixes need unit tests
- [x] **N/A** If you change/add to the external API be sure to update docs/openapi.yaml
- [x] **(Unchanged)** Additions to configuration variables and/or messages must be documented
  - Note: I think [the existing config text](https://github.com/okkays/flask-security/blob/ffbff90a3f3c7b91a2e1dbc0921a5d15aeb0e02c/docs/configuration.rst?plain=1#L239-L246) captures this with: `Set the base domain for checking allowable redirects.`
- [x] **(N/A)** Make sure any new public API methods have good docstrings, are picked up by the api.rst document, and are exposed in __init__.py if appropriate.
- [x] Add appropriate info to CHANGES.rst

Ran these; didn't see any errors in them or precommits, so hopefully I don't waste any CI time 🤞:

```
$ pip install -r requirements/tests.txt
$ pip install -e .
$ sphinx-build docs docs/_build/html
$ tox -e compile_catalog
$ pytest tests
$ pre-commit run --all-files

$ tox
$ tox -e style
```