### PR TITLE
Apply `SECURITY_CACHE_CONTROL` only to Flask-Security endpoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Fixes
   username, identity, name, phone, refresh token, recovery/2FA code, ...) to a
   non-string value (e.g. a dict), which used to crash with an unhandled
   ``TypeError`` instead of failing validation cleanly. (miettal)
+- (:issue:`1263`) :py:data:`SECURITY_CACHE_CONTROL` directives were added to every
+  application response instead of just responses from Flask-Security endpoints
+  as documented.
 
 
 Docs and Chores

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -147,6 +147,9 @@ These configuration keys are used globally across all features.
         This default setting is to ensure that out of the box, Flask-Security responses
         which might contain sensitive information aren't cached.
         Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#cache_directives.
+        Responses from your own application endpoints (including endpoints protected with
+        a Flask-Security decorator, such as token-authenticated APIs) are not modified -
+        set the Cache-Control header there yourself if needed.
 
     .. note::
         Flask itself adds the 'Vary: Cookie' header to all responses that access the session (cookie).

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1927,7 +1927,7 @@ class Security:
             if self.oauthglue:
                 self.oauthglue._create_blueprint(app, bp)
             if cv("CACHE_CONTROL", app=app):
-                bp.after_app_request(add_cache_control)
+                bp.after_request(add_cache_control)
             app.register_blueprint(bp)
             app.context_processor(_context_processor)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1373,3 +1373,12 @@ def test_override_cache_control(app, client_nc):
 def test_no_cache_control(app, client_nc):
     response = json_authenticate(client_nc)
     assert "Cache-Control" not in response.headers
+
+
+def test_cache_control_not_on_app_endpoints(app, client):
+    # SECURITY_CACHE_CONTROL applies to Flask-Security endpoints only -
+    # responses from application endpoints must not be touched.
+    response = client.get("/login")
+    assert response.cache_control.no_store
+    response = client.get("/")
+    assert "Cache-Control" not in response.headers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,8 +96,9 @@ def verify_token(client_nc, token, status=None):
         "/token",
         headers={"Content-Type": "application/json", "Authentication-Token": token},
     )
-    assert response.cache_control.private
-    assert response.cache_control.no_store
+    # /token is an application endpoint - SECURITY_CACHE_CONTROL must not
+    # be applied to it (see issue #1263).
+    assert "Cache-Control" not in response.headers
     if status:
         assert response.status_code == status
     else:


### PR DESCRIPTION
closes #1263

Only put the `SECURITY_CACHE_CONTROL` headers on routes by the fs bp instead of all routes.