### PR TITLE
Fix inverted is_locked logic - backport to 5.8.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ Fixes
 - (:issue:`1263`) :py:data:`SECURITY_CACHE_CONTROL` directives were added to every
   application response instead of just responses from Flask-Security endpoints
   as documented. (Ceirced)
+- (:issue:`1212`) Newly introduced :py:meth:`.UserMixin.is_locked` logic is inverted.
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+- The fix for the inverted `is_locked` logic will require any application using it
+  to invert their logic.
 
 
 Version 5.8.1

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1214,7 +1214,7 @@ class UserMixin(BaseUserMixin):
 
         .. versionadded:: 5.8.0
         """
-        return True
+        return False
 
 
 class WebAuthnMixin:

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -463,7 +463,7 @@ class ForgotPasswordForm(Form, UserEmailFormMixin):
         if not self.user.is_active:
             self.email.errors.append(get_message("DISABLED_ACCOUNT")[0])
             return False
-        if not self.user.is_locked(self.email.errors):
+        if self.user.is_locked(self.email.errors):
             return False
         self.requires_confirmation = requires_confirmation(self.user)
         if self.requires_confirmation:
@@ -495,7 +495,7 @@ class PasswordlessLoginForm(Form):
         if not self.user.is_active:
             self.email.errors.append(get_message("DISABLED_ACCOUNT")[0])
             return False
-        if not self.user.is_locked(self.email.errors):
+        if self.user.is_locked(self.email.errors):
             return False
         return True
 
@@ -620,7 +620,7 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
         if not self.user.is_active:
             self.ifield.errors.append(get_message("DISABLED_ACCOUNT")[0])
             return False
-        if not self.user.is_locked(self.ifield.errors):
+        if self.user.is_locked(self.ifield.errors):
             return False
         if self.requires_confirmation:
             self.ifield.errors.append(get_message("CONFIRMATION_REQUIRED")[0])

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -137,7 +137,7 @@ def oauthresponse(name: str) -> ResponseValue:
         assert oauth_provider is not None
         return oauth_provider.oauth_response_failure("LOGIN_ERROR_VIEW", e)
     form_error: list[str] = []
-    if user and user.is_active and user.is_locked(form_error):
+    if user and user.is_active and not user.is_locked(form_error):
         after_this_request(view_commit)
         next_loc = session.pop("fs_oauth_next", None)
         response = _security.two_factor_plugins.tf_enter(

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -142,7 +142,7 @@ def _us_common_validate(form):
     if not form.user.is_active:
         form.identity.errors.append(get_message("DISABLED_ACCOUNT")[0])
         return False
-    if not form.user.is_locked(form.identity.errors):
+    if form.user.is_locked(form.identity.errors):
         return False
     return True
 

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -331,7 +331,7 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
 
         if not self.user.is_active:
             self.credential.errors.append(get_message("DISABLED_ACCOUNT")[0])
-        if not self.user.is_locked(self.credential.errors):
+        if self.user.is_locked(self.credential.errors):
             return False
 
         verify = partial(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -483,15 +483,15 @@ def test_unset_password(client, get_message):
     assert get_message("PASSWORD_NOT_PROVIDED") in response.data
 
 
-def _allowed(self, form_error):
+def _locked(self, form_error):
     if self.email == "gal@lp.com":
         form_error.append("You are not allowed to do that")
-        return False
-    return True
+        return True
+    return False
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
-def test_override_user_allowed(app, client, get_message):
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
+def test_override_user_locked(app, client, get_message):
     data = dict(email="jill@lp.com", password="password")
     response = client.post("/login", json=data)
     assert response.status_code == 200
@@ -506,9 +506,9 @@ def test_override_user_allowed(app, client, get_message):
     ]
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
 @pytest.mark.settings(return_generic_responses=True)
-def test_override_user_allowed_gr(app, client, get_message):
+def test_override_user_locked_gr(app, client, get_message):
     data = dict(email="gal@lp.com", password="password")
     response = client.post("/login", json=data)
     assert response.status_code == 400

--- a/tests/test_oauthglue.py
+++ b/tests/test_oauthglue.py
@@ -256,16 +256,16 @@ def test_email_not_identity(app, sqlalchemy_datastore, get_message):
     )
 
 
-def _allowed(self, form_error):
+def _locked(self, form_error):
     if self.email == "gal@lp.com":
         form_error.append("You are not allowed to do that")
-        return False
-    return True
+        return True
+    return False
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
 @pytest.mark.settings(oauth_enable=True)
-def test_override_user_allowed(app, sqlalchemy_datastore, get_message):
+def test_override_user_locked(app, sqlalchemy_datastore, get_message):
     init_app_with_options(
         app,
         sqlalchemy_datastore,

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -216,15 +216,15 @@ def test_deprecated(app, sqlalchemy_datastore):
         assert any("passwordless feature" in str(m.message) for m in w)
 
 
-def _allowed(self, form_error):
+def _locked(self, form_error):
     if self.email == "gal@lp.com":
         form_error.append("You are not allowed to do that")
-        return False
-    return True
+        return True
+    return False
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
-def test_override_user_allowed(app, client, get_message):
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
+def test_override_user_locked(app, client, get_message):
     response = client.post("/login", json=dict(email="gal@lp.com"))
     assert response.status_code == 400
     assert response.json["response"]["errors"] == ["You are not allowed to do that"]

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -681,15 +681,15 @@ def test_generic_with_extra(app, sqlalchemy_datastore):
     assert len(flashes) == 0
 
 
-def _allowed(self, form_error):
+def _locked(self, form_error):
     if self.email == "gal@lp.com":
         form_error.append("You are not allowed to do that")
-        return False
-    return True
+        return True
+    return False
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
-def test_override_user_allowed(app, client, get_message):
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
+def test_override_user_locked(app, client, get_message):
     response = client.post("/reset", json=dict(email="gal@lp.com"))
     assert response.status_code == 400
     assert response.json["response"]["errors"] == ["You are not allowed to do that"]
@@ -1064,8 +1064,8 @@ def test_ur_confirmation_error_redirect(app, client):
 
 
 @pytest.mark.username_recovery()
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
-def test_ur_override_user_allowed(app, client, get_message):
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
+def test_ur_override_user_locked(app, client, get_message):
     response = client.post("/recover-username", json=dict(email="gal@lp.com"))
     assert response.status_code == 400
     assert response.json["response"]["errors"] == ["You are not allowed to do that"]

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -2424,15 +2424,15 @@ def test_override_tf_required(app, client, get_message):
     assert not response.json["response"]["tf_required"]
 
 
-def _allowed(self, form_error):
+def _locked(self, form_error):
     if self.email == "gal@lp.com":
         form_error.append("You are not allowed to do that")
-        return False
-    return True
+        return True
+    return False
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
-def test_override_user_allowed(app, client, get_message):
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
+def test_override_user_locked(app, client, get_message):
     data = dict(identity="jill@lp.com", passcode="password")
     response = client.post("/us-signin", json=data)
     assert response.status_code == 200
@@ -2447,9 +2447,9 @@ def test_override_user_allowed(app, client, get_message):
     ]
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
 @pytest.mark.settings(return_generic_responses=True)
-def test_override_user_allowed_gr(app, client, get_message):
+def test_override_user_locked_gr(app, client, get_message):
     data = dict(identity="gal@lp.com", passcode="password")
     response = client.post("/us-signin", json=data)
     assert response.status_code == 400

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -740,18 +740,18 @@ def test_disabled_account(app, client, get_message):
     )
 
 
-def _allowed(self, form_error):
+def _locked(self, form_error):
     if self.email == "gal@lp.com":
         from flask import request
 
         if request.endpoint != "security.login":
             form_error.append("You are not allowed to do that")
-            return False
-    return True
+            return True
+    return False
 
 
-@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_allowed))
-def test_override_user_allowed(app, client, get_message):
+@pytest.mark.app_settings(TESTING_USER_INJECT=dict(is_locked=_locked))
+def test_override_user_locked(app, client, get_message):
     authenticate(client, email="gal@lp.com")
     register_options, response_url = _register_start_json(
         client, name="testr3", usage="first"


### PR DESCRIPTION
At the last minute I changed is_allowed to is_locked - but didn't change the logic implementation - so is_locked was returning 'True' by default - but all was working since the uses of is_locked were also inverted.

closes #1212