### PR TITLE
Convert usernameUtil to use new input_svn method.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ Version 5.9.0
 
 Released TBD
 
+This release adds support for refresh tokens (finally!). In addition there are
+several configuration changes that try to align Flask-Security with latest
+best-practices.
+
+Please read these notes carefully - in particular the change to the default auth
+token lifetime might severely impact some applications.
+
 Features & Improvements
 +++++++++++++++++++++++
 - (:issue:`1206`) Add support for refresh tokens. See :ref:`token_topic`
@@ -21,7 +28,10 @@ Features & Improvements
 - (:issue:`1153`) Enable localization of %(within)s variables using humanize
 - (:pr:`1249`) Add link expiration to confirmation and reset password email templates.
 - (:issue:`536` Add template path configuration variables for all email templates.
-- (:issue:`1254`) Webauthn/passkey name input value is now sanitized and normalized.
+- (:issue:`1254`) Webauthn/passkey name input value is now sanitized and normalized. A new utility method
+  :py:meth:`flask_security.input_svn` is now used and is available for applications to use.
+- (:pr:`xxx`) Username validation and normalization now uses the new :py:meth:`flask_security.input_svn` utility. This has some
+  backwards compatibility concerns - see below.
 - (:pr:`1259`) Allow redirects to exactly :py:data:`SECURITY_REDIRECT_BASE_DOMAIN` by adding '.' to :py:data:`SECURITY_REDIRECT_ALLOWED_SUBDOMAINS`.
 
 Fixes
@@ -70,11 +80,20 @@ Backwards Compatibility Concerns
   :py:data:`SECURITY_USERNAME_ENABLE` you must now install ``nh3`` (included in the
   ``common`` extra) rather than ``bleach``.
 - Webauthn names are now sanitized, validated for certain allowable characters
-  and normalized. It is possible that some existing names would now be
+  and normalized. It is possible that some existing names could now be
   considered illegal and won't match (so can't be deleted via API). The allowed
   character categories can be set with :py:data:`SECURITY_WAN_NAME_ALLOWED_CHARS`.
   The module ``nh3`` is used to sanitize input - the application must have that
   package installed.
+- Username form input now uses the newer input sanitization and normalization utility class.
+  The configuration variable ``SECURITY_USERNAME_NORMALIZE_FORM`` has been replaced
+  with :py:data:`SECURITY_INPUT_NORMALIZE_FORM` (default is still "NKFD"). There is a new configuration
+  option :py:data:`SECURITY_USERNAME_ALLOWED_CHARS` which can be used to change
+  which unicode character classes are permitted in the username for validation
+  (the default is ``["L", "N"]`` which is the same as before).
+  The error message ``SECURITY_MSG_USERNAME_ILLEGAL_CHARACTERS`` has been replaced with
+  ``SECURITY_MSG_INVALID_INPUT``.
+- The UsernameUtil.check_username method has been removed.
 
 Notes
 +++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -909,6 +909,8 @@ Login/Logout
     returned (if request was a form post). For a JSON request, a 400 response will
     be returned.
 
+    Default: ``False``
+
     .. danger::
         Be sure to not configure ``"GET"`` as an accepted method since that is not
         CSRF protected.
@@ -1046,6 +1048,13 @@ Registerable
 
     .. versionadded:: 4.1.0
 
+.. py:data:: SECURITY_USERNAME_ALLOWED_CHARS
+
+    Define which unicode categories are used to validate usernames.
+
+    Default: ``["L", "N"]``
+
+    .. versionadded:: 5.9.0
 
 .. py:data:: SECURITY_USERNAME_MIN_LENGTH
 
@@ -1060,14 +1069,6 @@ Registerable
     Maximum length of a username.
 
     Default: ``32``
-
-    .. versionadded:: 4.1.0
-
-.. py:data:: SECURITY_USERNAME_NORMALIZE_FORM
-
-    Usernames, by default, are normalized using the Python unicodedata.normalize() method.
-
-    Default: ``"NFKD"``
 
     .. versionadded:: 4.1.0
 
@@ -2162,6 +2163,9 @@ Additional relevant configuration variables:
 
 Social Login (OAuth)
 --------------------
+    This integrates Flask-Security with authlib. Be sure to specify authlib in
+    your dependency file.
+
     .. versionadded:: 5.1.0
 
 .. py:data:: SECURITY_OAUTH_ENABLE
@@ -2261,7 +2265,7 @@ Refresh Tokens
     Default: ``timedelta(days=90)``
 .. py:data:: SECURITY_REFRESH_TOKEN_MAX_IDLE
 
