### PR TITLE
Reexport public interface names.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Features & Improvements
 +++++++++++++++++++++++
 - (:issue:`1206`) Add support for refresh tokens. See :ref:`token_topic`
 - (:pr:`1233`) Change :py:data:`SECURITY_TOKEN_MAX_AGE` from an int to a timedelta.
-  Also - change default from ``never expire`` to 15 minutes.
+  Also - *change default from ``never expire`` to 15 minutes*.
 - (:pr:`1235`) Change default :py:data:`SECURITY_LOGOUT_METHODS` to be just ``"POST"``
 - (:issue:`1228`) Change default ``csrf`` and ``tf_validity`` cookie config to ``secure=True``
 - (:issue:`1228`) The ``tf_validity`` cookie name is now configurable via :py:data:`SECURITY_TWO_FACTOR_VALIDITY_COOKIE_NAME`
@@ -48,6 +48,7 @@ Fixes
 - (:issue:`1263`) :py:data:`SECURITY_CACHE_CONTROL` directives were added to every
   application response instead of just responses from Flask-Security endpoints
   as documented.
+- (:issue:`1272`) Properly re-export public methods (using redundant symbol aliases).
 
 
 Docs and Chores
@@ -56,6 +57,7 @@ Docs and Chores
 - (:pr:`1240`) Remove deprecated get_token_status() and convert uses to check_and_get_token_status()
 - (:pr:`1252`) Replace ``bleach`` (deprecated/unmaintained) with ``nh3`` for username sanitization (tkfoss)
 - (:pr:`1273`) Improve translation tests to not use real french translations
+- (:pr:`1275`) Update Spanish and Catalan translations. (arielvb)
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,7 @@ nitpick_ignore = [
     ("py:class", "t.Callable"),
     ("py:class", "t.Any"),
     ("py:class", "timedelta"),
+    ("py:class", "wtforms.fields.core.Field"),
 ]
 autodoc_typehints = "description"
 # autodoc_mock_imports = ["flask_sqlalchemy"]

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -10,144 +10,149 @@ to Flask applications.
 :license: MIT, see LICENSE for more details.
 """
 
+from __future__ import annotations
+
 # flake8: noqa: F401
-from .changeable import admin_change_password
-from .change_email import ChangeEmailForm
-from .change_username import ChangeUsernameForm
+from .changeable import admin_change_password as admin_change_password
+from .change_email import ChangeEmailForm as ChangeEmailForm
+from .change_username import ChangeUsernameForm as ChangeUsernameForm
 from .core import (
-    Security,
-    RefreshTrackerMixin,
-    RoleMixin,
-    UserMixin,
-    WebAuthnMixin,
-    FormInfo,
-    current_user,
+    Security as Security,
+    RefreshTrackerMixin as RefreshTrackerMixin,
+    RoleMixin as RoleMixin,
+    UserMixin as UserMixin,
+    WebAuthnMixin as WebAuthnMixin,
+    FormInfo as FormInfo,
+    current_user as current_user,
 )
 from .datastore import (
-    FSQLALiteUserDatastore,
-    UserDatastore,
-    SQLAlchemyUserDatastore,
-    AsaList,
-    MongoEngineUserDatastore,
-    PeeweeUserDatastore,
-    SQLAlchemySessionUserDatastore,
+    FSQLALiteUserDatastore as FSQLALiteUserDatastore,
+    UserDatastore as UserDatastore,
+    SQLAlchemyUserDatastore as SQLAlchemyUserDatastore,
+    AsaList as AsaList,
+    MongoEngineUserDatastore as MongoEngineUserDatastore,
+    PeeweeUserDatastore as PeeweeUserDatastore,
+    SQLAlchemySessionUserDatastore as SQLAlchemySessionUserDatastore,
 )
 from .decorators import (
-    auth_token_required,
-    anonymous_user_required,
-    handle_csrf,
-    http_auth_required,
-    login_required,
-    roles_accepted,
-    roles_required,
-    auth_required,
-    permissions_accepted,
-    permissions_required,
-    unauth_csrf,
+    auth_token_required as auth_token_required,
+    anonymous_user_required as anonymous_user_required,
+    handle_csrf as handle_csrf,
+    http_auth_required as http_auth_required,
+    login_required as login_required,
+    roles_accepted as roles_accepted,
+    roles_required as roles_required,
+    auth_required as auth_required,
+    permissions_accepted as permissions_accepted,
+    permissions_required as permissions_required,
+    unauth_csrf as unauth_csrf,
 )
 from .forms import (
-    ChangePasswordForm,
-    ConfirmRegisterForm,
-    Form,
-    ForgotPasswordForm,
-    LoginForm,
-    LogoutForm,
-    PasswordlessLoginForm,
-    RegisterForm,
-    RegisterFormV2,
-    ResetPasswordForm,
-    SendConfirmationForm,
-    TwoFactorRescueForm,
-    TwoFactorSetupForm,
-    TwoFactorVerifyCodeForm,
-    unique_identity_attribute,
-    UsernameRecoveryForm,
-    VerifyForm,
+    ChangePasswordForm as ChangePasswordForm,
+    ConfirmRegisterForm as ConfirmRegisterForm,
+    Form as Form,
+    ForgotPasswordForm as ForgotPasswordForm,
+    LoginForm as LoginForm,
+    LogoutForm as LogoutForm,
+    PasswordlessLoginForm as PasswordlessLoginForm,
+    RegisterForm as RegisterForm,
+    RegisterFormV2 as RegisterFormV2,
+    ResetPasswordForm as ResetPasswordForm,
+    SendConfirmationForm as SendConfirmationForm,
+    TwoFactorRescueForm as TwoFactorRescueForm,
+    TwoFactorSetupForm as TwoFactorSetupForm,
+    TwoFactorVerifyCodeForm as TwoFactorVerifyCodeForm,
+    unique_identity_attribute as unique_identity_attribute,
+    UsernameRecoveryForm as UsernameRecoveryForm,
+    VerifyForm as VerifyForm,
 )
-from .mail_util import MailUtil, EmailValidateException
-from .oauth_glue import OAuthGlue
-from .oauth_provider import FsOAuthProvider
-from .password_util import PasswordUtil
-from .phone_util import PhoneUtil
+from .mail_util import (
+    MailUtil as MailUtil,
+    EmailValidateException as EmailValidateException,
+)
+from .oauth_glue import OAuthGlue as OAuthGlue
+from .oauth_provider import FsOAuthProvider as FsOAuthProvider
+from .password_util import PasswordUtil as PasswordUtil
+from .phone_util import PhoneUtil as PhoneUtil
 from .recovery_codes import (
-    MfRecoveryCodesUtil,
-    MfRecoveryForm,
-    MfRecoveryCodesForm,
+    MfRecoveryCodesUtil as MfRecoveryCodesUtil,
+    MfRecoveryForm as MfRecoveryForm,
+    MfRecoveryCodesForm as MfRecoveryCodesForm,
 )
-from .tokens import RefreshTokenForm
+from .tokens import RefreshTokenForm as RefreshTokenForm
 from .signals import (
-    change_email_confirmed,
-    change_email_instructions_sent,
-    confirm_instructions_sent,
-    login_instructions_sent,
-    password_changed,
-    password_reset,
-    refresh_tracker_created,
-    refresh_tracker_revoked,
-    reset_password_instructions_sent,
-    tf_code_confirmed,
-    tf_profile_changed,
-    tf_security_token_sent,
-    tf_disabled,
-    user_authenticated,
-    user_failed_authn,
-    user_unauthenticated,
-    user_confirmed,
-    user_registered,
-    user_not_registered,
-    username_recovery_email_sent,
-    username_changed,
-    us_security_token_sent,
-    us_profile_changed,
-    wan_deleted,
-    wan_registered,
+    change_email_confirmed as change_email_confirmed,
+    change_email_instructions_sent as change_email_instructions_sent,
+    confirm_instructions_sent as confirm_instructions_sent,
+    login_instructions_sent as login_instructions_sent,
+    password_changed as password_changed,
+    password_reset as password_reset,
+    refresh_tracker_created as refresh_tracker_created,
+    refresh_tracker_revoked as refresh_tracker_revoked,
+    reset_password_instructions_sent as reset_password_instructions_sent,
+    tf_code_confirmed as tf_code_confirmed,
+    tf_profile_changed as tf_profile_changed,
+    tf_security_token_sent as tf_security_token_sent,
+    tf_disabled as tf_disabled,
+    user_authenticated as user_authenticated,
+    user_failed_authn as user_failed_authn,
+    user_unauthenticated as user_unauthenticated,
+    user_confirmed as user_confirmed,
+    user_registered as user_registered,
+    user_not_registered as user_not_registered,
+    username_recovery_email_sent as username_recovery_email_sent,
+    username_changed as username_changed,
+    us_security_token_sent as us_security_token_sent,
+    us_profile_changed as us_profile_changed,
+    wan_deleted as wan_deleted,
+    wan_registered as wan_registered,
 )
-from .totp import Totp
-from .twofactor import tf_send_security_token
-from .tf_plugin import TwoFactorSelectForm
+from .totp import Totp as Totp
+from .twofactor import tf_send_security_token as tf_send_security_token
+from .tf_plugin import TwoFactorSelectForm as TwoFactorSelectForm
 from .unified_signin import (
-    UnifiedSigninForm,
-    UnifiedSigninSetupForm,
-    UnifiedSigninSetupValidateForm,
-    UnifiedVerifyForm,
-    us_send_security_token,
+    UnifiedSigninForm as UnifiedSigninForm,
+    UnifiedSigninSetupForm as UnifiedSigninSetupForm,
+    UnifiedSigninSetupValidateForm as UnifiedSigninSetupValidateForm,
+    UnifiedVerifyForm as UnifiedVerifyForm,
+    us_send_security_token as us_send_security_token,
 )
-from .username_util import UsernameUtil
+from .username_util import UsernameUtil as UsernameUtil
 from .utils import (
-    SmsSenderBaseClass,
-    SmsSenderFactory,
-    check_and_get_token_status,
-    check_and_update_authn_fresh,
-    get_hmac,
-    get_request_attr,
-    get_url,
-    hash_password,
-    input_svn,
-    login_user,
-    logout_user,
-    lookup_identity,
-    naive_utcnow,
-    password_breached_validator,
-    password_complexity_validator,
-    password_length_validator,
-    pwned,
-    send_mail,
-    transform_url,
-    uia_phone_mapper,
-    uia_email_mapper,
-    uia_username_mapper,
-    url_for_security,
-    verify_password,
-    verify_and_update_password,
+    SmsSenderBaseClass as SmsSenderBaseClass,
+    SmsSenderFactory as SmsSenderFactory,
+    check_and_get_token_status as check_and_get_token_status,
+    check_and_update_authn_fresh as check_and_update_authn_fresh,
+    get_hmac as get_hmac,
+    get_request_attr as get_request_attr,
+    get_url as get_url,
+    hash_password as hash_password,
+    input_svn as input_svn,
+    login_user as login_user,
+    logout_user as logout_user,
+    lookup_identity as lookup_identity,
+    naive_utcnow as naive_utcnow,
+    password_breached_validator as password_breached_validator,
+    password_complexity_validator as password_complexity_validator,
+    password_length_validator as password_length_validator,
+    pwned as pwned,
+    send_mail as send_mail,
+    transform_url as transform_url,
+    uia_phone_mapper as uia_phone_mapper,
+    uia_email_mapper as uia_email_mapper,
+    uia_username_mapper as uia_username_mapper,
+    url_for_security as url_for_security,
+    verify_password as verify_password,
+    verify_and_update_password as verify_and_update_password,
 )
 from .webauthn import (
-    WebAuthnRegisterForm,
-    WebAuthnRegisterResponseForm,
-    WebAuthnSigninForm,
-    WebAuthnSigninResponseForm,
-    WebAuthnDeleteForm,
-    WebAuthnVerifyForm,
+    WebAuthnRegisterForm as WebAuthnRegisterForm,
+    WebAuthnRegisterResponseForm as WebAuthnRegisterResponseForm,
+    WebAuthnSigninForm as WebAuthnSigninForm,
+    WebAuthnSigninResponseForm as WebAuthnSigninResponseForm,
+    WebAuthnDeleteForm as WebAuthnDeleteForm,
+    WebAuthnVerifyForm as WebAuthnVerifyForm,
 )
-from .webauthn_util import WebauthnUtil
+from .webauthn_util import WebauthnUtil as WebauthnUtil
 
 __version__ = "5.9.0"

--- a/flask_security/change_email.py
+++ b/flask_security/change_email.py
@@ -27,9 +27,9 @@ from .decorators import auth_required
 from .forms import (
     Form,
     UniqueEmailFormMixin,
-    build_form_from_request,
+    _build_form_from_request,
     form_errors_munge,
-    get_form_field_label,
+    _get_form_field_label,
 )
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
@@ -58,12 +58,11 @@ else:
     from flask import redirect
 
 
-class ChangeEmailForm(Form, UniqueEmailFormMixin):
-    submit = SubmitField(label=get_form_field_label("submit"))
+class ChangeEmailForm(UniqueEmailFormMixin, Form):
+    submit: SubmitField = SubmitField(label=_get_form_field_label("submit"))
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.existing_email_user = None
 
 
 @auth_required(
@@ -76,7 +75,7 @@ def change_email() -> ResponseValue:
     payload: dict[str, t.Any]
 
     form: ChangeEmailForm = t.cast(
-        ChangeEmailForm, build_form_from_request("change_email_form")
+        ChangeEmailForm, _build_form_from_request("change_email_form")
     )
 
     if form.validate_on_submit():

--- a/flask_security/change_username.py
+++ b/flask_security/change_username.py
@@ -36,8 +36,8 @@ from wtforms import Field, SubmitField
 from .decorators import auth_required
 from .forms import (
     Form,
-    build_form_from_request,
-    get_form_field_label,
+    _build_form_from_request,
+    _get_form_field_label,
 )
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
@@ -71,9 +71,9 @@ class ChangeUsernameForm(Form):
     """
 
     username: t.ClassVar[Field]
