### PR TITLE
Include next on verify and us-verify forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Features & Improvements
 
 Fixes
 +++++
+- (:issue:`1108`) ``/verify`` and ``/us-verify`` forms now include the optional
+  ``next`` field so form-posted redirect URLs are validated and preserved.
 - (:issue:`1212`) Newly introduced :py:meth:`.UserMixin.is_locked` logic is inverted.
 - (:pr:`1234`) Fix for GHSA-f66q-9rf6-8795 - WebAuthn reauthentication freshness bypass. (tonghuaroot)
 - (:issue:`1244`) Fix login form remember me checkbox.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2401,6 +2401,11 @@ components:
         password:
           type: string
           description: Password
+        next:
+          type: string
+          description: >
+            Redirect URL. Overrides SECURITY_POST_VERIFY_VIEW. Invalid
+            (e.g. external) URLs are rejected with INVALID_REDIRECT.
     Register:
       type: object
       required: [email, password]
@@ -2518,6 +2523,11 @@ components:
         passcode:
           type: string
           description: password or code
+        next:
+          type: string
+          description: >
+            Redirect URL. Overrides SECURITY_POST_VERIFY_VIEW. Invalid
+            (e.g. external) URLs are rejected with INVALID_REDIRECT.
     UsSigninVerifySendCode:
       type: object
       required: [chosen_method]

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -739,7 +739,7 @@ class LogoutForm(Form):
         return True
 
 
-class VerifyForm(Form, PasswordFormMixin):
+class VerifyForm(Form, PasswordFormMixin, NextFormMixin):
     """The verify authentication form"""
 
     submit = SubmitField(get_form_field_label("verify_password"))
@@ -747,6 +747,8 @@ class VerifyForm(Form, PasswordFormMixin):
     def __init__(self, *args: t.Any, user: UserMixin, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         self.user: UserMixin = user
+        if request and not self.next.data:
+            self.next.data = request.args.get("next", "")
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):  # pragma: no cover

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -284,10 +284,15 @@ class UnifiedSigninForm(_UnifiedPassCodeForm, NextFormMixin):
         return True
 
 
-class UnifiedVerifyForm(_UnifiedPassCodeForm):
+class UnifiedVerifyForm(_UnifiedPassCodeForm, NextFormMixin):
     """Verify authentication.
     This is for freshness 'reauthentication' required.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if request and not self.next.data:
+            self.next.data = request.args.get("next", "")
 
     def validate(self, **kwargs: t.Any) -> bool:
         self.user = current_user

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1268,6 +1268,28 @@ def test_verify_next(app, client, get_message):
     )
     assert response.location == "http://localhost/mynext"
 
+    # form.next (no query param)
+    response = client.post(
+        "/auth/",
+        data=dict(password="password", next="http://localhost/formnext"),
+        follow_redirects=False,
+    )
+    assert response.location == "http://localhost/formnext"
+
+    # GET should copy ?next into the hidden form field
+    response = client.get("/auth/?next=/profile")
+    assert b'name="next"' in response.data
+    assert b'value="/profile"' in response.data
+
+    # invalid form.next is rejected with INVALID_REDIRECT
+    response = client.post(
+        "/auth/",
+        data=dict(password="password", next="http://evil.example/phish"),
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert get_message("INVALID_REDIRECT") in response.data
+
 
 @pytest.mark.webauthn(webauthn_util_cls=HackWebauthnUtil)
 def test_verify_wan(app, client, get_message):

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1323,6 +1323,31 @@ def test_next(app, client, get_message):
     assert "/post_login" in response.location
 
 
+def test_us_verify_form_next(app, client, get_message):
+    # /us-verify should honor form.next and validate it (issue #1108)
+    set_email(app)
+    us_authenticate(client)
+
+    response = client.get("/us-verify?next=/profile")
+    assert b'name="next"' in response.data
+    assert b'value="/profile"' in response.data
+
+    response = client.post(
+        "/us-verify",
+        data=dict(passcode="password", next="/profile"),
+        follow_redirects=False,
+    )
+    assert check_location(app, response.location, "/profile")
+
+    response = client.post(
+        "/us-verify",
+        data=dict(passcode="password", next="http://evil.example/phish"),
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert get_message("INVALID_REDIRECT") in response.data
+
+
 @pytest.mark.registerable()
 @pytest.mark.confirmable()
 @pytest.mark.settings(requires_confirmation_error_view="/confirm")


### PR DESCRIPTION
Fixes #1108

`/verify` and `/us-verify` already honor a `?next=` query argument, but their forms did not include `NextFormMixin`. A `next` value posted with the form was therefore not copied into the hidden field and was not run through `validate_redirect_url`.

This adds the mixin (and the same `request.args` fallback used by login/register) to `VerifyForm` and `UnifiedVerifyForm`, so form-posted redirect URLs are preserved and invalid ones get `INVALID_REDIRECT`.