-    Specifies a timedelta used to compute the date the refresh token will
+    Specifies a timedelta used to compute the date the refresh token will be
     considered expired due to non-use.
 
     Default: ``timedelta(days=7)``
@@ -2273,7 +2277,7 @@ Refresh Tokens
     Default: ``True``
 .. py:data:: SECURITY_REFRESH_TOKEN_CLEANUP_REVOKED
 
-    If True then expired refresh tokens database trackers will be deleted
+    If True then revoked refresh tokens database trackers will be deleted
     whenever the user creates a new one (re-authenticates)
 
     Default: ``False``
@@ -2497,7 +2501,6 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_USER_DOES_NOT_EXIST``
 * ``SECURITY_MSG_USERNAME_CHANGE``
 * ``SECURITY_MSG_USERNAME_INVALID_LENGTH``
-* ``SECURITY_MSG_USERNAME_ILLEGAL_CHARACTERS``
 * ``SECURITY_MSG_USERNAME_DISALLOWED_CHARACTERS``
 * ``SECURITY_MSG_USERNAME_NOT_PROVIDED``
 * ``SECURITY_MSG_USERNAME_ALREADY_ASSOCIATED``
@@ -2506,6 +2509,7 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_WEBAUTHN_NAME_REQUIRED``
 * ``SECURITY_MSG_WEBAUTHN_NAME_INUSE``
 * ``SECURITY_MSG_WEBAUTHN_NAME_NOT_FOUND``
+* ``SECURITY_MSG_WEBAUTHN_NAME_DISALLOWED_CHARACTERS``
 * ``SECURITY_MSG_WEBAUTHN_CREDENTIAL_DELETED``
 * ``SECURITY_MSG_WEBAUTHN_REGISTER_SUCCESSFUL``
 * ``SECURITY_MSG_WEBAUTHN_CREDENTIAL_ID_INUSE``

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -405,9 +405,9 @@ _default_config: dict[str, t.Any] = {
     "JOIN_USER_ROLES": True,
     "USERNAME_ENABLE": False,
     "USERNAME_REQUIRED": False,
+    "USERNAME_ALLOWED_CHARS": ["L", "N"],
     "USERNAME_MIN_LENGTH": 4,
     "USERNAME_MAX_LENGTH": 32,
-    "USERNAME_NORMALIZE_FORM": "NFKD",
     "WEBAUTHN": False,
     "WAN_CHALLENGE_BYTES": None,  # uses system default
     "WAN_POST_REGISTER_VIEW": ".wan_register",  # endpoint or URL
@@ -626,10 +626,6 @@ _default_messages = {
         ),
         "error",
     ),