-    submit = SubmitField(label=get_form_field_label("submit"))
+    submit: SubmitField = SubmitField(label=_get_form_field_label("submit"))
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
 
 
@@ -87,7 +87,7 @@ def change_username() -> ResponseValue:
     payload: dict[str, t.Any]
 
     form: ChangeUsernameForm = t.cast(
-        ChangeUsernameForm, build_form_from_request("change_username_form")
+        ChangeUsernameForm, _build_form_from_request("change_username_form")
     )
 
     if form.validate_on_submit():

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -17,7 +17,7 @@ from werkzeug.local import LocalProxy
 from .quart_compat import get_quart_status
 
 from .changeable import admin_change_password
-from .forms import build_form
+from .forms import _build_form
 from .utils import (
     lookup_identity,
     get_identity_attributes,
@@ -157,7 +157,7 @@ def users_create(attributes, password, active, username):
         form_name = "confirm_register_form"
     else:
         form_name = "register_form"
-    form = build_form(
+    form = _build_form(
         form_name,
         meta={"csrf": False},
         **kwargs,
@@ -381,7 +381,7 @@ def users_change_password(user, password):
         raise click.UsageError("User not found.")
 
     kwargs = {"password": password, "password_confirm": password}
-    form = build_form("reset_password_form", meta={"csrf": False}, **kwargs)
+    form = _build_form("reset_password_form", meta={"csrf": False}, **kwargs)
     form.user = user_obj
 
     if form.validate():

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -56,9 +56,9 @@ from .forms import (
     TwoFactorRescueForm,
     UsernameRecoveryForm,
     VerifyForm,
-    build_username_field,
-    build_register_form,
-    build_login_form,
+    _build_username_field,
+    _build_register_form,
+    _build_login_form,
 )
 from .json import setup_json
 from .mail_util import MailUtil
@@ -114,7 +114,7 @@ from .utils import (
     url_for_security,
     verify_and_update_password,
 )
-from .views import create_blueprint, default_render_json
+from .views import _create_blueprint, default_render_json
 
 if t.TYPE_CHECKING:  # pragma: no cover
     import flask
@@ -956,7 +956,7 @@ class UserMixin(BaseUserMixin):
         webauthn: list[WebAuthnMixin]
         refresh_trackers: list[RefreshTrackerMixin]
 
-        def __init__(self, **kwargs): ...
+        def __init__(self, **kwargs: t.Any): ...
 
     def get_id(self) -> str:
         """Returns the user identification attribute. 'Alternative-token' for
@@ -1892,22 +1892,22 @@ class Security:
             # Add dynamic fields - probably overkill to check if these are our forms.
             fcls = self.forms["register_form"].cls
             if fcls and issubclass(fcls, RegisterFormMixin):
-                fcls.username = build_username_field(app)
+                fcls.username = _build_username_field(app)
             fcls = self.forms["confirm_register_form"].cls
             if fcls and issubclass(fcls, RegisterFormMixin):
-                fcls.username = build_username_field(app)
+                fcls.username = _build_username_field(app)
 
         fcls = self.forms["login_form"].cls
         if fcls and issubclass(fcls, LoginForm):
-            build_login_form(app=app, fcls=fcls)
+            _build_login_form(app=app, fcls=fcls)
 
         # new unified RegisterForm
         fcls = self.forms["register_form"].cls
         if fcls and issubclass(fcls, RegisterFormV2):
-            build_register_form(app=app, fcls=fcls)
+            _build_register_form(app=app, fcls=fcls)
         fcls = self.forms["change_username_form"].cls
         if fcls and issubclass(fcls, ChangeUsernameForm):
-            fcls.username = build_username_field(app=app)
+            fcls.username = _build_username_field(app=app)
 
         # initialize two-factor plugins. Note that each implementation likely
         # has its own feature flag which will control whether it is active or not.
@@ -1925,7 +1925,7 @@ class Security:
         # register our blueprint/endpoints
         bp = None
         if self.register_blueprint:
-            bp = create_blueprint(app, self, __name__)
+            bp = _create_blueprint(app, self, __name__)
             self.two_factor_plugins.create_blueprint(app, bp, self)
             if self.oauthglue:
                 self.oauthglue._create_blueprint(app, bp)

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -58,6 +58,13 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from flask_security import UserMixin
     from .tokens import RefreshTokenErrors, RefreshTrackerMixin
 
+    # a bit of a hack - typing mixins isn't supported very well
+    # we can't just use the BaseForm as the subclass for ValidateMixin since
+    # it will cause errors at import time.
+    _FsFormBase: type[BaseForm] = BaseForm
+else:
+    _FsFormBase = object
+
 _default_field_labels = {
     "authapp_method": _(
         "Set up using an authenticator app (e.g. google, lastpass, authy)"
@@ -105,7 +112,7 @@ _setup_methods_xlate = {
 }
 
 
-class ValidatorMixin:
+class ValidatorMixin(_FsFormBase):
     """
     This is called at import time - so there is no app context.
     Validators have state - namely self.message - but we need that
@@ -113,17 +120,17 @@ class ValidatorMixin:
     that until we are in an app context.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         # If the message is available from config[MSG_xx] then it can be xlated.
         # Otherwise, it will be used as is.
+        self.message: str | None = None
+        self._original_message: str | None = None
         if "message" in kwargs:
             self._original_message = kwargs["message"]
             del kwargs["message"]
-        else:
-            self._original_message = None
         super().__init__(*args, **kwargs)
 
-    def __call__(self, form, field):
+    def __call__(self, form: Form, field: Field) -> None:
         if self._original_message and (
             not is_lazy_string(self.message) and not self.message
         ):
@@ -136,41 +143,43 @@ class ValidatorMixin:
         return super().__call__(form, field)
 
 
-class EqualToLocalize(ValidatorMixin, EqualTo):
+class EqualToLocalize(ValidatorMixin, EqualTo):  # type: ignore[misc]
     pass
 
 
-class RequiredLocalize(ValidatorMixin, DataRequired):
+class RequiredLocalize(ValidatorMixin, DataRequired):  # type: ignore[misc]
     pass
 
 
-class LengthLocalize(ValidatorMixin, Length):
+class LengthLocalize(ValidatorMixin, Length):  # type: ignore[misc]
     pass
 
 
 class IsString(ValidatorMixin):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         if "message" not in kwargs:
             kwargs["message"] = "API_ERROR"
         super().__init__(*args, **kwargs)
 
-    def __call__(self, form, field):
+    def __call__(self, form: Form, field: Field) -> None:
         # Skip None so this can be combined with Optional().
         if field.data is not None and not isinstance(field.data, str):
+            assert self._original_message
             raise StopValidation(get_message(self._original_message)[0])
 
 
 # OTP/2FA code fields accept int,so these fields should use this validator
 # instead of IsString()
 class IsStringOrInt(ValidatorMixin):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         if "message" not in kwargs:
             kwargs["message"] = "API_ERROR"
         super().__init__(*args, **kwargs)
 
-    def __call__(self, form, field):
+    def __call__(self, form: Form, field: Field) -> None:
         # Skip None so this can be combined with Optional().
         if field.data is not None and not isinstance(field.data, (str, int)):
+            assert self._original_message
             raise StopValidation(get_message(self._original_message)[0])
 
 
@@ -183,10 +192,10 @@ class EmailValidation:
     Set to False - just normalize (for use with identity purposes).
     """
 
-    def __init__(self, *args, **kwargs):
-        self.verify = kwargs.get("verify", False)
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
+        self.verify: bool = kwargs.get("verify", False)
 
-    def __call__(self, form, field):
+    def __call__(self, form: Form, field: Field) -> None:
         if field.data is None:  # pragma: no cover
             raise ValidationError(get_message("EMAIL_NOT_PROVIDED")[0])
 
@@ -208,8 +217,8 @@ class EmailValidation:
             raise StopValidation(msg)
 
 
-email_required = RequiredLocalize(message="EMAIL_NOT_PROVIDED")
-password_required = RequiredLocalize(message="PASSWORD_NOT_PROVIDED")
+email_required: RequiredLocalize = RequiredLocalize(message="EMAIL_NOT_PROVIDED")
+password_required: RequiredLocalize = RequiredLocalize(message="PASSWORD_NOT_PROVIDED")
 
 
 def _local_xlate(text):
@@ -219,19 +228,21 @@ def _local_xlate(text):
     return localize_callback(text)
 
 
-def get_form_field_label(key):
+def _get_form_field_label(key: str) -> str:
     """This is called during import since form fields are declared as part of
     class. Thus, can't call 'localize_callback' until we need to actually
     translate/render form.
     """
-    return make_lazy_string(_local_xlate, _default_field_labels.get(key, ""))
+    return t.cast(
+        str, make_lazy_string(_local_xlate, _default_field_labels.get(key, ""))
+    )
 
 
-def get_form_field_xlate(txt):
-    return make_lazy_string(_local_xlate, txt)
+def get_form_field_xlate(txt: str) -> str:
+    return t.cast(str, make_lazy_string(_local_xlate, txt))
 
 
-def valid_user_email(form, field):
+def valid_user_email(form: Form, field: Field) -> None:
     # Verify email exists in DB - be sure to normalize first.
     # Side-effect - set form.user if field is valid
     uia_email = get_identity_attribute("email")
@@ -242,7 +253,7 @@ def valid_user_email(form, field):
         raise ValidationError(get_message("USER_DOES_NOT_EXIST")[0])
 
 
-def unique_user_email(form, field):
+def unique_user_email(form: UniqueEmailFormMixin, field: Field) -> None:
     # Verify email not already in DB
     # Assumes field value already normalized - email_validator does this.
     uia_email = get_identity_attribute("email")
@@ -254,14 +265,14 @@ def unique_user_email(form, field):
         raise ValidationError(msg)
 
 
-def username_validator(form, field):
+def username_validator(form: BaseForm, field: Field) -> None:
     # Side-effect - field.data is updated to normalized value.
     msg, field.data = _security.username_util.validate(field.data)
     if msg:
         raise ValidationError(msg)
 
 
-def unique_username(form, field):
+def _unique_username(form: Form, field: Field) -> None:
     # Verify username not already in DB
     # Assumes field value already normalized - username_validator does this.
     uia_username = get_identity_attribute("username")
@@ -274,7 +285,7 @@ def unique_username(form, field):
         raise ValidationError(msg)
 
 
-def unique_identity_attribute(form, field):
+def unique_identity_attribute(form: Form, field: Field) -> None:
     """A validator that checks the field data against all configured
     :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`.
     This can be used as part of registration.
@@ -302,13 +313,13 @@ def unique_identity_attribute(form, field):
 
 
 class Form(BaseForm):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         if current_app and current_app.testing:
             self.TIME_LIMIT = None
         super().__init__(*args, **kwargs)
 
 
-def generic_message(
+def _generic_message(
     detailed_msg: str, generic_msg: str, **kwargs: t.Any
 ) -> tuple[str, str]:
     if cv("RETURN_GENERIC_RESPONSES"):
@@ -340,8 +351,8 @@ def form_errors_munge(form: Form, fields: dict[str, dict[str, str]]) -> None:
 
 
 class UserEmailFormMixin:
-    email = EmailField(
-        get_form_field_label("email"),
+    email: EmailField = EmailField(
+        _get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
         validators=[
             IsString(),
@@ -353,8 +364,8 @@ class UserEmailFormMixin:
 
 
 class UniqueEmailFormMixin:
-    email = EmailField(
-        get_form_field_label("email"),
+    email: EmailField = EmailField(
+        _get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
         validators=[
             IsString(),
@@ -364,26 +375,30 @@ class UniqueEmailFormMixin:
         ],
     )
 
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
+        super().__init__(*args, **kwargs)
+        self.existing_email_user: UserMixin | None = None
+
 
 class PasswordFormMixin:
-    password = PasswordField(
-        get_form_field_label("password"),
+    password: PasswordField = PasswordField(
+        _get_form_field_label("password"),
         render_kw={"autocomplete": "current-password"},
         validators=[IsString(), password_required],
     )
 
 
 class NewPasswordFormMixin:
-    password = PasswordField(
-        get_form_field_label("password"),
+    password: PasswordField = PasswordField(
+        _get_form_field_label("password"),
         render_kw={"autocomplete": "new-password"},
         validators=[IsString(), password_required],
     )
 
 
 class PasswordConfirmFormMixin:
-    password_confirm = PasswordField(
-        get_form_field_label("retype_password"),
+    password_confirm: PasswordField = PasswordField(
+        _get_form_field_label("retype_password"),
         render_kw={"autocomplete": "new-password"},
         validators=[
             IsString(),
@@ -394,9 +409,9 @@ class PasswordConfirmFormMixin:
 
 
 class NextFormMixin:
-    next = HiddenField()
+    next: HiddenField = HiddenField()
 
-    def validate_next(self, field):
+    def validate_next(self, field: Field) -> None:
         if field.data and not validate_redirect_url(field.data):
             field.data = ""
             do_flash(*get_message("INVALID_REDIRECT"))
@@ -404,8 +419,8 @@ class NextFormMixin:
 
 
 class CodeFormMixin:
-    code = StringField(
-        get_form_field_label("code"),
+    code: StringField = StringField(
+        _get_form_field_label("code"),
         render_kw={
             "autocomplete": "one-time-code",
             "type": "text",
@@ -415,31 +430,31 @@ class CodeFormMixin:
     )
 
 
-def build_username_field(app):
+def _build_username_field(app):
     if cv("USERNAME_REQUIRED", app=app):
         validators = [
             IsString(),
             RequiredLocalize(message="USERNAME_NOT_PROVIDED"),
             username_validator,
-            unique_username,
+            _unique_username,
         ]
     else:
-        validators = [username_validator, unique_username]
+        validators = [IsString(), username_validator, _unique_username]
     return StringField(
-        get_form_field_label("username"),
+        _get_form_field_label("username"),
         render_kw={"autocomplete": "username"},
         validators=validators,
     )
 
 
 class RegisterFormMixin:
-    submit = SubmitField(get_form_field_label("register"))
+    submit: SubmitField = SubmitField(_get_form_field_label("register"))
 
     # The "username" field is added in init_app if USERNAME_ENABLE is set.
     # This is just a type hint.
     username: t.ClassVar[Field]
 
-    def to_dict(self, only_user):
+    def to_dict(self, only_user: bool) -> dict[str, t.Any]:
         """
         Return form data as dictionary
         :param only_user: bool, if True then only fields that have
@@ -465,7 +480,7 @@ class RegisterFormMixin:
 class SendConfirmationForm(Form, UserEmailFormMixin):
     """The default send confirmation form"""
 
-    submit = SubmitField(get_form_field_label("send_confirmation"))
+    submit: SubmitField = SubmitField(_get_form_field_label("send_confirmation"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -487,7 +502,7 @@ class SendConfirmationForm(Form, UserEmailFormMixin):
 class ForgotPasswordForm(Form, UserEmailFormMixin):
     """The default forgot password form"""
 
-    submit = SubmitField(get_form_field_label("recover_password"))
+    submit: SubmitField = SubmitField(_get_form_field_label("recover_password"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -514,8 +529,8 @@ class ForgotPasswordForm(Form, UserEmailFormMixin):
 class PasswordlessLoginForm(Form):
     """The passwordless login form"""
 
-    email = EmailField(
-        get_form_field_label("email"),
+    email: EmailField = EmailField(
+        _get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
         validators=[
             IsString(),
@@ -525,7 +540,7 @@ class PasswordlessLoginForm(Form):
         ],
     )
 
-    submit = SubmitField(get_form_field_label("send_login_link"))
+    submit: SubmitField = SubmitField(_get_form_field_label("send_login_link"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -568,19 +583,19 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
     # user_identity_attributes to ensure 'email' is listed.
     # If USERNAME_ENABLE is set - this field will be replaced to be Optional()
     # see build_login_form()
-    email = EmailField(
-        get_form_field_label("email"),
+    email: EmailField = EmailField(
+        _get_form_field_label("email"),
         render_kw={"autocomplete": "email"},
         validators=[IsString(), email_required, EmailValidation(verify=False)],
     )
 
     # username is added dynamically based on USERNAME_ENABLED.
     username: t.ClassVar[Field]
-    remember = BooleanField(
-        get_form_field_label("remember_me"),
+    remember: BooleanField = BooleanField(
+        _get_form_field_label("remember_me"),
         default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),
     )
-    submit = SubmitField(get_form_field_label("login"))
+    submit: SubmitField = SubmitField(_get_form_field_label("login"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -597,7 +612,7 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
         # ifield can be set by subclasses to skip identity checks.
         self.ifield: Field | None = None
         # If True then user has authenticated so we can show detailed errors
-        self.user_authenticated = False
+        self.user_authenticated: bool = False
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):
@@ -674,7 +689,7 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
         return True
 
 
-def build_login_form(app, fcls):
+def _build_login_form(app, fcls):
     # Based on app configuration, add optional/configurable fields to the login form
     # Allow app to override the field using mixins.
     # Note this is only called (from init_app()) if form is subclassed from ours.
@@ -683,7 +698,7 @@ def build_login_form(app, fcls):
     # email for example).
     if cv("USERNAME_ENABLE", app):
         fcls.username = StringField(
-            get_form_field_label("username"),
+            _get_form_field_label("username"),
             render_kw={"autocomplete": "username"},
             validators=[IsString(), username_validator],
         )
@@ -692,7 +707,7 @@ def build_login_form(app, fcls):
             # let subclass easily get rid of this
             # Note that WTForms 'del' operator actually sets this to None
             fcls.email = EmailField(
-                get_form_field_label("email"),
+                _get_form_field_label("email"),
                 render_kw={"autocomplete": "email"},
                 validators=[IsString(), Optional(), EmailValidation(verify=False)],
             )
@@ -706,11 +721,11 @@ class LogoutForm(Form):
     the view.
     """
 
-    refresh_token = HiddenField(
+    refresh_token: HiddenField = HiddenField(
         get_form_field_xlate(_("Refresh Token")),
         validators=[IsString(), Optional()],
     )
-    submit = SubmitField(label=get_form_field_label("submit"))
+    submit: SubmitField = SubmitField(label=_get_form_field_label("submit"))
 
     # returned to caller
     refresh_errors: RefreshTokenErrors | None = None
@@ -742,7 +757,7 @@ class LogoutForm(Form):
 class VerifyForm(Form, PasswordFormMixin, NextFormMixin):
     """The verify authentication form"""
 
-    submit = SubmitField(get_form_field_label("verify_password"))
+    submit: SubmitField = SubmitField(_get_form_field_label("verify_password"))
 
     def __init__(self, *args: t.Any, user: UserMixin, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -764,7 +779,7 @@ class VerifyForm(Form, PasswordFormMixin, NextFormMixin):
         return True
 
 
-class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
+class ConfirmRegisterForm(UniqueEmailFormMixin, Form, RegisterFormMixin):
     """This form is used for registering when 'confirmable' is set.
     The only difference between this and the other RegisterForm is that
     this one doesn't require re-typing in the password...
@@ -780,16 +795,15 @@ class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
     """
 
     # Password optional when Unified Signin enabled.
-    password = PasswordField(
-        get_form_field_label("password"),
+    password: PasswordField = PasswordField(
+        _get_form_field_label("password"),
         render_kw={"autocomplete": "new-password"},
         validators=[IsString()],
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.existing_username_user = None
-        self.existing_email_user = None
+        self.existing_username_user: UserMixin | None = None
 
     def validate(self, **kwargs: t.Any) -> bool:
         failed = False
@@ -843,8 +857,8 @@ class RegisterForm(ConfirmRegisterForm, NextFormMixin):
     """
 
     # Password optional when Unified Signin enabled.
-    password_confirm = PasswordField(
-        get_form_field_label("retype_password"),
+    password_confirm: PasswordField = PasswordField(
+        _get_form_field_label("retype_password"),
         validators=[
             IsString(),
             EqualToLocalize("password", message="RETYPE_PASSWORD_MISMATCH"),
@@ -865,18 +879,18 @@ class RegisterForm(ConfirmRegisterForm, NextFormMixin):
                 return False
         return True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         if request and not self.next.data:
             self.next.data = request.args.get("next", "")
 
 
 class RegisterFormV2(
-    Form,
     UniqueEmailFormMixin,
     NextFormMixin,
     NewPasswordFormMixin,
     PasswordConfirmFormMixin,
+    Form,
 ):
     """This form is used for registering.
 
@@ -900,10 +914,10 @@ class RegisterFormV2(
     .. versionadded:: 5.6
     """
 
-    submit = SubmitField(get_form_field_label("register"))
+    submit: SubmitField = SubmitField(_get_form_field_label("register"))
     username: t.ClassVar[Field]
 
-    def to_dict(self, only_user):
+    def to_dict(self, only_user: bool) -> dict[str, t.Any]:
         """
         Return form data as dictionary
         :param only_user: bool, if True then only fields that have
@@ -957,27 +971,26 @@ class RegisterFormV2(
                     failed = True
         return not failed
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.existing_username_user = None
-        self.existing_email_user = None
+        self.existing_username_user: UserMixin | None = None
         if request and not self.next.data:
             self.next.data = request.args.get("next", "")
 
 
-def build_register_form(app, fcls):
+def _build_register_form(app, fcls):
     # Based on app configuration, add optional/configurable fields to the register form
     # Allow app to override the field using mixins
     # Note that this occurs AFTER app might have sub-classed the form
     if not cv("PASSWORD_REQUIRED", app):
         # mark password field as Optional
         fcls.password = PasswordField(
-            label=get_form_field_label("password"),
+            label=_get_form_field_label("password"),
             render_kw={"autocomplete": "new-password"},
             validators=[IsString(), Optional()],
         )
         fcls.password_confirm = PasswordField(
-            get_form_field_label("retype_password"),
+            _get_form_field_label("retype_password"),
             render_kw={"autocomplete": "new-password"},
             validators=[
                 IsString(),
@@ -987,7 +1000,7 @@ def build_register_form(app, fcls):
     if not cv("PASSWORD_CONFIRM_REQUIRED", app=app):
         fcls.password_confirm = None
     if cv("USERNAME_ENABLE", app):
-        fcls.username = build_username_field(app=app)
+        fcls.username = _build_username_field(app=app)
 
 
 class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
@@ -996,7 +1009,7 @@ class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
     # filled in by caller
     user: UserMixin | None
 
-    submit = SubmitField(get_form_field_label("reset_password"))
+    submit: SubmitField = SubmitField(_get_form_field_label("reset_password"))
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):
@@ -1016,17 +1029,18 @@ class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
 class ChangePasswordForm(Form):
     """The default change password form"""
 
-    password = PasswordField(
-        get_form_field_label("password"), render_kw={"autocomplete": "current-password"}
+    password: PasswordField = PasswordField(
+        _get_form_field_label("password"),
+        render_kw={"autocomplete": "current-password"},
     )
-    new_password = PasswordField(
-        get_form_field_label("new_password"),
+    new_password: PasswordField = PasswordField(
+        _get_form_field_label("new_password"),
         render_kw={"autocomplete": "new-password"},
         validators=[IsString(), password_required],
     )
 
-    new_password_confirm = PasswordField(
-        get_form_field_label("retype_password"),
+    new_password_confirm: PasswordField = PasswordField(
+        _get_form_field_label("retype_password"),
         render_kw={"autocomplete": "new-password"},
         validators=[
             IsString(),
@@ -1035,7 +1049,7 @@ class ChangePasswordForm(Form):
         ],
     )
 
-    submit = SubmitField(get_form_field_label("change_password"))
+    submit: SubmitField = SubmitField(_get_form_field_label("change_password"))
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):
@@ -1071,21 +1085,21 @@ class ChangePasswordForm(Form):
 class TwoFactorSetupForm(Form):
     """The Two-factor token validation form"""
 
-    setup = RadioField(
+    setup: RadioField = RadioField(
         get_form_field_xlate(_("Available Methods")),
         choices=[
             ("disable", get_form_field_xlate(_("Disable two-factor authentication"))),
-            ("email", get_form_field_label("email_method")),
+            ("email", _get_form_field_label("email_method")),
             (
                 "authenticator",
-                get_form_field_label("authapp_method"),
+                _get_form_field_label("authapp_method"),
             ),
-            ("sms", get_form_field_label("sms_method")),
+            ("sms", _get_form_field_label("sms_method")),
         ],
         validate_choice=False,
     )
-    phone = TelField(get_form_field_label("phone"), validators=[IsString()])
-    submit = SubmitField(get_form_field_label("submit"))
+    phone: TelField = TelField(_get_form_field_label("phone"), validators=[IsString()])
+    submit: SubmitField = SubmitField(_get_form_field_label("submit"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -1121,7 +1135,9 @@ class TwoFactorSetupForm(Form):
 class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
     """The Two-factor token validation form"""
 
-    submit = SubmitField(get_form_field_label("submitcode"), id="submit-code")
+    submit: SubmitField = SubmitField(
+        _get_form_field_label("submitcode"), id="submit-code"
+    )
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -1169,19 +1185,19 @@ class TwoFactorRescueForm(Form):
     """The Two-factor Rescue validation form"""
 
     # rescue options - additional options are generated in set_rescue_options()
-    help_setup = RadioField(
+    help_setup: RadioField = RadioField(
         get_form_field_xlate(_("Trouble Accessing Your Account?/Lost Mobile Device?")),
         choices=[
             ("help", get_form_field_xlate(_("Contact Administrator"))),
         ],
     )
-    submit = SubmitField(get_form_field_label("submit"), id="rescue")
+    submit: SubmitField = SubmitField(_get_form_field_label("submit"), id="rescue")
 
 
 class UsernameRecoveryForm(ForgotPasswordForm):
     """The username recovery form"""
 
-    submit = SubmitField(get_form_field_label("recover_username"))
+    submit: SubmitField = SubmitField(_get_form_field_label("recover_username"))
 
 
 class DummyForm(Form):
@@ -1192,17 +1208,17 @@ class DummyForm(Form):
         self.user: UserMixin | None = kwargs.get("user", None)
 
 
-def build_form_from_request(form_name: str, **kwargs: dict[str, t.Any]) -> Form:
+def _build_form_from_request(form_name: str, **kwargs: dict[str, t.Any]) -> Form:
     # helper function for views
     form_data = None
     if request.content_length:
         form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    return build_form(
+    return _build_form(
         form_name, formdata=form_data, meta=suppress_form_csrf(), **kwargs
     )
 
 
-def build_form(form_name, **kwargs):
+def _build_form(form_name, **kwargs):
     # helper function for views
     kwargs.setdefault("formdata", None)
     return _security.forms[form_name].instantiator(

--- a/flask_security/recovery_codes.py
+++ b/flask_security/recovery_codes.py
@@ -18,8 +18,8 @@ from flask_login import current_user
 
 from .decorators import anonymous_user_required, auth_required, unauth_csrf
 from .forms import (
-    build_form_from_request,
-    get_form_field_label,
+    _build_form_from_request,
+    _get_form_field_label,
     get_form_field_xlate,
     Form,
     RequiredLocalize,
@@ -140,12 +140,14 @@ class MfRecoveryCodesForm(Form):
     """Generate and fetch recovery codes"""
 
     # show_codes is a GET option., generate_new_codes is a POST option
-    show_codes = SubmitField(get_form_field_xlate(_("Show Recovery Codes")))
-    generate_new_codes = SubmitField(
+    show_codes: SubmitField = SubmitField(
+        get_form_field_xlate(_("Show Recovery Codes"))
+    )
+    generate_new_codes: SubmitField = SubmitField(
         get_form_field_xlate(_("Generate New Recovery Codes"))
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -157,11 +159,11 @@ class MfRecoveryCodesForm(Form):
 class MfRecoveryForm(Form):
     """Accept recovery code for second factor authentication"""
 
-    code = StringField(
+    code: StringField = StringField(
         get_form_field_xlate(_("Recovery Code")),
         validators=[IsString(), RequiredLocalize()],
     )
-    submit = SubmitField(get_form_field_label("submitcode"))
+    submit: SubmitField = SubmitField(_get_form_field_label("submitcode"))
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
@@ -194,7 +196,7 @@ def mf_recovery_codes() -> ResponseValue:
     the form has a show_codes submit button.
     """
     form = t.cast(
-        MfRecoveryCodesForm, build_form_from_request("mf_recovery_codes_form")
+        MfRecoveryCodesForm, _build_form_from_request("mf_recovery_codes_form")
     )
 
     if form.validate_on_submit():
@@ -237,7 +239,7 @@ def mf_recovery():
     User must have already established 2FA
 
     """
-    form = t.cast(MfRecoveryForm, build_form_from_request("mf_recovery_form"))
+    form = t.cast(MfRecoveryForm, _build_form_from_request("mf_recovery_form"))
     form.user = tf_check_state(["ready"])
     if not form.user:
         return tf_illegal_state(form, cv("TWO_FACTOR_ERROR_VIEW"))

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -10,56 +10,63 @@ Flask-Security signals module
 """
 
 import blinker
+from blinker import Namespace, NamedSignal
 
-signals = blinker.Namespace()
+signals: Namespace = blinker.Namespace()
 
-user_authenticated = signals.signal("user-authenticated")
+user_authenticated: NamedSignal = signals.signal("user-authenticated")
 
-user_unauthenticated = signals.signal("user-unauthenticated")
+user_unauthenticated: NamedSignal = signals.signal("user-unauthenticated")
 
-user_failed_authn = signals.signal("user-failed-authn")
+user_failed_authn: NamedSignal = signals.signal("user-failed-authn")
 
-user_registered = signals.signal("user-registered")
+user_registered: NamedSignal = signals.signal("user-registered")
 
 # For cases of RETURN_GENERIC_RESPONSES with existing email/username
-user_not_registered = signals.signal("user-not-registered")
+user_not_registered: NamedSignal = signals.signal("user-not-registered")
 
-user_confirmed = signals.signal("user-confirmed")
+user_confirmed: NamedSignal = signals.signal("user-confirmed")
 
-confirm_instructions_sent = signals.signal("confirm-instructions-sent")
+confirm_instructions_sent: NamedSignal = signals.signal("confirm-instructions-sent")
 
-login_instructions_sent = signals.signal("login-instructions-sent")
+login_instructions_sent: NamedSignal = signals.signal("login-instructions-sent")
 
-password_reset = signals.signal("password-reset")
+password_reset: NamedSignal = signals.signal("password-reset")
 
-password_changed = signals.signal("password-changed")
+password_changed: NamedSignal = signals.signal("password-changed")
 
-refresh_tracker_created = signals.signal("refresh-tracker-created")
+refresh_tracker_created: NamedSignal = signals.signal("refresh-tracker-created")
 
-refresh_tracker_revoked = signals.signal("refresh-tracker-revoked")
+refresh_tracker_revoked: NamedSignal = signals.signal("refresh-tracker-revoked")
 
-reset_password_instructions_sent = signals.signal("password-reset-instructions-sent")
+reset_password_instructions_sent: NamedSignal = signals.signal(
+    "password-reset-instructions-sent"
+)
 
-tf_code_confirmed = signals.signal("tf-code-confirmed")
+tf_code_confirmed: NamedSignal = signals.signal("tf-code-confirmed")
 
-tf_profile_changed = signals.signal("tf-profile-changed")
+tf_profile_changed: NamedSignal = signals.signal("tf-profile-changed")
 
-tf_security_token_sent = signals.signal("tf-security-token-sent")
+tf_security_token_sent: NamedSignal = signals.signal("tf-security-token-sent")
 
-tf_disabled = signals.signal("tf-disabled")
+tf_disabled: NamedSignal = signals.signal("tf-disabled")
 
-us_security_token_sent = signals.signal("us-security-token-sent")
+us_security_token_sent: NamedSignal = signals.signal("us-security-token-sent")
 
-us_profile_changed = signals.signal("us-profile-changed")
+us_profile_changed: NamedSignal = signals.signal("us-profile-changed")
 
-wan_registered = signals.signal("wan-registered")
+wan_registered: NamedSignal = signals.signal("wan-registered")
 
-wan_deleted = signals.signal("wan-deleted")
+wan_deleted: NamedSignal = signals.signal("wan-deleted")
 
-change_email_instructions_sent = signals.signal("change-email-instructions-sent")
+change_email_instructions_sent: NamedSignal = signals.signal(
+    "change-email-instructions-sent"
+)
 
-change_email_confirmed = signals.signal("change-email")
+change_email_confirmed: NamedSignal = signals.signal("change-email")
 
-username_recovery_email_sent = signals.signal("username-recovery-email-sent")
+username_recovery_email_sent: NamedSignal = signals.signal(
+    "username-recovery-email-sent"
+)
 
-username_changed = signals.signal("username-changed")
+username_changed: NamedSignal = signals.signal("username-changed")

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -19,7 +19,7 @@ from flask import request, redirect, session
 
 from .decorators import unauth_csrf
 from .forms import (
-    build_form_from_request,
+    _build_form_from_request,
     get_form_field_xlate,
     Form,
     RadioField,
@@ -48,10 +48,12 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 class TwoFactorSelectForm(Form):
-    which = RadioField(get_form_field_xlate(_("Available Second Factor Methods:")))
-    submit = SubmitField(get_form_field_xlate(_("Select")))
+    which: RadioField = RadioField(
+        get_form_field_xlate(_("Available Second Factor Methods:"))
+    )
+    submit: SubmitField = SubmitField(get_form_field_xlate(_("Select")))
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
 
 
@@ -60,7 +62,7 @@ def tf_select() -> ResponseValue:
     # Ask user which MFA method they want to use.
     # This is used when a user has setup more than one type of 2FA.
     form = t.cast(
-        TwoFactorSelectForm, build_form_from_request("two_factor_select_form")
+        TwoFactorSelectForm, _build_form_from_request("two_factor_select_form")
     )
 
     # This endpoint is unauthenticated - make sure we're in a valid state

--- a/flask_security/tokens.py
+++ b/flask_security/tokens.py
@@ -36,9 +36,9 @@ from .forms import (
     Form,
     RequiredLocalize,
     SubmitField,
-    get_form_field_label,
+    _get_form_field_label,
     get_form_field_xlate,
-    build_form_from_request,
+    _build_form_from_request,
     IsString,
 )
 from .proxies import _security, _datastore
@@ -197,11 +197,11 @@ class RefreshTokenForm(Form):
     Given a valid refresh token, this will return a new access token.
     """
 
-    refresh_token = StringField(
+    refresh_token: StringField = StringField(
         get_form_field_xlate(_("Refresh Token")),
         validators=[IsString(), RequiredLocalize()],
     )
-    submit = SubmitField(label=get_form_field_label("submit"))
+    submit: SubmitField = SubmitField(label=_get_form_field_label("submit"))
 
     # returned to caller
     refresh_errors: RefreshTokenErrors | None = None
@@ -248,7 +248,7 @@ def refresh() -> ResponseValue:
         abort(400)
 
     form: RefreshTokenForm = t.cast(
-        RefreshTokenForm, build_form_from_request("refresh_token_form")
+        RefreshTokenForm, _build_form_from_request("refresh_token_form")
     )
 
     if form.validate_on_submit():

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -49,7 +49,9 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from flask.typing import ResponseValue
 
 
-def tf_send_security_token(user, method, totp_secret, phone_number):
+def tf_send_security_token(
+    user: UserMixin, method: str, totp_secret: str, phone_number: str | None
+) -> None:
     """Sends the security token via email/sms for the specified user.
 
     :param user: The user to send the code to
@@ -64,7 +66,9 @@ def tf_send_security_token(user, method, totp_secret, phone_number):
     Flask-Security code should NOT call this directly -
     call :meth:`.UserMixin.tf_send_security_token`
     """
-    token_to_be_sent = _security.totp_factory.generate_totp_password(totp_secret)
+    token_to_be_sent: str | None = _security.totp_factory.generate_totp_password(
+        totp_secret
+    )
     if method == "email" or method == "mail":
         send_mail(
             cv("EMAIL_SUBJECT_TWO_FACTOR"),
@@ -87,7 +91,7 @@ def tf_send_security_token(user, method, totp_secret, phone_number):
         token_to_be_sent = None
 
     tf_security_token_sent.send(
-        current_app._get_current_object(),
+        current_app._get_current_object(),  # type: ignore[attr-defined]
         _async_wrapper=current_app.ensure_sync,
         user=user,
         method=method,
@@ -97,7 +101,7 @@ def tf_send_security_token(user, method, totp_secret, phone_number):
     )
 
 
-def complete_two_factor_process(user, primary_method, totp_secret, is_changing):
+def _complete_two_factor_process(user, primary_method, totp_secret, is_changing):
     """clean session according to process (login or changing two-factor method)
     and perform action accordingly
     """
@@ -129,7 +133,7 @@ def complete_two_factor_process(user, primary_method, totp_secret, is_changing):
     return completion_message, token
 
 
-def set_rescue_options(form: TwoFactorRescueForm, user: UserMixin) -> dict[str, str]:
+def _set_rescue_options(form: TwoFactorRescueForm, user: UserMixin) -> dict[str, str]:
     # Based on config - set up options for rescue.
     # Note that this modifies the passed in Form as well as returns
     # a dict that can be returned as part of a JSON response.
@@ -158,20 +162,20 @@ def set_rescue_options(form: TwoFactorRescueForm, user: UserMixin) -> dict[str, 
     return recovery_options
 
 
-def tf_disable(user):
+def tf_disable(user: UserMixin) -> None:
     """Disable two factor for user"""
     tf_clean_session()
     _datastore.tf_reset(user)
     tf_disabled.send(
-        current_app._get_current_object(),
+        current_app._get_current_object(),  # type: ignore[attr-defined]
         _async_wrapper=current_app.ensure_sync,
         user=user,
     )
 
 
-def is_tf_setup(user):
+def is_tf_setup(user: UserMixin) -> bool:
     """Return True is user account is setup for 2FA."""
-    return user.tf_totp_secret and user.tf_primary_method
+    return bool(user.tf_totp_secret and user.tf_primary_method)
 
 
 class CodeTfPlugin(TfPluginBase):

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -57,11 +57,11 @@ from .forms import (
     Form,
     NextFormMixin,
     RequiredLocalize,
-    build_form_from_request,
-    build_form,
+    _build_form_from_request,
+    _build_form,
     form_errors_munge,
-    generic_message,
-    get_form_field_label,
+    _generic_message,
+    _get_form_field_label,
     get_form_field_xlate,
     IsString,
     IsStringOrInt,
@@ -162,17 +162,17 @@ class _UnifiedPassCodeForm(Form):
 
     # PasswordField so it doesn't show, no autocomplete since it might be a password
     # (could also be a passcode).
-    passcode = PasswordField(
-        get_form_field_label("passcode"),
+    passcode: PasswordField = PasswordField(
+        _get_form_field_label("passcode"),
         render_kw={
             "placeholder": get_form_field_xlate(_("Code or Password")),
             "autocomplete": "off",
         },
         validators=[IsStringOrInt()],
     )
-    submit = SubmitField(get_form_field_label("submit"))
+    submit: SubmitField = SubmitField(_get_form_field_label("submit"))
 
-    chosen_method = RadioField(
+    chosen_method: RadioField = RadioField(
         _("Available Methods"),
         choices=[
             ("email", get_form_field_xlate(_("Via email"))),
@@ -180,9 +180,9 @@ class _UnifiedPassCodeForm(Form):
         ],
         validators=[IsString(), validators.Optional()],
     )
-    submit_send_code = SubmitField(get_form_field_label("sendcode"))
+    submit_send_code: SubmitField = SubmitField(_get_form_field_label("sendcode"))
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -254,18 +254,18 @@ class UnifiedSigninForm(_UnifiedPassCodeForm, NextFormMixin):
     For either identity/password or request and enter code.
     """
 
-    identity = StringField(
-        get_form_field_label("identity"),
+    identity: StringField = StringField(
+        _get_form_field_label("identity"),
         validators=[IsString(), RequiredLocalize()],
     )
-    remember = BooleanField(
-        get_form_field_label("remember_me"),
+    remember: BooleanField = BooleanField(
+        _get_form_field_label("remember_me"),
         default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.requires_confirmation = False
+        self.requires_confirmation: bool = False
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):
@@ -289,7 +289,7 @@ class UnifiedVerifyForm(_UnifiedPassCodeForm, NextFormMixin):
     This is for freshness 'reauthentication' required.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         if request and not self.next.data:
             self.next.data = request.args.get("next", "")
@@ -306,19 +306,19 @@ class UnifiedVerifyForm(_UnifiedPassCodeForm, NextFormMixin):
 class UnifiedSigninSetupForm(Form):
     """Setup form"""
 
-    setup_choices = [
-        ("email", get_form_field_label("email_method")),
+    setup_choices: list[tuple[str, str]] = [
+        ("email", _get_form_field_label("email_method")),
         (
             "authenticator",
-            get_form_field_label("authapp_method"),
+            _get_form_field_label("authapp_method"),
         ),
-        ("sms", get_form_field_label("sms_method")),
+        ("sms", _get_form_field_label("sms_method")),
     ]
-    chosen_method = RadioField(
+    chosen_method: RadioField = RadioField(
         get_form_field_xlate(_("Setup additional sign in option")),
         validate_choice=False,
     )
-    delete_choices = [
+    delete_choices: list[tuple[str, str]] = [
         ("email", get_form_field_xlate("Delete email option")),
         (
             "authenticator",
@@ -327,15 +327,15 @@ class UnifiedSigninSetupForm(Form):
         ("sms", get_form_field_xlate("Delete SMS option")),
     ]
 
-    delete_method = SelectMultipleField(
+    delete_method: SelectMultipleField = SelectMultipleField(
         label=get_form_field_xlate(_("Delete active sign in option")),
         option_widget=CheckboxInput(),
         validate_choice=False,
     )
-    phone = TelField(get_form_field_label("phone"), validators=[IsString()])
-    submit = SubmitField(get_form_field_label("submit"))
+    phone: TelField = TelField(_get_form_field_label("phone"), validators=[IsString()])
+    submit: SubmitField = SubmitField(_get_form_field_label("submit"))
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -394,8 +394,8 @@ class UnifiedSigninSetupValidateForm(Form):
     user: UserMixin
     totp_secret: str
 
-    passcode = StringField(
-        get_form_field_label("passcode"),
+    passcode: StringField = StringField(
+        _get_form_field_label("passcode"),
         render_kw={
             "autocomplete": "one-time-code",
             "type": "text",
@@ -403,9 +403,11 @@ class UnifiedSigninSetupValidateForm(Form):
         },
         validators=[IsStringOrInt(), RequiredLocalize()],
     )
-    submit = SubmitField(get_form_field_label("submitcode"), id="submit-code")
+    submit: SubmitField = SubmitField(
+        _get_form_field_label("submitcode"), id="submit-code"
+    )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -449,7 +451,7 @@ def us_signin_send_code() -> ResponseValue:
     This takes an identity (as configured in USER_IDENTITY_ATTRIBUTES)
     and a method request to send a code.
     """
-    form = t.cast(UnifiedSigninForm, build_form_from_request("us_signin_form"))
+    form = t.cast(UnifiedSigninForm, _build_form_from_request("us_signin_form"))
     form.submit_send_code.data = True
     form.submit.data = False
 
@@ -469,7 +471,7 @@ def us_signin_send_code() -> ResponseValue:
 
         if not msg:
             # Make sure same response as non-setup method below
-            do_flash(*generic_message("CODE_HAS_BEEN_SENT", "GENERIC_US_SIGNIN"))
+            do_flash(*_generic_message("CODE_HAS_BEEN_SENT", "GENERIC_US_SIGNIN"))
 
         return _security.render_template(
             cv("US_SIGNIN_TEMPLATE"),
@@ -517,7 +519,7 @@ def us_verify_send_code() -> ResponseValue:
     """
     Send code during verify. POST only.
     """
-    form = t.cast(UnifiedVerifyForm, build_form_from_request("us_verify_form"))
+    form = t.cast(UnifiedVerifyForm, _build_form_from_request("us_verify_form"))
     form.submit_send_code.data = True
     form.submit.data = False
 
@@ -567,7 +569,7 @@ def us_signin() -> ResponseValue:
     This takes an identity (as configured in USER_IDENTITY_ATTRIBUTES)
     and a passcode (password or OTP).
     """
-    form = t.cast(UnifiedSigninForm, build_form_from_request("us_signin_form"))
+    form = t.cast(UnifiedSigninForm, _build_form_from_request("us_signin_form"))
     form.submit.data = True
     form.submit_send_code.data = False
     code_methods = _compute_code_methods()
@@ -649,7 +651,7 @@ def us_verify() -> ResponseValue:
     will have filled in ?next=xxx - which we want to carefully not lose as we
     go through these steps.
     """
-    form = t.cast(UnifiedVerifyForm, build_form_from_request("us_verify_form"))
+    form = t.cast(UnifiedVerifyForm, _build_form_from_request("us_verify_form"))
     form.submit.data = True
     form.submit_send_code.data = False
 
@@ -691,7 +693,7 @@ def us_verify() -> ResponseValue:
         code_methods=code_methods,
         skip_login_menu=True,
         has_webauthn_verify_credential=webauthn_available,
-        wan_verify_form=build_form("wan_verify_form"),
+        wan_verify_form=_build_form("wan_verify_form"),
         **_security._run_ctx_processor("us_verify"),
     )
 
@@ -715,9 +717,9 @@ def us_verify_link() -> ResponseValue:
     user = _datastore.find_user(fs_uniquifier=fs_uniquifier)
     if not user or not user.active:
         if not user:
-            m, c = generic_message("USER_DOES_NOT_EXIST", "GENERIC_AUTHN_FAILED")
+            m, c = _generic_message("USER_DOES_NOT_EXIST", "GENERIC_AUTHN_FAILED")
         else:
-            m, c = generic_message("DISABLED_ACCOUNT", "GENERIC_AUTHN_FAILED")
+            m, c = _generic_message("DISABLED_ACCOUNT", "GENERIC_AUTHN_FAILED")
         if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
         do_flash(m, c)
@@ -730,7 +732,7 @@ def us_verify_link() -> ResponseValue:
         user=user,
         window=cv("US_TOKEN_VALIDITY"),
     ):
-        m, c = generic_message("INVALID_CODE", "GENERIC_AUTHN_FAILED")
+        m, c = _generic_message("INVALID_CODE", "GENERIC_AUTHN_FAILED")
         user.track_failed_authn("passcode")
 
         if cv("REDIRECT_BEHAVIOR") == "spa":
@@ -797,7 +799,7 @@ def us_setup() -> ResponseValue:
     use a timed signed token to pass along state.
     GET - retrieve current info (json) or form.
     """
-    form = t.cast(UnifiedSigninSetupForm, build_form_from_request("us_setup_form"))
+    form = t.cast(UnifiedSigninSetupForm, _build_form_from_request("us_setup_form"))
 
     setup_methods = _compute_setup_methods()
     active_methods = _compute_active_methods(current_user)
@@ -937,7 +939,7 @@ def us_setup() -> ResponseValue:
             code_sent=form.chosen_method.data in _compute_code_methods(),
             chosen_method=form.chosen_method.data,
             us_setup_form=form,
-            us_setup_validate_form=build_form("us_setup_validate_form"),
+            us_setup_validate_form=_build_form("us_setup_validate_form"),
             **qrcode_values,
             state=state_token,
             **_security._run_ctx_processor("us_setup"),
@@ -983,7 +985,7 @@ def us_setup_validate(token: str) -> ResponseValue:
     """
     form = t.cast(
         UnifiedSigninSetupValidateForm,
-        build_form_from_request("us_setup_validate_form"),
+        _build_form_from_request("us_setup_validate_form"),
     )
 
     expired, invalid, state = check_and_get_token_status(
@@ -1038,8 +1040,12 @@ def us_setup_validate(token: str) -> ResponseValue:
 
 
 def us_send_security_token(
-    user, method, totp_secret, phone_number, send_magic_link=False
-):
+    user: UserMixin,
+    method: str,
+    totp_secret: str,
+    phone_number: str | None,
+    send_magic_link: bool = False,
+) -> None:
     """Generate and send the security code.
 
     :param user: The user to send the code to
@@ -1057,7 +1063,7 @@ def us_send_security_token(
 
     .. versionadded:: 3.4.0
     """
-    code = _security.totp_factory.generate_totp_password(totp_secret)
+    code: str | None = _security.totp_factory.generate_totp_password(totp_secret)
 
     if method == "email":
         login_link = None
@@ -1089,7 +1095,7 @@ def us_send_security_token(
         # Still go ahead and notify signal receivers that they requested it.
         code = None
     us_security_token_sent.send(
-        current_app._get_current_object(),
+        current_app._get_current_object(),  # type: ignore[attr-defined]
         _async_wrapper=current_app.ensure_sync,
         user=user,
         method=method,

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -60,8 +60,8 @@ from .forms import (
     ForgotPasswordForm,
     LoginForm,
     LogoutForm,
-    build_form_from_request,
-    build_form,
+    _build_form_from_request,
+    _build_form,
     form_errors_munge,
     ResetPasswordForm,
     SendConfirmationForm,
@@ -99,8 +99,8 @@ from .tf_plugin import (
     tf_set_validity_token_cookie,
 )
 from .twofactor import (
-    complete_two_factor_process,
-    set_rescue_options,
+    _complete_two_factor_process,
+    _set_rescue_options,
     tf_clean_session,
     tf_disable,
 )
@@ -152,9 +152,15 @@ else:
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask.typing import ResponseValue
+    from flask_security import UserMixin
 
 
-def default_render_json(payload, code, headers, user):
+def default_render_json(
+    payload: dict[str, t.Any],
+    code: int,
+    headers: dict[str, str] | None,
+    user: UserMixin | None,
+) -> ResponseValue:
     """Default JSON response handler."""
     # Force Content-Type header to json.
     if headers is None:
@@ -171,7 +177,7 @@ def _ctx(endpoint):
 @unauth_csrf()
 def login() -> ResponseValue:
     """View function for login view"""
-    form = t.cast(LoginForm, build_form_from_request("login_form"))
+    form = t.cast(LoginForm, _build_form_from_request("login_form"))
 
     if is_user_authenticated(current_user):
         return handle_already_auth(
@@ -240,7 +246,9 @@ def login() -> ResponseValue:
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
 def verify():
     """View function which handles a reauthentication request."""
-    form = t.cast(VerifyForm, build_form_from_request("verify_form", user=current_user))
+    form = t.cast(
+        VerifyForm, _build_form_from_request("verify_form", user=current_user)
+    )
 
     if form.validate_on_submit():
         # form may have called verify_and_update_password()
@@ -271,12 +279,12 @@ def verify():
         cv("VERIFY_TEMPLATE"),
         verify_form=form,
         has_webauthn_verify_credential=webauthn_available,
-        wan_verify_form=build_form("wan_verify_form"),
+        wan_verify_form=_build_form("wan_verify_form"),
         **_ctx("verify"),
     )
 
 
-def logout():
+def logout() -> ResponseValue:
     """View function which handles a logout request.
     As part of the refresh_token feature, logout now has a form defined
     which a client can pass a refresh token that will be revoked as part of logout
@@ -291,7 +299,7 @@ def logout():
 
     if is_user_authenticated(current_user):
         form = t.cast(
-            LogoutForm, build_form_from_request("logout_form", user=current_user)
+            LogoutForm, _build_form_from_request("logout_form", user=current_user)
         )
         if cv("LOGOUT_CSRF"):
             try:
@@ -349,7 +357,7 @@ def register() -> ResponseValue:
         form_name = "confirm_register_form"
     else:
         form_name = "register_form"
-    form = build_form_from_request(form_name)
+    form = _build_form_from_request(form_name)
 
     if form.validate_on_submit():
         after_this_request(view_commit)
@@ -402,7 +410,7 @@ def register() -> ResponseValue:
 @unauth_csrf()
 def send_login():
     """View function that sends login instructions for passwordless login"""
-    form = build_form_from_request("passwordless_login_form")
+    form = _build_form_from_request("passwordless_login_form")
 
     if form.validate_on_submit():
         send_login_instructions(form.user)
@@ -463,7 +471,7 @@ def token_login(token):
 def send_confirmation():
     """View function which sends confirmation instructions (/confirm)."""
     form = t.cast(
-        SendConfirmationForm, build_form_from_request("send_confirmation_form")
+        SendConfirmationForm, _build_form_from_request("send_confirmation_form")
     )
 
     if form.validate_on_submit():
@@ -493,7 +501,7 @@ def send_confirmation():
     )
 
 
-def confirm_email(token):
+def confirm_email(token: str) -> ResponseValue:
     """
     View function which handles an email confirmation request.
     This is always a GET from an email - so for 'spa' must always redirect.
@@ -579,7 +587,7 @@ def forgot_password():
     often users stay logged in for a long time and might have forgotten their password
     and might be prompted for it for sensitive operations (/verify).
     """
-    form = t.cast(ForgotPasswordForm, build_form_from_request("forgot_password_form"))
+    form = t.cast(ForgotPasswordForm, _build_form_from_request("forgot_password_form"))
 
     if form.validate_on_submit():
         send_reset_password_instructions(form.user)
@@ -634,7 +642,7 @@ def reset_password(token):
     For POST normal/successful case - return 200 with new authentication token
     For POST error case return 400
     """
-    form = t.cast(ResetPasswordForm, build_form_from_request("reset_password_form"))
+    form = t.cast(ResetPasswordForm, _build_form_from_request("reset_password_form"))
     expired, invalid, form.user = reset_password_token_status(token)
 
     if request.method == "GET":
@@ -733,7 +741,7 @@ def reset_password(token):
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
 def change_password():
     """View function which handles a change password request."""
-    form = t.cast(ChangePasswordForm, build_form_from_request("change_password_form"))
+    form = t.cast(ChangePasswordForm, _build_form_from_request("change_password_form"))
 
     if not current_user.password:
         # This is case where user registered w/o a password - since we can't
@@ -796,7 +804,7 @@ def two_factor_setup():
     state via the session as part of login to show a) who and b) that they successfully
     authenticated.
     """
-    form = t.cast(TwoFactorSetupForm, build_form_from_request("two_factor_setup_form"))
+    form = t.cast(TwoFactorSetupForm, _build_form_from_request("two_factor_setup_form"))
 
     changing = is_user_authenticated(current_user)
     if not changing:
@@ -908,7 +916,7 @@ def two_factor_setup():
             )
         if _security._want_json(request):
             return base_render_json(form, include_user=False, additional=json_response)
-        code_form = build_form("two_factor_verify_code_form")
+        code_form = _build_form("two_factor_verify_code_form")
         return _security.render_template(
             cv("TWO_FACTOR_SETUP_TEMPLATE"),
             two_factor_setup_form=form,
@@ -941,7 +949,7 @@ def two_factor_setup():
         }
         return base_render_json(form, include_user=False, additional=json_response)
 
-    code_form = build_form("two_factor_verify_code_form")
+    code_form = _build_form("two_factor_verify_code_form")
     return _security.render_template(
         cv("TWO_FACTOR_SETUP_TEMPLATE"),
         two_factor_setup_form=form,
@@ -968,7 +976,7 @@ def two_factor_setup_validate(token: str) -> ResponseValue:
     It also is JUST for setting up/changing two factor for an authenticated user.
     """
     form = t.cast(
-        TwoFactorVerifyCodeForm, build_form_from_request("two_factor_verify_code_form")
+        TwoFactorVerifyCodeForm, _build_form_from_request("two_factor_verify_code_form")
     )
 
     expired, invalid, state = check_and_get_token_status(
@@ -1045,7 +1053,7 @@ def two_factor_token_validation():
 
     """
     form = t.cast(
-        TwoFactorVerifyCodeForm, build_form_from_request("two_factor_verify_code_form")
+        TwoFactorVerifyCodeForm, _build_form_from_request("two_factor_verify_code_form")
     )
 
     # state info in session
@@ -1090,7 +1098,7 @@ def two_factor_token_validation():
     form.tf_totp_secret = totp_secret
     if form.validate_on_submit():
         # Success - finish process based on 'changing' and clear all session variables
-        completion_message, token = complete_two_factor_process(
+        completion_message, token = _complete_two_factor_process(
             form.user, pm, totp_secret, changing
         )
 
@@ -1126,8 +1134,8 @@ def two_factor_token_validation():
 
     # if we were trying to validate an existing method
     else:
-        rescue_form = build_form("two_factor_rescue_form")
-        recovery_options = set_rescue_options(rescue_form, form.user)
+        rescue_form = _build_form("two_factor_rescue_form")
+        recovery_options = _set_rescue_options(rescue_form, form.user)
         if _security._want_json(request):
             return base_render_json(
                 form, additional=dict(recovery_options=recovery_options)
@@ -1153,14 +1161,14 @@ def two_factor_rescue():
 
     """
     form = t.cast(
-        TwoFactorRescueForm, build_form_from_request("two_factor_rescue_form")
+        TwoFactorRescueForm, _build_form_from_request("two_factor_rescue_form")
     )
 
     form.user = tf_check_state(["ready"])
     if not form.user:
         return tf_illegal_state(form, cv("TWO_FACTOR_ERROR_VIEW"))
 
-    recovery_options = set_rescue_options(form, form.user)
+    recovery_options = _set_rescue_options(form, form.user)
     rproblem = ""
     if form.validate_on_submit():
         raction = form.help_setup.data
@@ -1199,7 +1207,7 @@ def two_factor_rescue():
             form, include_user=False, additional=dict(recovery_options=recovery_options)
         )
 
-    code_form = build_form("two_factor_verify_code_form")
+    code_form = _build_form("two_factor_verify_code_form")
     return _security.render_template(
         cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
         two_factor_verify_code_form=code_form,
@@ -1219,7 +1227,7 @@ def recover_username():
     """View function for username recovery"""
 
     form = t.cast(
-        UsernameRecoveryForm, build_form_from_request("username_recovery_form")
+        UsernameRecoveryForm, _build_form_from_request("username_recovery_form")
     )
 
     if form.validate_on_submit():
@@ -1251,7 +1259,7 @@ def recover_username():
     )
 
 
-def create_blueprint(app, state, import_name):
+def _create_blueprint(app, state, import_name):
     """Creates the security extension blueprint"""
 
     bp = Blueprint(

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -79,9 +79,9 @@ from .decorators import anonymous_user_required, auth_required, unauth_csrf
 from .forms import (
     Form,
     RequiredLocalize,
-    build_form_from_request,
-    build_form,
-    get_form_field_label,
+    _build_form_from_request,
+    _build_form,
+    _get_form_field_label,
     get_form_field_xlate,
     _setup_methods_xlate,
     IsString,
@@ -139,7 +139,7 @@ class WebAuthnRegisterForm(Form):
         default="secondary",
         validate_choice=True,
     )
-    submit = SubmitField(label=get_form_field_label("submit"), id="wan_register")
+    submit = SubmitField(label=_get_form_field_label("submit"), id="wan_register")
     clean_name: str | None
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -162,7 +162,7 @@ class WebAuthnRegisterForm(Form):
 
 class WebAuthnRegisterResponseForm(Form):
     credential = HiddenField()
-    submit = SubmitField(label=get_form_field_label("submit"))
+    submit = SubmitField(label=_get_form_field_label("submit"))
 
     # from state
     challenge: str
@@ -228,9 +228,9 @@ class WebAuthnRegisterResponseForm(Form):
 
 
 class WebAuthnSigninForm(Form, NextFormMixin):
-    identity = StringField(get_form_field_label("identity"), validators=[IsString()])
+    identity = StringField(_get_form_field_label("identity"), validators=[IsString()])
     remember = BooleanField(
-        get_form_field_label("remember_me"),
+        _get_form_field_label("remember_me"),
         default=lambda: cv("DEFAULT_REMEMBER_ME", app=current_app),
     )
     submit = SubmitField(label=get_form_field_xlate(_("Start")), id="wan_signin")
@@ -266,7 +266,7 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
     """
 
     remember = HiddenField()
-    submit = SubmitField(label=get_form_field_label("submit"))
+    submit = SubmitField(label=_get_form_field_label("submit"))
     credential = HiddenField()
 
     # set by caller
@@ -382,7 +382,7 @@ class WebAuthnDeleteForm(Form):
         validators=[IsString(), RequiredLocalize(message="WEBAUTHN_NAME_REQUIRED")],
         id="delete-name",
     )
-    submit = SubmitField(label=get_form_field_label("delete"))
+    submit = SubmitField(label=_get_form_field_label("delete"))
     clean_name: str | None
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -403,7 +403,7 @@ class WebAuthnDeleteForm(Form):
 
 
 class WebAuthnVerifyForm(Form):
-    submit = SubmitField(label=get_form_field_label("submit"), id="wan_verify")
+    submit = SubmitField(label=_get_form_field_label("submit"), id="wan_verify")
 
     user: UserMixin
 
@@ -432,7 +432,7 @@ def webauthn_register() -> ResponseValue:
     payload: dict[str, t.Any]
 
     form: WebAuthnRegisterForm = t.cast(
-        WebAuthnRegisterForm, build_form_from_request("wan_register_form")
+        WebAuthnRegisterForm, _build_form_from_request("wan_register_form")
     )
 
     if form.validate_on_submit():
@@ -489,7 +489,7 @@ def webauthn_register() -> ResponseValue:
         return _security.render_template(
             cv("WAN_REGISTER_TEMPLATE"),
             wan_register_form=form,
-            wan_register_response_form=build_form("wan_register_response_form"),
+            wan_register_response_form=_build_form("wan_register_response_form"),
             wan_state=state_token,
             credential_options=json.dumps(co_json),
             **_security._run_ctx_processor("wan_register"),
@@ -526,7 +526,7 @@ def webauthn_register() -> ResponseValue:
     return _security.render_template(
         cv("WAN_REGISTER_TEMPLATE"),
         wan_register_form=form,
-        wan_delete_form=build_form("wan_delete_form"),
+        wan_delete_form=_build_form("wan_delete_form"),
         registered_credentials=current_creds,
         **_security._run_ctx_processor("wan_register"),
     )
@@ -537,7 +537,7 @@ def webauthn_register_response(token: str) -> ResponseValue:
     """Response from browser."""
     form: WebAuthnRegisterResponseForm = t.cast(
         WebAuthnRegisterResponseForm,
-        build_form_from_request("wan_register_response_form"),
+        _build_form_from_request("wan_register_response_form"),
     )
 
     expired, invalid, state = check_and_get_token_status(
@@ -651,7 +651,7 @@ def webauthn_signin() -> ResponseValue:
     else:
         abort(404)
 
-    form = t.cast(WebAuthnSigninForm, build_form_from_request("wan_signin_form"))
+    form = t.cast(WebAuthnSigninForm, _build_form_from_request("wan_signin_form"))
     form.is_secondary = is_secondary
     if form.validate_on_submit():
         o_json, state_token = _signin_common(
@@ -671,7 +671,7 @@ def webauthn_signin() -> ResponseValue:
         return _security.render_template(
             cv("WAN_SIGNIN_TEMPLATE"),
             wan_signin_form=form,
-            wan_signin_response_form=build_form(
+            wan_signin_response_form=_build_form(
                 "wan_signin_response_form",
                 remember=form.remember.data,
                 next=form.next.data,
@@ -687,7 +687,7 @@ def webauthn_signin() -> ResponseValue:
     return _security.render_template(
         cv("WAN_SIGNIN_TEMPLATE"),
         wan_signin_form=form,
-        wan_signin_response_form=build_form("wan_signin_response_form"),
+        wan_signin_response_form=_build_form("wan_signin_response_form"),
         is_secondary=is_secondary,
         **_security._run_ctx_processor("wan_signin"),
     )
@@ -700,7 +700,7 @@ def webauthn_signin_response(token: str) -> ResponseValue:
     ] in ["ready"]
 
     form = t.cast(
-        WebAuthnSigninResponseForm, build_form_from_request("wan_signin_response_form")
+        WebAuthnSigninResponseForm, _build_form_from_request("wan_signin_response_form")
     )
 
     expired, invalid, state = check_and_get_token_status(
@@ -799,7 +799,7 @@ def webauthn_signin_response(token: str) -> ResponseValue:
 )
 def webauthn_delete() -> ResponseValue:
     """Deletes an existing registered credential."""
-    form = t.cast(WebAuthnDeleteForm, build_form_from_request("wan_delete_form"))
+    form = t.cast(WebAuthnDeleteForm, _build_form_from_request("wan_delete_form"))
 
     if form.validate_on_submit():
         # validate made sure form.name.data exists.
@@ -833,7 +833,7 @@ def webauthn_verify() -> ResponseValue:
     will have filled in ?next=xxx - which we want to carefully not lose as we
     go through these steps.
     """
-    form = t.cast(WebAuthnVerifyForm, build_form_from_request("wan_verify_form"))
+    form = t.cast(WebAuthnVerifyForm, _build_form_from_request("wan_verify_form"))
 
     if form.validate_on_submit():
         o_json, state_token = _signin_common(form.user, cv("WAN_ALLOW_AS_VERIFY"))
@@ -844,7 +844,7 @@ def webauthn_verify() -> ResponseValue:
         return _security.render_template(
             cv("WAN_VERIFY_TEMPLATE"),
             wan_verify_form=form,
-            wan_signin_response_form=build_form("wan_signin_response_form"),
+            wan_signin_response_form=_build_form("wan_signin_response_form"),
             wan_state=state_token,
             credential_options=json.dumps(o_json),
             **_security._run_ctx_processor("wan_verify"),
@@ -855,7 +855,7 @@ def webauthn_verify() -> ResponseValue:
     return _security.render_template(
         cv("WAN_VERIFY_TEMPLATE"),
         wan_verify_form=form,
-        wan_signin_response_form=build_form("wan_signin_response_form"),
+        wan_signin_response_form=_build_form("wan_signin_response_form"),
         skip_login_menu=True,
         **_security._run_ctx_processor("wan_verify"),
     )
@@ -864,7 +864,7 @@ def webauthn_verify() -> ResponseValue:
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
 def webauthn_verify_response(token: str) -> ResponseValue:
     form = t.cast(
-        WebAuthnSigninResponseForm, build_form_from_request("wan_signin_response_form")
+        WebAuthnSigninResponseForm, _build_form_from_request("wan_signin_response_form")
     )
 
     expired, invalid, state = check_and_get_token_status(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,8 @@ exclude = ["docs/_build/"]
 [tool.djlint]
     ignore="H005,H006"  # lang, img height/width
 
-[tool.pyright]
+[tool.basedpyright]
     include=["flask_security", "tests/view_scaffold.py"]
-    analyzeUnannotatedFunctions = "none"
+    analyzeUnannotatedFunctions = false
     reportMissingImports = false
+    failOnWarnings = false

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -1071,7 +1071,7 @@ def test_subclass(app, sqlalchemy_datastore):
     # Test/show how to use multiple inheritance to override individual form fields.
     from wtforms import PasswordField, ValidationError
     from wtforms.validators import DataRequired
-    from flask_security.forms import get_form_field_label
+    from flask_security.forms import _get_form_field_label
 
     def password_validator(form, field):
         if field.data.startswith("PASS"):
@@ -1079,7 +1079,7 @@ def test_subclass(app, sqlalchemy_datastore):
 
     class NewPasswordFormMixinEx:
         password = PasswordField(
-            get_form_field_label("password"),
+            _get_form_field_label("password"),
             validators=[
                 DataRequired(message="PASSWORD_NOT_PROVIDED"),
                 password_validator,

--- a/tox.ini
+++ b/tox.ini
@@ -148,8 +148,10 @@ commands =
 deps =
     -r requirements/tests.txt
     mypy
+    basedpyright
 commands =
     mypy --install-types --non-interactive flask_security tests
+    # basedpyright --verifytypes flask_security --ignoreexternal
 
 
 [testenv:py{310,311,312,313,314}-appinstall]


### PR DESCRIPTION
Get basedpyright running locally and do some work to fix issues. pyright is really quite annoying - and working with mixins doesn't seem like a solved problem.

Mostly added redundent variable type info for forms.

According to typing.python.org - type checkers can/should consider any important symbol as public unless starts with an '_' or contained in a module file that starts with a '_'. Flask-Security has hundreds of methods etc that should be considered private. So some renaming of low-level utilities to have an '_'. Just a very small start.

closes #1272