-    "USERNAME_ILLEGAL_CHARACTERS": (
-        _("Username contains illegal characters"),
-        "error",
-    ),
     "USERNAME_DISALLOWED_CHARACTERS": (
         _("Username can contain only letters and numbers"),
         "error",
@@ -653,6 +649,13 @@ _default_messages = {
     ),
     "WEBAUTHN_NAME_NOT_FOUND": (
         _("%(name)s not registered with current user."),
+        "error",
+    ),
+    "WEBAUTHN_NAME_DISALLOWED_CHARACTERS": (
+        _(
+            "Passkey nicknames can contain only letters, numbers,"
+            " and limited punctuation."
+        ),
         "error",
     ),
     "WEBAUTHN_CREDENTIAL_DELETED": (

--- a/flask_security/username_util.py
+++ b/flask_security/username_util.py
@@ -4,7 +4,7 @@ flask_security.username_util
 
 Utility class providing methods for validating and normalizing usernames.
 
-:copyright: (c) 2020-2025 by J. Christopher Wagner (jwag).
+:copyright: (c) 2020-2026 by J. Christopher Wagner (jwag).
 :license: MIT, see LICENSE for more details.
 
 """
@@ -12,11 +12,11 @@ Utility class providing methods for validating and normalizing usernames.
 from __future__ import annotations
 
 import typing as t
-import unicodedata
 
 from .utils import (
     config_value as cv,
     get_message,
+    input_svn,
 )
 
 if t.TYPE_CHECKING:  # pragma: no cover
@@ -40,39 +40,18 @@ class UsernameUtil:
         """
         pass
 
-    def check_username(self, username: str) -> str | None:
-        """
-        Given a username - check for allowable character categories.
-        This is broken out so applications can easily override this method only.
-
-        By default, allow letters and numbers (using unicodedata.category).
-
-        Returns None if allowed, error message if not allowed.
-        """
-        cats = [unicodedata.category(c)[0] for c in username]
-        if any([cat not in ["L", "N"] for cat in cats]):
-            return get_message("USERNAME_DISALLOWED_CHARACTERS")[0]
-        return None
-
-    def normalize(self, username: str) -> str:
+    def normalize(self, username: str) -> str | None:
         """
         Given an input username - return a clean (using nh3) and normalized
         (using Python's unicodedata.normalize()) version.
         Must be called in app context and uses
-        :py:data:`SECURITY_USERNAME_NORMALIZE_FORM` config variable.
+        :py:data:`SECURITY_INPUT_NORMALIZE_FORM` and
+        :py:data:`SECURITY_USERNAME_ALLOWED_CHARS` config variables.
         """
-        import nh3
-
-        if not username:
-            return ""
-
-        username = nh3.clean(username.strip(), tags=set())
-        if not username:
-            return ""
-        cf = cv("USERNAME_NORMALIZE_FORM")
-        if cf:
-            return unicodedata.normalize(cf, username)
-        return username
+        reason, clean_input = input_svn(
+            username, cv("USERNAME_ALLOWED_CHARS"), cv("INPUT_NORMALIZE_FORM")
+        )
+        return clean_input
 
     def validate(self, username: str) -> tuple[str | None, str | None]:
         """
@@ -80,28 +59,29 @@ class UsernameUtil:
         Called in app/request context.
 
         The username is first validated then normalized.
-        Input is restricted/validated via a call to check_username.
         Return value is a tuple (msg, normalized_username). msg will be None if
         properly validated.
 
         It is important that None be returned if data is an empty string since
         otherwise DBs will complain since the field is unique/nullable.
         """
-        import nh3
-
         if not username:
             return None, None
-        uclean = nh3.clean(username.strip(), tags=set())
-        if uclean != username:
-            return get_message("USERNAME_ILLEGAL_CHARACTERS")[0], None
-
-        msg = self.check_username(uclean)
-        if msg:
-            return msg, None
-
-        unorm = self.normalize(username)
+        reason, clean_input = input_svn(
+            username, cv("USERNAME_ALLOWED_CHARS"), cv("INPUT_NORMALIZE_FORM")
+        )
+        if clean_input is None:
+            msg = (
+                "USERNAME_DISALLOWED_CHARACTERS"
+                if reason == "unallowed"
+                else "INVALID_INPUT"
+            )
+            return get_message(msg)[0], None
         umin = cv("USERNAME_MIN_LENGTH")
         umax = cv("USERNAME_MAX_LENGTH")
-        if len(unorm) < umin or len(unorm) > umax:
-            return get_message("USERNAME_INVALID_LENGTH", min=umin, max=umax)[0], unorm
-        return None, unorm
+        if len(clean_input) < umin or len(clean_input) > umax:
+            return (
+                get_message("USERNAME_INVALID_LENGTH", min=umin, max=umax)[0],
+                clean_input,
+            )
+        return None, clean_input

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -1500,17 +1500,20 @@ def handle_already_auth(form, payload=None):
 
 def input_svn(
     value: str,
-    allowed_categories: list[str],
+    allowed_categories: list[str] | None,
     normalize_form: t.Literal["NFC", "NFD", "NFKC", "NFKD"] | None,
-) -> str | None:
+) -> t.Tuple[t.Literal["ok", "illegal", "unallowed"], str | None]:
     """
     Used to sanitize, validate, and normalize (user/form) input
 
-    allowed_categories: list of allowed categories (using unicodedata.category()).
+    allowed_categories: list of allowed categories (input to unicodedata.category()).
 
-    normalize_form: input to unicodedata.normalize() (or None)
+    normalize_form: input to unicodedata.normalize().
 
-    Returns None if error (illegal characters)
+    Returns a tuple of ("reason", cleaned_input)
+    If cleaned_input is None, "reason" will be why. The "unallowed" response
+    is dependent on the input 'allowed_categories' which normally is from a config
+    variable.
 
     .. versionadded:: 5.9.0
     """
@@ -1518,10 +1521,11 @@ def input_svn(
 
     sanitized = nh3.clean(value.strip(), tags=set())
     if sanitized != value.strip():
-        return None
-    cats = [unicodedata.category(c)[0] for c in sanitized]
-    if any([cat not in allowed_categories for cat in cats]):
-        return None
+        return "illegal", None
+    if allowed_categories:
+        cats = [unicodedata.category(c)[0] for c in sanitized]
+        if any([cat not in allowed_categories for cat in cats]):
+            return "unallowed", None
     if normalize_form:
-        return unicodedata.normalize(normalize_form, sanitized)
-    return sanitized
+        return "ok", unicodedata.normalize(normalize_form, sanitized)
+    return "ok", sanitized

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -161,23 +161,32 @@ class WebauthnUtil:
 
     def name_svn(self, value: str) -> tuple[str | None, str | None]:
         """
-        Sanitize, validate, and normalize form input
+        Sanitize, validate, and normalize form input.
 
         Return value is a tuple (msg, clean_value). msg will be None if
         properly validated.
+        The config variable :py:data:`SECURITY_WAN_NAME_ALLOWED_CHARS` specifies
+        which unicode character classes are allowed (if None then all are allowed).
+
+        The config variable :py:data:`SECURITY_INPUT_NORMALIZE_FORM` specifies
+        the input to unicode normalization (if None then no normalization is performed).
 
         For webauthn names, allow letters, numbers, and some punctuation.
         """
-        clean_input = input_svn(
+        reason, clean_input = input_svn(
             value, cv("WAN_NAME_ALLOWED_CHARS"), cv("INPUT_NORMALIZE_FORM")
         )
         if clean_input is None:
-            return get_message("INVALID_INPUT")[0], None
+            msg = (
+                "WEBAUTHN_NAME_DISALLOWED_CHARACTERS"
+                if reason == "unallowed"
+                else "INVALID_INPUT"
+            )
+            return get_message(msg)[0], None
         if len(clean_input) > cv("WAN_NAME_MAX_LENGTH"):
+            msg = "INVALID_INPUT_LENGTH"
             return (
-                get_message("INVALID_INPUT_LENGTH", length=cv("WAN_NAME_MAX_LENGTH"))[
-                    0
-                ],
+                get_message(msg, length=cv("WAN_NAME_MAX_LENGTH"))[0],
                 None,
             )
         return None, clean_input

--- a/tests/test_change_username.py
+++ b/tests/test_change_username.py
@@ -241,9 +241,10 @@ def test_custom_post_change_view(client):
 
 def test_my_validator(app, sqlalchemy_datastore):
     class MyUsernameUtil(UsernameUtil):
-        def check_username(self, username):
+        def validate(self, username):
             if username == "nowayjose":
-                return "Are you crazy?"
+                return "Are you crazy?", None
+            return username, None
 
     init_app_with_options(
         app,
@@ -287,7 +288,7 @@ def test_username_normalize(app, client):
     assert response.status_code == 200
 
 
-@pytest.mark.settings(username_normalize_form=None, username_enable=True)
+@pytest.mark.settings(input_normalize_form=None, username_enable=True)
 def test_username_no_normalize(app, client):
     """Verify that can log in with original but not normalized if have
     disabled normalization

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -721,7 +721,7 @@ def test_username_errors(app, client, get_message):
     )
     assert response.status_code == 400
     assert (
-        get_message("USERNAME_ILLEGAL_CHARACTERS")
+        get_message("INVALID_INPUT")
         == response.json["response"]["field_errors"]["username"][0].encode()
     )
 
@@ -745,6 +745,23 @@ def test_username_errors(app, client, get_message):
         get_message("USERNAME_NOT_PROVIDED")
         == response.json["response"]["errors"][0].encode()
     )
+
+
+@pytest.mark.settings(
+    username_enable=True, username_required=True, username_allowed_chars=None
+)
+def test_username_anything_goes(app, client, get_message):
+    # allow app to allow any characters in a username
+    data = dict(
+        email="dude@lp.com",
+        username="hi there?",
+        password="awesome sunset",
+        password_confirm="awesome sunset",
+    )
+    response = client.post(
+        "/register", json=data, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 200
 
 
 def test_username_not_enabled(app, client, get_message):

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1895,7 +1895,7 @@ def test_name_clean(app, client, get_message):
     response = client.post("wan-register", json=dict(name=name, usage="secondary"))
     assert response.status_code == 400
     assert (
-        get_message("INVALID_INPUT")
+        get_message("WEBAUTHN_NAME_DISALLOWED_CHARACTERS")
         == response.json["response"]["field_errors"]["name"][0].encode()
     )
 


### PR DESCRIPTION
Add config option for allowed character classes for username validation (SECURITY_USERNAME_ALLOWED_CHARS)

Replace SECURITY_USERNAME_NORMALIZE_FORM with SECURITY_INPUT_NORMALIZE_FORM (same as webauthn)

Improve input_svn to differentiate between 'unallowed' chars and 'invalid' chars (the latter is the result of nh3.clean).